### PR TITLE
List sandbox server first

### DIFF
--- a/openapi/combined.yaml
+++ b/openapi/combined.yaml
@@ -16,10 +16,10 @@ info:
   description:
     $ref: description.md
 servers:
-  - url: 'https://api.rebilly.com/v2.1'
-    description: Live Server
   - url: 'https://api-sandbox.rebilly.com/v2.1'
     description: Sandbox Server
+  - url: 'https://api.rebilly.com/v2.1'
+    description: Live Server
 tags:
   - name: 3D Secure
     description: |

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -16,10 +16,10 @@ info:
   description:
     $ref: description.md
 servers:
-  - url: 'https://api.rebilly.com/v2.1'
-    description: Live Server
   - url: 'https://api-sandbox.rebilly.com/v2.1'
     description: Sandbox Server
+  - url: 'https://api.rebilly.com/v2.1'
+    description: Live Server
 tags:
   - name: 3D Secure
     description: |

--- a/openapi/storefront.yaml
+++ b/openapi/storefront.yaml
@@ -60,10 +60,10 @@ x-tagGroups:
     tags:
       - Website
 servers:
-  - url: 'https://api.rebilly.com/storefront/v1'
-    description: Live Server
   - url: 'https://api-sandbox.rebilly.com/storefront/v1'
     description: Sandbox Server
+  - url: 'https://api.rebilly.com/storefront/v1'
+    description: Live Server
 components:
   securitySchemes:
     CustomerJWT:

--- a/openapi/users.yaml
+++ b/openapi/users.yaml
@@ -255,10 +255,10 @@ security:
   - SecretApiKey: []
   - JWT: []
 servers:
-  - url: 'https://api.rebilly.com/v2.1'
-    description: Live Server
   - url: 'https://api-sandbox.rebilly.com/v2.1'
     description: Sandbox Server
+  - url: 'https://api.rebilly.com/v2.1'
+    description: Live Server
 
 
 components:


### PR DESCRIPTION
The Redocly `Try it out` console pulls in the list of servers from the API definitions. In order to improve our docs experience, we will be pre-filling a default secret API sandbox key from the currently logged in user when they view the docs.

Due to lack of customizability with the `Try it out` console, this is currently the only way to control which `target` server is the default in the console UI. 

