### PR TITLE
Replace Subscription to Order where it's not about recurring orders

### DIFF
--- a/openapi/combined.yaml
+++ b/openapi/combined.yaml
@@ -24,7 +24,7 @@ tags:
   - name: 3D Secure
     description: |
       3D Secure is a way to authenticate and protect transactions.  Typically,
-      it's only possible to protect the initial transaction in a subscription
+      it's only possible to protect the initial transaction in an order
       with 3D Secure.
   - name: Bank Accounts
     description: |
@@ -41,7 +41,7 @@ tags:
   - name: Coupons
     description: >
       Coupons allows to apply different types of discounts to Invoices,
-      Subscriptions and Plans. Redeemed Coupons will be applied only to Invoices
+      Orders and Plans. Redeemed Coupons will be applied only to Invoices
       with the same currency.
   - name: Customers
     description: |
@@ -84,7 +84,7 @@ tags:
       Attachment is an entity that is used to link a File to one or multiple
       objects like Customer, Dispute, Payment,
 
-      Transaction, Subscription, Plan, Product, Invoice, Note. That allows to
+      Transaction, Order, Plan, Product, Invoice, Note. That allows to
       quickly find and use files related to
 
       those specific entities.
@@ -138,8 +138,8 @@ tags:
       that has a 30-day free trial followed by a recurring charge of $19.95 per
       month
 
-      until canceled.  The combination of the plan and a request to make a
-      subscription
+      until canceled.  The combination of the plan and a request to make an
+      order
 
       will apply those instructions to create the invoices according to the
       plan's
@@ -164,14 +164,11 @@ tags:
     description: >
       A shipping zone contains regions and countries that you ship to. Each
       shipping zone has its own shipping rates.
-  - name: Subscriptions
+  - name: Orders
     description: >
-      A subscription applies a plan's template to create invoices for a customer
-      at the
-
-      appropriate scheduled intervals.  A subscription may also determine if the
-      payment
-
+      An order applies a plan's template to create invoice(s) for a customer,
+      optionally at the appropriate scheduled intervals.
+      A subscription order may also determine if the payment
       is collected automatically (with autopay set true).
   - name: Taxes
     description: |
@@ -193,7 +190,7 @@ tags:
       their granted permissions.  It has resources less commonly integrated by
 
       3rd parties.
-  - name: Subscriptions
+  - name: Orders
   - name: Organizations
   - name: Customers
   - name: Tags

--- a/openapi/components/requestBodies/Subscription.yaml
+++ b/openapi/components/requestBodies/Subscription.yaml
@@ -2,5 +2,5 @@ content:
   application/json:
     schema:
       $ref: ../schemas/Subscription.yaml
-description: Subscription resource.
+description: Order resource.
 required: true

--- a/openapi/components/requestBodies/Webhooks/InvoiceAndSubscription.yaml
+++ b/openapi/components/requestBodies/Webhooks/InvoiceAndSubscription.yaml
@@ -3,7 +3,7 @@ content:
     schema:
       properties:
         subscriptionId:
-          description: The subscription ID.
+          description: The order ID.
           type: string
         invoiceId:
           description: The invoice ID.
@@ -25,4 +25,4 @@ content:
             anyOf:
               - $ref: ../../schemas/Links/SubscriptionLink.yaml
               - $ref: ../../schemas/Links/InvoiceLink.yaml
-description: Invoice and Subscription webhook request body resource.
+description: Invoice and Order webhook request body resource.

--- a/openapi/components/requestBodies/Webhooks/Subscription.yaml
+++ b/openapi/components/requestBodies/Webhooks/Subscription.yaml
@@ -3,7 +3,7 @@ content:
     schema:
       properties:
         subscriptionId:
-          description: The subscription ID.
+          description: The order ID.
           type: string
         eventType:
           $ref: ../../schemas/GlobalWebhookEventType.yaml
@@ -19,4 +19,4 @@ content:
           items:
             anyOf:
               - $ref: ../../schemas/Links/SubscriptionLink.yaml
-description: Subscription webhook request body resource.
+description: Order webhook request body resource.

--- a/openapi/components/schemas/Common/CommonInvoice.yaml
+++ b/openapi/components/schemas/Common/CommonInvoice.yaml
@@ -12,7 +12,7 @@ properties:
     readOnly: true
     type: integer
   subscriptionId:
-    description: The related subscription's ID if available, otherwise null.
+    description: The related order's ID if available, otherwise null.
     readOnly: true
     allOf:
       - $ref: ../ResourceId.yaml

--- a/openapi/components/schemas/Common/CommonPlan.yaml
+++ b/openapi/components/schemas/Common/CommonPlan.yaml
@@ -42,8 +42,9 @@ properties:
         properties:
           limit:
             description: |
-              The number of invoices this subscription will generate (if 1, it will not generate any beyond the initial
-              subscription creation). For example, set this property to `12`, when the `periodUnit` is month and the
+              The number of invoices this subscription order will generate
+              (if 1, it will not generate any beyond the initial order creation).
+              For example, set this property to `12`, when the `periodUnit` is month and the
               `periodDuration` is 1, for a 1 year contract billed monthly.
             type: integer
           billingTiming:

--- a/openapi/components/schemas/Common/CommonTransaction.yaml
+++ b/openapi/components/schemas/Common/CommonTransaction.yaml
@@ -101,13 +101,13 @@ properties:
     items:
       $ref: ../ResourceId.yaml
   subscriptionIds:
-    description: The subscription IDs related to transaction's invoice(s).
+    description: The orders IDs related to transaction's invoice(s)
     readOnly: true
     type: array
     items:
       $ref: ../ResourceId.yaml
   planIds:
-    description: The plan IDs related to transaction's subscription(s).
+    description: The plan IDs related to transaction's order(s).
     readOnly: true
     type: array
     items:

--- a/openapi/components/schemas/Common/CommonTransaction.yaml
+++ b/openapi/components/schemas/Common/CommonTransaction.yaml
@@ -101,7 +101,7 @@ properties:
     items:
       $ref: ../ResourceId.yaml
   subscriptionIds:
-    description: The orders IDs related to transaction's invoice(s)
+    description: The orders IDs related to transaction's invoice(s).
     readOnly: true
     type: array
     items:

--- a/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-subscriptions.yaml
+++ b/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-subscriptions.yaml
@@ -8,6 +8,6 @@ allOf:
     properties:
       subscriptionIds:
         type: array
-        description: Subscription IDs coupon can be applied to.
+        description: Order IDs coupon can be applied to.
         items:
           type: string

--- a/openapi/components/schemas/DataExports/resources/subscriptions.yaml
+++ b/openapi/components/schemas/DataExports/resources/subscriptions.yaml
@@ -1,4 +1,4 @@
-description: Subscriptions resource type to export.
+description: Orders resource type to export.
 allOf:
   - $ref: ../DataExport.yaml
   - type: object

--- a/openapi/components/schemas/Embeds/SubscriptionEmbed.yaml
+++ b/openapi/components/schemas/Embeds/SubscriptionEmbed.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Subscription object.
+description: Order object.
 readOnly: true
 properties:
   subscription:

--- a/openapi/components/schemas/Invoices/InvoiceItem.yaml
+++ b/openapi/components/schemas/Invoices/InvoiceItem.yaml
@@ -47,7 +47,7 @@ properties:
     type: string
     format: date-time
   periodNumber:
-    description: Invoice item subscription period number.
+    description: Invoice item subscription order period number.
     type: integer
   createdTime:
     description: Invoice item created time.

--- a/openapi/components/schemas/Plans/PlanPriceFormula.yaml
+++ b/openapi/components/schemas/Plans/PlanPriceFormula.yaml
@@ -16,8 +16,8 @@ properties:
       The price formula determines what algorithm is used to calculate the
       invoice price based on a few factors,
 
-      - the quantity in the subscription (which may be variable if usage
-      pricing, otherwise determined when creating the subscription)
+      - the quantity in the order (which may be variable if usage
+      pricing, otherwise determined when creating the order)
 
       - the price brackets data
 

--- a/openapi/components/schemas/Rules/Actions/remove-reminder.yaml
+++ b/openapi/components/schemas/Rules/Actions/remove-reminder.yaml
@@ -10,7 +10,7 @@ allOf:
           - renewal
           - trial-end
         description: >-
-          The role of Reminder (available only on Subscription events, other
+          The role of Reminder (available only on Order events, other
           events should use `all`).
     required:
       - role

--- a/openapi/components/schemas/Rules/Actions/reset-reminder.yaml
+++ b/openapi/components/schemas/Rules/Actions/reset-reminder.yaml
@@ -10,7 +10,7 @@ allOf:
           - renewal
           - trial-end
         description: >-
-          The role of Reminder (available only on Subscription events, other
+          The role of Reminder (available only on Order events, other
           events should use `all`).
     required:
       - role

--- a/openapi/components/schemas/Rules/Actions/schedule-reminder.yaml
+++ b/openapi/components/schemas/Rules/Actions/schedule-reminder.yaml
@@ -10,7 +10,7 @@ allOf:
           - renewal
           - trial-end
         description: >-
-          The role of Reminder (available only on Subscription events, other
+          The role of Reminder (available only on Order events, other
           events should use `all`).
       schedule:
         $ref: ../../Scheduling/ReminderSchedule.yaml

--- a/openapi/components/schemas/Subscription.yaml
+++ b/openapi/components/schemas/Subscription.yaml
@@ -11,7 +11,7 @@ required:
   - items
 properties:
   id:
-    description: The Subscription identifier string.
+    description: The Order identifier string.
     readOnly: true
     allOf:
       - $ref: ./ResourceId.yaml
@@ -92,7 +92,7 @@ properties:
     allOf:
       - $ref: ./RiskMetadata.yaml
   activationTime:
-    description: Subscription activation time.
+    description: Order activation time.
     allOf:
       - $ref: ./ServerTimestamp.yaml
   couponIds:
@@ -123,9 +123,9 @@ properties:
       passed list will be canceled.
 
 
-      If list of applied coupons on pending subscription will be changed due to
-      this param during update subscription,
-       Invoice for the subscription will be reissued.
+      If list of applied coupons on pending order will be changed due to
+      this param during update order,
+       Invoice for the order will be reissued.
     writeOnly: true
     items:
       type: string
@@ -137,7 +137,7 @@ properties:
     type: string
   revision:
     description: >
-      The number of times the subscription data has been modified.
+      The number of times the order data has been modified.
 
       The revision is useful when analyzing webhook data to determine if the
       change takes precedence over the current representation.

--- a/openapi/components/schemas/Subscription/SubscriptionCancellation.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionCancellation.yaml
@@ -9,7 +9,7 @@ properties:
     allOf:
       - $ref: ../ResourceId.yaml
   subscriptionId:
-    description: Identifier of the canceled subscription.
+    description: Identifier of the canceled subscription order.
     allOf:
       - $ref: ../ResourceId.yaml
   proratedInvoiceId:

--- a/openapi/components/schemas/Subscription/SubscriptionCancellationState.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionCancellationState.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   canceledTime:
-    description: Subscription canceled time.
+    description: Subscription order canceled time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
   canceledBy:

--- a/openapi/components/schemas/Subscription/SubscriptionMetadata.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionMetadata.yaml
@@ -3,11 +3,11 @@ properties:
   customFields:
     $ref: ../ResourceCustomFields.yaml
   createdTime:
-    description: Subscription created time.
+    description: Order created time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Subscription updated time.
+    description: Order updated time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
   _links:

--- a/openapi/components/schemas/SubscriptionRenewalList.yaml
+++ b/openapi/components/schemas/SubscriptionRenewalList.yaml
@@ -13,7 +13,7 @@ items:
       allOf:
         - $ref: ./ResourceId.yaml
     subscriptionId:
-      description: Subscription ID.
+      description: Subscription order ID.
       allOf:
         - $ref: ./ResourceId.yaml
     customerId:

--- a/openapi/components/schemas/Tracking/SubscriptionTracking.yaml
+++ b/openapi/components/schemas/Tracking/SubscriptionTracking.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Tracking subscription log.
+description: Tracking order log.
 readOnly: true
 properties:
   id:
@@ -13,7 +13,7 @@ properties:
       - $ref: ../ResourceId.yaml
   result:
     type: string
-    description: Subscription's result.
+    description: Order's result.
     enum:
       - created
       - postponed

--- a/openapi/components/schemas/TransactionsPlan.yaml
+++ b/openapi/components/schemas/TransactionsPlan.yaml
@@ -24,7 +24,7 @@ items:
       allOf:
         - $ref: ./ResourceId.yaml
     subscriptionId:
-      description: Subscription's identifier.
+      description: Subscription order's identifier.
       allOf:
         - $ref: ./ResourceId.yaml
     currency:

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -24,7 +24,7 @@ tags:
   - name: 3D Secure
     description: |
       3D Secure is a way to authenticate and protect transactions.  Typically,
-      it's only possible to protect the initial transaction in a subscription
+      it's only possible to protect the initial transaction in an order
       with 3D Secure.
   - name: AML
     description: |
@@ -48,7 +48,7 @@ tags:
   - name: Coupons
     description: >
       Coupons allows to apply different types of discounts to Invoices,
-      Subscriptions and Plans. Redeemed Coupons will be applied only to Invoices
+      Orders and Plans. Redeemed Coupons will be applied only to Invoices
       with the same currency.
   - name: Customers
     description: |
@@ -91,7 +91,7 @@ tags:
       Attachment is an entity that is used to link a File to one or multiple
       objects like Customer, Dispute, Payment,
 
-      Transaction, Subscription, Plan, Product, Invoice, Note. That allows to
+      Transaction, Order, Plan, Product, Invoice, Note. That allows to
       quickly find and use files related to
 
       those specific entities.
@@ -145,8 +145,8 @@ tags:
       that has a 30-day free trial followed by a recurring charge of $19.95 per
       month
 
-      until canceled.  The combination of the plan and a request to make a
-      subscription
+      until canceled.  The combination of the plan and a request to make an
+      order
 
       will apply those instructions to create the invoices according to the
       plan's
@@ -171,14 +171,11 @@ tags:
     description: >
       A shipping zone contains regions and countries that you ship to. Each
       shipping zone has its own shipping rates.
-  - name: Subscriptions
+  - name: Orders
     description: >
-      A subscription applies a plan's template to create invoices for a customer
-      at the
-
-      appropriate scheduled intervals.  A subscription may also determine if the
-      payment
-
+      An order applies a plan's template to create invoice(s) for a customer,
+      optionally at the appropriate scheduled intervals.
+      A subscription order may also determine if the payment
       is collected automatically (with autopay set true).
   - name: Tags
     description: |
@@ -225,9 +222,9 @@ x-tagGroups:
       - 3D Secure
       - Disputes
       - Blocklists
-  - name: Subscriptions & Invoices
+  - name: Orders & Invoices
     tags:
-      - Subscriptions
+      - Orders
       - Invoices
       - Plans
       - Products

--- a/openapi/paths/subscription-cancellations.yaml
+++ b/openapi/paths/subscription-cancellations.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
+    - Orders
   summary: Retrieve a list of cancellations
   operationId: GetSubscriptionCancellationCollection
   description: Retrieve a list of cancellations for all subscriptions.
@@ -37,15 +37,15 @@ get:
       $ref: ../components/responses/Forbidden.yaml
 post:
   tags:
-    - Subscriptions
-  summary: Cancel a subscription
+    - Orders
+  summary: Cancel an order
   operationId: PostSubscriptionCancellation
-  description: Cancel a subscription or preview the cancellation parameters before that.
+  description: Cancel an order or preview the cancellation parameters before that.
   requestBody:
     $ref: ../components/requestBodies/SubscriptionCancellation.yaml
   responses:
     '201':
-      description: Cancellation was created, subscription is or will be deactivated.
+      description: Cancellation was created, the order is or will be deactivated.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml

--- a/openapi/paths/subscription-cancellations@{id}.yaml
+++ b/openapi/paths/subscription-cancellations@{id}.yaml
@@ -3,10 +3,10 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve a subscription сancellation
+    - Orders
+  summary: Retrieve an order сancellation
   operationId: GetSubscriptionCancellation
-  description: Retrieve a subscription сancellation with specified identifier string.
+  description: Retrieve an order сancellation with specified identifier string.
   responses:
     '200':
       description: Cancellation was retrieved successfully.
@@ -29,15 +29,15 @@ get:
       $ref: ../components/responses/NotFound.yaml
 put:
   tags:
-    - Subscriptions
-  summary: Cancel a subscription
+    - Orders
+  summary: Cancel an order
   operationId: PutSubscriptionCancellation
   description: Cancel a subscription.
   requestBody:
     $ref: ../components/requestBodies/SubscriptionCancellation.yaml
   responses:
     '200':
-      description: Cancellation was updated, subscription is or will be deactivated.
+      description: Cancellation was updated, the order is or will be deactivated.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml
@@ -50,7 +50,7 @@ put:
           schema:
             $ref: ../components/schemas/Subscription/SubscriptionCancellation.yaml
     '201':
-      description: Cancellation was created, subscription is or will be deactivated.
+      description: Cancellation was created, the order is or will be deactivated.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml
@@ -74,10 +74,10 @@ put:
         $ref: '../code_samples/JavaScript/subscription-cancellations@{id}/put.js'
 delete:
   tags:
-    - Subscriptions
+    - Orders
   summary: Delete a cancellation
   operationId: DeleteSubscriptionCancellation
-  description: Delete a subscription's cancellation. Only draft can be deleted.
+  description: Delete an order's cancellation. Only draft can be deleted.
   responses:
     '204':
       description: Cancellaton was deleted.

--- a/openapi/paths/subscription-reactivations.yaml
+++ b/openapi/paths/subscription-reactivations.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
+    - Orders
   summary: Retrieve a list of reactivations
   operationId: GetSubscriptionReactivationCollection
   description: Retrieve a list of reactivations for all subscriptions.
@@ -41,8 +41,8 @@ get:
         $ref: ../code_samples/JavaScript/subscription-reactivations/get.js
 post:
   tags:
-    - Subscriptions
-  summary: Reactivate a subscription
+    - Orders
+  summary: Reactivate an order
   operationId: PostSubscriptionReactivation
   description: Reactivate a subscription.
   requestBody:
@@ -55,7 +55,7 @@ post:
   responses:
     '201':
       description: >
-        Reactivation was created, subscription is active and won't be.
+        Reactivation was created, the order is active and won't be.
         deactivated.
 
         If there was a cancellation with status "confirmed", it is revoked.

--- a/openapi/paths/subscription-reactivations@{id}.yaml
+++ b/openapi/paths/subscription-reactivations@{id}.yaml
@@ -3,10 +3,10 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve a subscription reactivation
+    -Orders
+  summary: Retrieve an order reactivation
   operationId: GetSubscriptionReactivation
-  description: Retrieve a subscription reactivation with specified identifier string.
+  description: Retrieve an order reactivation with specified identifier string.
   responses:
     '200':
       description: Reactivation was retrieved successfully.

--- a/openapi/paths/subscription-reactivations@{id}.yaml
+++ b/openapi/paths/subscription-reactivations@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    -Orders
+    - Orders
   summary: Retrieve an order reactivation
   operationId: GetSubscriptionReactivation
   description: Retrieve an order reactivation with specified identifier string.

--- a/openapi/paths/subscriptions.yaml
+++ b/openapi/paths/subscriptions.yaml
@@ -2,11 +2,11 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve a list of subscriptions
+    - Orders
+  summary: Retrieve a list of orders
   operationId: GetSubscriptionCollection
   description: |
-    Retrieve a list of subscriptions.
+    Retrieve a list of orders.
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -46,11 +46,11 @@ get:
         $ref: ../code_samples/JavaScript/subscriptions/get.js
 post:
   tags:
-    - Subscriptions
-  summary: Create a subscription
+    - Orders
+  summary: Create an order
   operationId: PostSubscription
   description: |
-    Create a subscription. Consider using the upsert.
+    Create an order. Consider using the upsert.
     operation to accomplish this task.
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
@@ -58,7 +58,7 @@ post:
     $ref: ../components/requestBodies/Subscription.yaml
   responses:
     '201':
-      description: Subscription was created.
+      description: Order was created.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml

--- a/openapi/paths/subscriptions@{id}.yaml
+++ b/openapi/paths/subscriptions@{id}.yaml
@@ -3,16 +3,16 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve a subscription
+    - Orders
+  summary: Retrieve an order
   operationId: GetSubscription
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
   description: |
-    Retrieve a subscription with specified identifier string.
+    Retrieve an order with specified identifier string.
   responses:
     '200':
-      description: Subscription was retrieved successfully.
+      description: Order was retrieved successfully.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml
@@ -39,18 +39,18 @@ get:
         $ref: '../code_samples/JavaScript/subscriptions@{id}/get.js'
 put:
   tags:
-    - Subscriptions
-  summary: Upsert a subscription with predefined ID
+    - Orders
+  summary: Upsert an order with predefined ID
   operationId: PutSubscription
   description: |
-    Create or update a subscription with predefined identifier string.
+    Create or update an order with predefined identifier string.
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
   requestBody:
     $ref: ../components/requestBodies/Subscription.yaml
   responses:
     '200':
-      description: Subscription was updated.
+      description: Order was updated.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml
@@ -63,7 +63,7 @@ put:
           schema:
             $ref: ../components/schemas/Subscription.yaml
     '201':
-      description: Subscription was created.
+      description: Order was created.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml

--- a/openapi/paths/subscriptions@{id}@change-plan.yaml
+++ b/openapi/paths/subscriptions@{id}@change-plan.yaml
@@ -9,7 +9,7 @@ post:
   description: >
     Change an order's plan and designate when and if there should be pro-rata credits given.
 
-    Only active order orders with a single plan can be changed.
+    Only active subscription orders with a single plan can be changed.
 
     Edit pending unpaid orders directly regardless the number of plans.
   requestBody:

--- a/openapi/paths/subscriptions@{id}@change-plan.yaml
+++ b/openapi/paths/subscriptions@{id}@change-plan.yaml
@@ -3,16 +3,15 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 post:
   tags:
-    - Subscriptions
-  summary: Change a subscription's plan
+    - Orders
+  summary: Change an order's plan
   operationId: PostSubscriptionPlanChange
   description: >
-    Change a subscription's plan and designate when and if there should be pro.
-    rata credits given.
+    Change an order's plan and designate when and if there should be pro-rata credits given.
 
-    Only active subscriptions with a single plan can be changed.
+    Only active order orders with a single plan can be changed.
 
-    Edit pending unpaid subscriptions directly regardless the number of plans.
+    Edit pending unpaid orders directly regardless the number of plans.
   requestBody:
     content:
       application/json:
@@ -22,7 +21,7 @@ post:
     required: true
   responses:
     '201':
-      description: Subscription was changed.
+      description: Order was changed.
       headers:
         Rate-Limit-Limit:
           $ref: ../components/headers/Rate-Limit-Limit.yaml

--- a/openapi/paths/subscriptions@{id}@interim-invoice.yaml
+++ b/openapi/paths/subscriptions@{id}@interim-invoice.yaml
@@ -3,8 +3,8 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 post:
   tags:
-    - Subscriptions
-  summary: Issue an interim invoice for a subscription
+    - Orders
+  summary: Issue an interim invoice for a subscription order
   operationId: PostSubscriptionInterimInvoice
   description: >
     Issue an interim invoice for a subscription, typically used in conjunction.

--- a/openapi/paths/subscriptions@{id}@timeline.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
+    - Orders
   summary: Retrieve a list of order timeline messages
   operationId: GetSubscriptionTimelineCollection
   description: |
@@ -42,7 +42,7 @@ get:
         $ref: '../code_samples/JavaScript/subscriptions@{id}@timeline/get.js'
 post:
   tags:
-    - Subscriptions
+    - Orders
   summary: Create an order Timeline comment
   operationId: PostSubscriptionTimeline
   description: |

--- a/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
@@ -9,7 +9,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
+    - Orders
   summary: Retrieve an Order Timeline message
   operationId: GetSubscriptionTimeline
   description: |
@@ -41,7 +41,7 @@ get:
           ../code_samples/JavaScript/subscriptions@{id}@timeline@{messageId}/get.js
 delete:
   tags:
-    - Subscriptions
+    - Orders
   summary: Delete an Order Timeline message
   operationId: DeleteSubscriptionTimeline
   description: |

--- a/openapi/paths/subscriptions@{id}@upcoming-invoices.yaml
+++ b/openapi/paths/subscriptions@{id}@upcoming-invoices.yaml
@@ -3,11 +3,11 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve subscription's upcoming invoice
+    - Orders
+  summary: Retrieve subscription order's upcoming invoice
   operationId: GetSubscriptionUpcomingInvoiceCollection
   description: >
-    Retrieve an upcoming invoice from the specified subscription.
+    Retrieve an upcoming invoice from the specified subscription order.
 
     The endpoint is temporary before upcoming invoices get a complete
     integration.

--- a/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
+++ b/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
@@ -9,7 +9,7 @@ parameters:
   - $ref: ../components/parameters/organizationId.yaml
 post:
   tags:
-    - Subscriptions
+    - Orders
   summary: Issue an upcoming invoice for early pay
   operationId: PostUpcomingInvoiceIssuance
   description: |

--- a/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
+++ b/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
@@ -5,17 +5,17 @@ parameters:
   - name: subscriptionId
     in: path
     required: true
-    description: Subscription's ID.
+    description: Order's ID.
     schema:
       type: string
   - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
-    - Subscriptions
-  summary: Retrieve subscription summary metrics
+    - Orders
+  summary: Retrieve subscription order summary metrics
   operationId: GetSubscriptionSummaryMetricReport
   description: |
-    Retrieve subscription summary metrics.
+    Retrieve subscription order summary metrics.
   responses:
     '200':
       description: Metrics were retrieved successfully.

--- a/openapi/reports.yaml
+++ b/openapi/reports.yaml
@@ -21,8 +21,8 @@ info:
 
     ## Javascript SDK
 
-    The [Javascript SDK](https://github.com/Rebilly/rebilly-js-sdk) is maintained 
-    within Github, and contains the installation and usage instructions in the Readme file. 
+    The [Javascript SDK](https://github.com/Rebilly/rebilly-js-sdk) is maintained
+    within Github, and contains the installation and usage instructions in the Readme file.
     SDK code examples are included in these docs.
 
 tags:
@@ -65,7 +65,7 @@ tags:
   - name: Activity Feed
     description: |
       Activity Feed is holding various events that occurred in the app.
-  - name: Subscriptions
+  - name: Orders
   - name: Organizations
   - name: Customers
 security:

--- a/openapi/webhooks/order-completed.yaml
+++ b/openapi/webhooks/order-completed.yaml
@@ -1,7 +1,7 @@
 summary: Order completed
 operationId: order-completed
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/renewal-invoice-issued.yaml
+++ b/openapi/webhooks/renewal-invoice-issued.yaml
@@ -1,7 +1,7 @@
 summary: Renewal invoice issued
 operationId: renewal-invoice-issued
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceAndSubscription.yaml
 responses:

--- a/openapi/webhooks/subscription-activated.yaml
+++ b/openapi/webhooks/subscription-activated.yaml
@@ -1,7 +1,7 @@
-summary: Subscription activated
+summary: Order activated
 operationId: subscription-activated
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-canceled.yaml
+++ b/openapi/webhooks/subscription-canceled.yaml
@@ -1,7 +1,7 @@
-summary: Subscription canceled
+summary: Subscription order canceled
 operationId: subscription-canceled
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-modified.yaml
+++ b/openapi/webhooks/subscription-modified.yaml
@@ -1,7 +1,7 @@
-summary: Subscription modified
+summary: Order modified
 operationId: subscription-modified
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-reactivated.yaml
+++ b/openapi/webhooks/subscription-reactivated.yaml
@@ -1,7 +1,7 @@
 summary: Subscription reactivated
 operationId: subscription-reactivated
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-renewal-reminder.yaml
+++ b/openapi/webhooks/subscription-renewal-reminder.yaml
@@ -1,7 +1,7 @@
 summary: Subscription renewal reminder
 operationId: subscription-renewal-reminder
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-renewed.yaml
+++ b/openapi/webhooks/subscription-renewed.yaml
@@ -1,7 +1,7 @@
 summary: Subscription renewed
 operationId: subscription-renewed
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-trial-converted.yaml
+++ b/openapi/webhooks/subscription-trial-converted.yaml
@@ -1,7 +1,7 @@
 summary: Subscription trial converted
 operationId: subscription-trial-converted
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-trial-end-changed.yaml
+++ b/openapi/webhooks/subscription-trial-end-changed.yaml
@@ -1,7 +1,7 @@
 summary: Subscription trial end changed
 operationId: subscription-trial-end-changed
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-trial-end-reminder.yaml
+++ b/openapi/webhooks/subscription-trial-end-reminder.yaml
@@ -1,7 +1,7 @@
 summary: Subscription trial end reminder
 operationId: subscription-trial-end-reminder
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:

--- a/openapi/webhooks/subscription-trial-ended.yaml
+++ b/openapi/webhooks/subscription-trial-ended.yaml
@@ -1,7 +1,7 @@
 summary: Subscription trial ended
 operationId: subscription-trial-ended
 tags:
-  - Subscriptions
+  - Orders
 requestBody:
   $ref: ../components/requestBodies/Webhooks/Subscription.yaml
 responses:


### PR DESCRIPTION
This changes only descriptions and more importantly tags, so it's only about what people see in UI (thus unrelated to backward compatibility). The reason is that when you're looking to implement something like a cart and browsing the API, you would overlook the "Subscriptions" subdivision.

This would introduce a certain inconsistancy with API resources and endpoints though as API remains to be `/subscriptions/`.

https://preview.redoc.ly/rebilly-core/subscription-to-order/tag/Orders