### PR TITLE
Add the x-multiline flag for sftpPrivateKey

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Wirecard.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Wirecard.yaml
@@ -29,6 +29,7 @@ allOf:
             type: string
             description: Wirecard sftp private key.
             format: password
+            x-multiline: true
         required:
           - merchantUsername
           - merchantPassword


### PR DESCRIPTION
The `x-multiline` flag is used for Gateway properties that accept an RSA key