### PR TITLE
Add banktransfer for IPayOptions

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/IpayOptions.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/IpayOptions.yaml
@@ -42,7 +42,8 @@ allOf:
               - SecureHosted
           cardType:
             type: string
-            description: Manually set the card_type for iDEAL.
+            description: Manually set the card_type
             enum:
               - ideal
               - idealqr
+              - banktransfer


### PR DESCRIPTION
This is the default value but it is confusing to have to configure "empty" instead 