### PR TITLE
Add commands to start particular API version with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "start": "openapi preview-docs",
     "build": "openapi bundle -o dist",
     "test": "openapi validate",
-    "gh-pages": "echo \"Not implemented\""
+    "gh-pages": "echo \"Not implemented\"",
+    "serve-core": "yarn start core",
+    "serve-users": "yarn start users",
+    "serve-reports": "yarn start reports",
+    "serve-storefront": "yarn start storefront",
+    "serve-combined": "yarn start combined"
   }
 }


### PR DESCRIPTION
It helps to start them from IDE and not use console if no one minds.