### PR TITLE
Add redirects related events to Transaction Timeline

### DIFF
--- a/openapi/components/schemas/Timelines/TransactionTimeline.yaml
+++ b/openapi/components/schemas/Timelines/TransactionTimeline.yaml
@@ -36,6 +36,8 @@ properties:
       - transaction-capture-delayed
       - transaction-captured
       - transaction-waiting-gateway
+      - customer-redirected-offsite
+      - customer-redirected-back
   triggeredBy:
     description: Shows who or what triggered the Timeline message
     type: string

--- a/openapi/components/schemas/Timelines/TransactionTimeline.yaml
+++ b/openapi/components/schemas/Timelines/TransactionTimeline.yaml
@@ -10,34 +10,34 @@ properties:
     type: string
     readOnly: true
     enum:
-      - timeline-comment-created
-      - transaction-approved
-      - transaction-canceled
-      - transaction-declined
-      - transaction-abandoned
-      - transaction-refunded
-      - transaction-voided
-      - transaction-discrepancy-found
-      - transaction-amount-discrepancy-found
-      - transaction-reconciled
-      - transaction-initiated
-      - transaction-retried
-      - risk-score-changed
-      - transaction-timeout-resolved
+      - customer-redirected-back
+      - customer-redirected-offsite
+      - dispute-changed
       - dispute-created
-      - dispute-won
+      - dispute-forfeited
       - dispute-lost
       - dispute-responded
-      - dispute-forfeited
-      - dispute-changed
+      - dispute-won
       - gateway-response-received
-      - transaction-scheduled-time-changed
-      - transaction-rules-processed
+      - risk-score-changed
+      - timeline-comment-created
+      - transaction-abandoned
+      - transaction-amount-discrepancy-found
+      - transaction-approved
+      - transaction-canceled
       - transaction-capture-delayed
       - transaction-captured
+      - transaction-declined
+      - transaction-discrepancy-found
+      - transaction-initiated
+      - transaction-reconciled
+      - transaction-refunded
+      - transaction-retried
+      - transaction-rules-processed
+      - transaction-scheduled-time-changed
+      - transaction-timeout-resolved
+      - transaction-voided
       - transaction-waiting-gateway
-      - customer-redirected-offsite
-      - customer-redirected-back
   triggeredBy:
     description: Shows who or what triggered the Timeline message
     type: string


### PR DESCRIPTION
This PR adds redirects related events to Transaction Timeline and sorts events alphabetically.
New events are: 
`customer-redirected-back`
`customer-redirected-offsite`