### PR TITLE
Rename GooglePay to Google Pay

### DIFF
--- a/openapi/components/schemas/Method.yaml
+++ b/openapi/components/schemas/Method.yaml
@@ -28,7 +28,7 @@ enum:
   - Finrax
   - Flexepin
   - Giropay
-  - GooglePay
+  - Google Pay
   - Gpaysafe
   - iDebit
   - iDEAL


### PR DESCRIPTION
https://developers.google.com/pay/api/web/guides/brand-guidelines#using-google-pay-in-text