### PR TITLE
Add parameter for SubscriptionChangePlan bool 'keepTrial'

### DIFF
--- a/openapi/components/schemas/SubscriptionChange.yaml
+++ b/openapi/components/schemas/SubscriptionChange.yaml
@@ -47,7 +47,7 @@ properties:
     default: false
   keepTrial:
     description: >-
-      If set to true and the old plan has an active trial, that trial will be used for the new plan. Works with 'retain'
+      If set to true and the subscription order has an active trial, it will use that trial further. Works with 'retain'
       renewalPolicy only.
     type: boolean
     default: false

--- a/openapi/components/schemas/SubscriptionChange.yaml
+++ b/openapi/components/schemas/SubscriptionChange.yaml
@@ -45,3 +45,9 @@ properties:
       to preview the changes that would be made to a subscription.
     type: boolean
     default: false
+  keepTrial:
+    description: >-
+      If set to true and the old plan has an active trial, that trial will be used for the new plan. Works with 'retain'
+      renewalPolicy only.
+    type: boolean
+    default: false


### PR DESCRIPTION
https://api-reference.rebilly.com/#operation/PostSubscriptionPlanChange - additional parameter bool "keepTrial". Allows to keep trial on plan change with 'retain' renewal policy.