### PR TITLE
Reduce x-rebillyMerge

### DIFF
--- a/openapi/components/headers/Location.yaml
+++ b/openapi/components/headers/Location.yaml
@@ -1,0 +1,4 @@
+description: The location of the related resource
+schema:
+  type: string
+  format: url

--- a/openapi/components/parameters/mediaTypeJsonPdf.yaml
+++ b/openapi/components/parameters/mediaTypeJsonPdf.yaml
@@ -1,0 +1,9 @@
+name: Accept
+in: header
+description: The response media type
+schema:
+  type: string
+  enum:
+    - application/json
+    - application/pdf
+  default: application/json

--- a/openapi/components/schemas/EmailCredentials/SmtpCredential.yaml
+++ b/openapi/components/schemas/EmailCredentials/SmtpCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: SMTP Credential

--- a/openapi/components/schemas/MailgunCredentials/MailgunCredential.yaml
+++ b/openapi/components/schemas/MailgunCredentials/MailgunCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: Mailgun Credential

--- a/openapi/components/schemas/OAuth2Credentials/OAuth2Credential.yaml
+++ b/openapi/components/schemas/OAuth2Credentials/OAuth2Credential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: OAuth2 credential

--- a/openapi/components/schemas/PostmarkCredentials/PostmarkCredential.yaml
+++ b/openapi/components/schemas/PostmarkCredentials/PostmarkCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: Postmark Credential

--- a/openapi/components/schemas/SESCredentials/SESCredential.yaml
+++ b/openapi/components/schemas/SESCredentials/SESCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: Amazon simple email service (AWS SES) credential

--- a/openapi/components/schemas/SendGridCredentials/SendGridCredential.yaml
+++ b/openapi/components/schemas/SendGridCredentials/SendGridCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: SendGrid Credential

--- a/openapi/components/schemas/WebhookCredentials/WebhookCredential.yaml
+++ b/openapi/components/schemas/WebhookCredentials/WebhookCredential.yaml
@@ -1,4 +1,4 @@
-x-rebillyMerge:
+allOf:
   - $ref: ../Credentials/Credential.yaml
   - type: object
     description: Webhook credential

--- a/openapi/paths/credential-hashes@aws-ses.yaml
+++ b/openapi/paths/credential-hashes@aws-ses.yaml
@@ -22,7 +22,7 @@ post:
           schema:
             $ref: ../components/schemas/SESCredentials/SESCredential.yaml
     '303':
-      x-rebillyMerge:
+      allOf:
         - $ref: ../components/responses/SeeOther.yaml
         - description: An existent AWS SES credential was retrieved
           content:

--- a/openapi/paths/credential-hashes@aws-ses.yaml
+++ b/openapi/paths/credential-hashes@aws-ses.yaml
@@ -22,13 +22,20 @@ post:
           schema:
             $ref: ../components/schemas/SESCredentials/SESCredential.yaml
     '303':
-      allOf:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent AWS SES credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: ../components/schemas/SESCredentials/SESCredential.yaml
+      description: An existent AWS SES credential was retrieved
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/SESCredentials/SESCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/credential-hashes@emails.yaml
+++ b/openapi/paths/credential-hashes@emails.yaml
@@ -29,13 +29,20 @@ post:
           schema:
             $ref: ../components/schemas/EmailCredentials/SmtpCredential.yaml
     '303':
-      x-rebillyMerge:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent SMTP credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: ../components/schemas/EmailCredentials/SmtpCredential.yaml
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      description: An existent SMTP credential was retrieved
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/EmailCredentials/SmtpCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/credential-hashes@mailgun.yaml
+++ b/openapi/paths/credential-hashes@mailgun.yaml
@@ -29,14 +29,20 @@ post:
           schema:
             $ref: ../components/schemas/MailgunCredentials/MailgunCredential.yaml
     '303':
-      x-rebillyMerge:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent Mailgun credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  ../components/schemas/MailgunCredentials/MailgunCredential.yaml
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      description: An existent Mailgun credential was retrieved
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/MailgunCredentials/MailgunCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/credential-hashes@postmark.yaml
+++ b/openapi/paths/credential-hashes@postmark.yaml
@@ -29,14 +29,20 @@ post:
           schema:
             $ref: ../components/schemas/PostmarkCredentials/PostmarkCredential.yaml
     '303':
-      x-rebillyMerge:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent Postmark credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  ../components/schemas/PostmarkCredentials/PostmarkCredential.yaml
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      description: An existent Postmark credential was retrieved
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/PostmarkCredentials/PostmarkCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/credential-hashes@sendgrid.yaml
+++ b/openapi/paths/credential-hashes@sendgrid.yaml
@@ -29,14 +29,20 @@ post:
           schema:
             $ref: ../components/schemas/SendGridCredentials/SendGridCredential.yaml
     '303':
-      x-rebillyMerge:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent SendGrid credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  ../components/schemas/SendGridCredentials/SendGridCredential.yaml
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      description: An existent SendGrid credential was retrieved
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/SendGridCredentials/SendGridCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/credential-hashes@webhooks.yaml
+++ b/openapi/paths/credential-hashes@webhooks.yaml
@@ -29,14 +29,20 @@ post:
           schema:
             $ref: ../components/schemas/WebhookCredentials/WebhookCredential.yaml
     '303':
-      x-rebillyMerge:
-        - $ref: ../components/responses/SeeOther.yaml
-        - description: An existent Webhook credential was retrieved
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  ../components/schemas/WebhookCredentials/WebhookCredential.yaml
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+        Rate-Limit-Limit:
+          $ref: ../components/headers/Rate-Limit-Limit.yaml
+        Rate-Limit-Remaining:
+          $ref: ../components/headers/Rate-Limit-Remaining.yaml
+        Rate-Limit-Reset:
+          $ref: ../components/headers/Rate-Limit-Reset.yaml
+      description: An existent Webhook credential was retrieved
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/WebhookCredentials/WebhookCredential.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/customers.yaml
+++ b/openapi/paths/customers.yaml
@@ -28,12 +28,6 @@ get:
                 - invoiceCount
                 - createdTime
                 - updatedTime
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: A list of Customers was retrieved successfully
@@ -52,11 +46,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Customer.yaml
-        text/csv:
           schema:
             type: array
             items:

--- a/openapi/paths/invoices.yaml
+++ b/openapi/paths/invoices.yaml
@@ -10,12 +10,6 @@ get:
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: A list of invoices was retrieved successfully
@@ -34,11 +28,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Invoices/Invoice.yaml
-        text/csv:
           schema:
             type: array
             items:

--- a/openapi/paths/invoices@{id}.yaml
+++ b/openapi/paths/invoices@{id}.yaml
@@ -9,12 +9,7 @@ get:
   description: |
     Retrieve an invoice with specified identifier string
   parameters:
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - application/pdf
+    - $ref: ../components/parameters/mediaTypeJsonPdf.yaml
   responses:
     '200':
       description: Invoice was retrieved successfully

--- a/openapi/paths/kyc-documents.yaml
+++ b/openapi/paths/kyc-documents.yaml
@@ -19,11 +19,6 @@ get:
                 - id
                 - createdTime
                 - updatedTime
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
   responses:
     '200':
       description: A list of KYC documents was retrieved successfully

--- a/openapi/paths/kyc-documents@{id}.yaml
+++ b/openapi/paths/kyc-documents@{id}.yaml
@@ -7,12 +7,6 @@ get:
   summary: Retrieve a KYC Document
   operationId: GetKycDocument
   description: Retrieve a KYC document with specified identifier string.
-  parameters:
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
   responses:
     '200':
       description: KYC document was retrieved successfully

--- a/openapi/paths/reports@cumulative-subscriptions-plans.yaml
+++ b/openapi/paths/reports@cumulative-subscriptions-plans.yaml
@@ -25,12 +25,6 @@ get:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionFilter.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: Report was retrieved successfully

--- a/openapi/paths/reports@subscription-cancellation.yaml
+++ b/openapi/paths/reports@subscription-cancellation.yaml
@@ -44,11 +44,6 @@ get:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionFilter.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
   responses:
     '200':
       description: Report was retrieved successfully

--- a/openapi/paths/reports@transactions-plan.yaml
+++ b/openapi/paths/reports@transactions-plan.yaml
@@ -24,12 +24,6 @@ get:
         type: string
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: Report was retrieved successfully
@@ -48,9 +42,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            $ref: ../components/schemas/TransactionsPlan.yaml
-        text/csv:
           schema:
             $ref: ../components/schemas/TransactionsPlan.yaml
     '401':

--- a/openapi/paths/search.yaml
+++ b/openapi/paths/search.yaml
@@ -9,11 +9,11 @@ get:
     Search merchant's data to return resources such as customers, invoices,
     orders, transactions
   parameters:
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/collectionQuery.yaml
-        - description: >
-            The default or "global" search. It will search all searchable
-            resources across as many fields as possible.
+    - name: q
+      in: query
+      description: The default search. It will search across resources and many fields.
+      schema:
+        type: string    
     - x-rebillyMerge:
         - $ref: ../components/parameters/collectionFilter.yaml
         - description: >

--- a/openapi/paths/subscriptions.yaml
+++ b/openapi/paths/subscriptions.yaml
@@ -11,12 +11,6 @@ get:
     - $ref: ../components/parameters/subscriptionExpand.yaml
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: A list of subscriptions was retrieved successfully
@@ -35,11 +29,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Subscription.yaml
-        text/csv:
           schema:
             type: array
             items:

--- a/openapi/paths/transactions.yaml
+++ b/openapi/paths/transactions.yaml
@@ -63,12 +63,6 @@ get:
     - $ref: ../components/parameters/collectionFilter.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
     - $ref: ../components/parameters/collectionSort.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: A list of transactions was retrieved successfully
@@ -87,11 +81,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Transactions/Transaction.yaml
-        text/csv:
           schema:
             type: array
             items:

--- a/openapi/paths/websites.yaml
+++ b/openapi/paths/websites.yaml
@@ -10,12 +10,6 @@ get:
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
-    - x-rebillyMerge:
-        - $ref: ../components/parameters/mediaType.yaml
-        - schema:
-            enum:
-              - application/json
-              - text/csv
   responses:
     '200':
       description: A list of Websites was retrieved successfully
@@ -34,11 +28,6 @@ get:
           $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
-          schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Website.yaml
-        text/csv:
           schema:
             type: array
             items:

--- a/openapi/plugins/README.md
+++ b/openapi/plugins/README.md
@@ -12,7 +12,7 @@ Inline references and merge all subschemas using [JSON Merge Patch](https://tool
 
 ```yaml
   x-rebillyMerge:
-    - $ref: "#/components/arameters/someParam"
+    - $ref: "#/components/parameters/someParam"
     - enum:
         - aaa
         - bbb


### PR DESCRIPTION
This removes usage of `x-rebillyMerge` in:
- schemas (replaced with `allOf`)
- 303 responses (replaced with regular-style definitions and a location header)
- media type header parameter (removed and replaced with one media type object)

It remains used in the collectionSort header parameter.