### PR TITLE
Rename Storefront expirationYear/expirationMonth to expYear/expMonth

### DIFF
--- a/openapi/components/schemas/Storefront/PaymentInstruments/PaymentCard.yaml
+++ b/openapi/components/schemas/Storefront/PaymentInstruments/PaymentCard.yaml
@@ -44,10 +44,10 @@ properties:
     description: The card PAN (primary account number).
     type: string
     writeOnly: true
-  expirationYear:
+  expYear:
     description: Card's expiration year.
     type: integer
-  expirationMonth:
+  expMonth:
     description: Card's expiration month.
     type: integer
   cvv:


### PR DESCRIPTION
To be consistent with the rest of the API. Will allow to remove schema duplication