### PR TITLE
fix: reference list of events

### DIFF
--- a/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
+++ b/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
@@ -7,17 +7,7 @@ parameters:
     required: true
     description: The system event type
     schema:
-      type: string
-      enum:
-        - dispute-created
-        - gateway-account-requested
-        - transaction-processed
-        - subscription-canceled
-        - subscription-renewed
-        - payment-card-expired
-        - payment-declined
-        - transaction-process-requested
-        - risk-score-changed
+      $ref: ../components/schemas/EventType.yaml
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:


### PR DESCRIPTION
This API was left-behind (not actually, just the API definition). 