### PR TITLE
Add merchantInitiatedReason setting property for Worldpay

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -24,6 +24,10 @@ allOf:
       settings:
         type: object
         properties:
+          enableStoredCredentials:
+            type: boolean
+            description: True to enable Stored Credentials
+            default: false
           merchantInitiatedReason:
             type: string
             description: The value of merchantInitiatedReason to send with merchant-initiated transactions.

--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -21,3 +21,19 @@ allOf:
           - merchantPassword
       threeDSecureServer:
         $ref: ../ThreeDSecureServers/Worldpay3dsServers/Worldpay3dsServers.yaml
+      settings:
+        type: object
+        properties:
+          merchantInitiatedReason:
+            type: string
+            description: The value of merchantInitiatedReason to send with merchant-initiated transactions.
+            enum:
+              - RECURRING
+              - INSTALMENT
+              - UNSCHEDULED
+              - REAUTH
+              - DELAYED
+              - INCREMENTAL
+              - RESUBMISSION
+              - NOSHOW
+            default: RECURRING

--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -28,12 +28,12 @@ allOf:
             type: string
             description: The value of merchantInitiatedReason to send with merchant-initiated transactions.
             enum:
+              - UNSCHEDULED
               - RECURRING
               - INSTALMENT
-              - UNSCHEDULED
               - REAUTH
               - DELAYED
               - INCREMENTAL
               - RESUBMISSION
               - NOSHOW
-            default: RECURRING
+            default: UNSCHEDULED


### PR DESCRIPTION
Adds a setting property for the Worldpay gateway which will be sent with merchant-initiated transactions. The values for this setting are taken from the [Worldpay stored credentials documentation](https://developer.worldpay.com/docs/wpg/industryschemeextras/storedcredentials#merchant).