### PR TITLE
Add enableGuestCheckout setting for PayPal gateway accounts

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
@@ -15,3 +15,7 @@ allOf:
             type: string
             description: The URL where the user will be redirected after authorizing the account on PayPal.
             format: url
+          enableGuestCheckout:
+            type: boolean
+            default: false
+            description: Allow users without PayPal accounts to pay using credit or debit cards.


### PR DESCRIPTION
Adds a boolean setting property named `enableGuestCheckout` to PayPal gateway accounts.

When this setting is enabled, customers without PayPal accounts will be able to make purchases using credit/debit cards. In order for this setting to work, merchants must have the "PayPal Account Optional" setting set to "On" in their PayPal account. Additionally, all transactions will require user approval when this setting is enabled.