### PR TITLE
Add amounts property to CashToCode settings object

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
@@ -35,3 +35,6 @@ allOf:
             type: boolean
             description: Skip amount selection screen
             default: false
+          amounts:
+            type: string
+            description: A comma-separated list of formatted numeric amounts to allow


### PR DESCRIPTION
This allows transaction amounts to be defined as a CashToCode Gateway Account setting. Amounts may be provided as a comma-separated list of formatted numeric values, ex `'1,2.50,5,10.00'`