### PR TITLE
Update README, switch to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ TBD: Add Redocly validation status badge.
 ### Install
 
 1. Install [Node JS](https://nodejs.org/)
-2. Clone repo and run `yarn install` in the repo root
+2. Clone repo and run `npm ci` in the repo root
 
 ### Usage
 
-#### `yarn start`
+#### Preview
 
-Starts the development server to preview the docs (Core API by default).
+Starts the development server to preview the docs:
 
-- `yarn start core` - preview Core API docs
-- `yarn start users` - preview Users API docs
-- `yarn start reports` - preview Reports API doc
-- `yarn start storefront` - preview Storefront API docs
-- `yarn start combined` - preview combined API docs
+- `npm run serve-core` - preview Core API docs
+- `npm run serve-users` - preview Users API docs
+- `npm run serve-reports` - preview Reports API doc
+- `npm run serve-storefront` - preview Storefront API docs
+- `npm run serve-combined` - preview combined API docs
 
-#### `yarn build`
+#### Build
 
-Bundles the definitions into a single file in the `dist` folder.
+Run `npm build` to bundle the definitions into a single file in the `dist` folder.
 
-#### `yarn test`
+#### Validate
 
-Validates.
+Run `npm test` to validate the definitions.
 
 ### Organization
 


### PR DESCRIPTION
We seems to switch to npm

- `package-lock.json` is indexed
- `npm` is used in scripts in `package.json`