### PR TITLE
Revert "Allow override of Stripe metadata Organization ID"

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
@@ -23,8 +23,5 @@ allOf:
             type: boolean
             description: If `true`, `off_session` param will always be `true` in Stripe requests.
             default: false
-          organizationId:
-            type: string
-            description: Override the default Origanization ID sent in metadata used for lookup upon notification.
       threeDSecureServer:
         $ref: ../ThreeDSecureServers/Stripe3dsServers/Stripe3dsServers.yaml


### PR DESCRIPTION
Reverts Rebilly/api-definitions#479