### PR TITLE
Allow to use custom domain for Apple Pay validation

### DIFF
--- a/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
+++ b/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
@@ -8,10 +8,24 @@ allOf:
       type:
         type: string
       validationRequest:
-        description: The validation request provided by the Apple Pay SDK to validate payment ability
+        description: The validation request.
         type: object
+        properties:
+          validationURL:
+            type: string
+            description: The URL provided by the Apple Pay SDK to perform the validation.
+          domainName:
+            type: string
+            description: >
+              The domain where the client code like FramePay is executed.
+              Should be Registered in the Apple Pay console by Rebilly before using.
+            example: www.example.com
+          displayName:
+              type: string
+              description: A name of your store, suitable for display.
+              example: My Store
         writeOnly: true
       validationResponse:
-        description: The validation response to use by the Apple Pay SDK to proceed
+        description: The validation response to use by the Apple Pay SDK to proceed.
         type: object
         readOnly: true

--- a/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
+++ b/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
@@ -18,7 +18,7 @@ allOf:
             type: string
             description: >
               The domain where the client code like FramePay is executed.
-              Should be Registered in the Apple Pay console by Rebilly before using.
+              Should be registered in the Apple Pay console by Rebilly before using.
             example: www.example.com
           displayName:
               type: string


### PR DESCRIPTION
Direct link to the preview: https://preview.redoc.ly/rebilly-core/Allow-to-use-custom-domain-for-digital-wallet-validation/tag/Payment-Tokens#operation/PostDigitalWalletValidation