### PR TITLE
Remove deprecated ApiKey fields

### DIFF
--- a/openapi/code_samples/JavaScript/api-keys/post.js
+++ b/openapi/code_samples/JavaScript/api-keys/post.js
@@ -1,10 +1,7 @@
 // first set the properties for the new API key
 const data = {
     description: 'My new API key',
-    // the `datetimeFormat` defines how dates will be saved 
-    // and handled by Rebilly for this API key
-    // can be either `iso8601` (default) or `mysql`
-    datetimeFormat: 'iso8601'
+    type: 'secret'
 };
 
 // the ID is optional

--- a/openapi/components/schemas/Acl.yaml
+++ b/openapi/components/schemas/Acl.yaml
@@ -5,11 +5,6 @@ items:
     - scope
     - permissions
   properties:
-    scopes:
-      deprecated: true
-      description: Array of api key scopes.
-      allOf:
-        - $ref: ./ApiKeyScopes.yaml
     scope:
       description: Api Key scope.
       allOf:

--- a/openapi/components/schemas/ApiKey.yaml
+++ b/openapi/components/schemas/ApiKey.yaml
@@ -8,13 +8,6 @@ properties:
   description:
     description: API key description.
     type: string
-  datetimeFormat:
-    description: Date time format.
-    type: string
-    default: iso8601
-    enum:
-      - mysql
-      - iso8601
   type:
     description: Type of API key.
     type: string
@@ -22,12 +15,6 @@ properties:
     enum:
       - secret
       - publishable
-  permissions:
-    description: >-
-      Specify individual permissions here if creating a restricted API key.
-    deprecated: true
-    allOf:
-      - $ref: ./AclPermissions.yaml
   acl:
     description: >-
       Specify access control list here if creating a restricted API key. Send

--- a/openapi/components/schemas/ApiKey.yaml
+++ b/openapi/components/schemas/ApiKey.yaml
@@ -1,5 +1,7 @@
 type: object
 description: API secret Key.
+required:
+  - description
 properties:
   id:
     readOnly: true


### PR DESCRIPTION
Remove deprecated ApiKey fields: datetimeFormat, persmissions
Remove deprecated Acl fields: scopes
Make `description` required (it is required in API)