### PR TITLE
Add Paymero amountExceeded setting

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Paymero.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Paymero.yaml
@@ -39,3 +39,7 @@ allOf:
             enum:
               - TRX
               - ETH
+          amountExceeded:
+            description: Decline transactions when the amount received exceeds the amount requested.
+            type: boolean
+            default: false


### PR DESCRIPTION
Adds a setting for Paymero gateway accounts named `amountExceed`. When enabled, transactions will automatically be declined when the amount received exceeds the amount requested.