### PR TITLE
Mark x-basic columns (shown as default in datatables and dataexports)

### DIFF
--- a/openapi/components/schemas/Common/CommonInvoice.yaml
+++ b/openapi/components/schemas/Common/CommonInvoice.yaml
@@ -16,6 +16,7 @@ properties:
     description: An auto-incrementing number based on the sequence of invoices for any particular customer.
     readOnly: true
     type: integer
+    x-basic: true
   subscriptionId:
     description: The related order's ID if available, otherwise null.
     readOnly: true
@@ -23,6 +24,7 @@ properties:
       - $ref: ../ResourceId.yaml
   currency:
     x-sortable: true
+    x-basic: true
     allOf:
       - $ref: ../CurrencyCode.yaml
   amount:
@@ -30,6 +32,7 @@ properties:
     type: number
     x-type: Money
     x-sortable: true
+    x-basic: true
     format: double
     readOnly: true
   amountDue:
@@ -99,6 +102,7 @@ properties:
   status:
     type: string
     description: Invoice status.
+    x-basic: true
     readOnly: true
     enum:
      - "draft"
@@ -134,6 +138,7 @@ properties:
   paidTime:
     x-label: Payment Date
     x-sortable: true
+    x-basic: true
     description: Invoice paid time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
@@ -146,6 +151,7 @@ properties:
     description: Invoice issued time.
     x-label: Date Issued
     x-sortable: true
+    x-basic: true
     allOf:
       - $ref: ../ServerTimestamp.yaml
   createdTime:

--- a/openapi/components/schemas/Common/CommonSubscription.yaml
+++ b/openapi/components/schemas/Common/CommonSubscription.yaml
@@ -32,6 +32,7 @@ properties:
   websiteId:
     description: The website identifier string.
     x-sortable: true
+    x-basic: true
     allOf:
       - $ref: ../ResourceId.yaml
   initialInvoiceId:
@@ -56,6 +57,7 @@ properties:
         planId:
           description: The plan identifier string.
           deprecated: true
+          x-basic: true
           allOf:
             - $ref: ../ResourceId.yaml
         quantity:

--- a/openapi/components/schemas/Common/CommonSubscriptionOrder.yaml
+++ b/openapi/components/schemas/Common/CommonSubscriptionOrder.yaml
@@ -85,6 +85,7 @@ allOf:
           period.
         nullable: true
         x-sortable: true
+        x-basic: true
         example: null
         type: string
         format: date-time
@@ -97,6 +98,7 @@ allOf:
         description: Subscription renewal time.
         type: string
         x-sortable: true
+        x-basic: true
         format: date-time
       rebillNumber:
         description: The current period number.

--- a/openapi/components/schemas/Common/CommonTransaction.yaml
+++ b/openapi/components/schemas/Common/CommonTransaction.yaml
@@ -12,11 +12,13 @@ properties:
       - $ref: ../ResourceId.yaml
   customerId:
     description: The сustomer's ID.
+    x-basic: true
     allOf:
       - $ref: ../ResourceId.yaml
   type:
     description: Transaction type.
     type: string
+    x-basic: true
     readOnly: true
     enum:
       - 3ds-authentication
@@ -50,6 +52,7 @@ properties:
   result:
     description: Transaction result.
     type: string
+    x-basic: true
     readOnly: true
     enum:
       - abandoned
@@ -60,6 +63,7 @@ properties:
   amount:
     x-type: Money
     x-sortable: true
+    x-basic: true
     description: The transaction's amount.
     type: number
     format: double
@@ -175,6 +179,7 @@ properties:
     description: |
       Payment Gateway name, available only after the gateway is selected for the transaction.
     x-label: Gateway account
+    x-basic: true
     allOf:
       - $ref: ../Gateways/GatewayName.yaml
   customFields:
@@ -182,6 +187,7 @@ properties:
   processedTime:
     description: Transaction processed time.
     x-sortable: true
+    x-basic: true
     allOf:
       - $ref: ../ServerTimestamp.yaml
   createdTime:

--- a/openapi/components/schemas/Coupon/Coupon.yaml
+++ b/openapi/components/schemas/Coupon/Coupon.yaml
@@ -31,6 +31,7 @@ properties:
       - expired
   description:
     type: string
+    x-basic: true
     description: >
       Your coupon description. When it is not empty this is used for invoice discount item description,
       otherwise the item's description uses coupon's ID like 'Coupon "COUPON-ID"'.
@@ -39,12 +40,14 @@ properties:
     type: string
     x-label: Valid from
     x-sortable: true
+    x-basic: true
     format: date-time
   expiredTime:
     description: Coupon's expire time (end time).
     type: string
     x-label: Valid until
     x-sortable: true
+    x-basic: true
     format: date-time
   createdTime:
     description: Coupon created time.

--- a/openapi/components/schemas/Coupon/Discount.yaml
+++ b/openapi/components/schemas/Coupon/Discount.yaml
@@ -10,6 +10,7 @@ properties:
     type: string
     x-label: Type
     x-sortable: true
+    x-basic: true
     enum:
       - fixed
       - percent

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -11,14 +11,17 @@ properties:
     format: email
     readOnly: true
     x-sortable: true
+    x-basic: true
   firstName:
     description: The customer's first name.
     type: string
+    x-basic: true
     readOnly: true
   lastName:
     description: The customer's last name.
     type: string
     x-sortable: true
+    x-basic: true
     readOnly: true
   websiteId:
     x-sortable: true
@@ -57,12 +60,14 @@ properties:
   paymentCount:
     x-label: Payments
     x-sortable: true
+    x-basic: true
     description: The number of approved payments for the customer.
     readOnly: true
     type: integer
   lastPaymentTime:
     x-label: Last Payment
     x-sortable: true
+    x-basic: true
     description: The most recent time of an approved payment for the customer.
     allOf:
       - $ref: ./ServerTimestamp.yaml

--- a/openapi/components/schemas/CustomerAverageValue.yaml
+++ b/openapi/components/schemas/CustomerAverageValue.yaml
@@ -9,6 +9,7 @@ properties:
     x-type: Money
     x-label: Average Value
     x-sortable: true
+    x-basic: true
     description: Average approved payment amount in Merchant's reporting currency.
     type: number
     format: double

--- a/openapi/components/schemas/CustomerLifetimeRevenue.yaml
+++ b/openapi/components/schemas/CustomerLifetimeRevenue.yaml
@@ -9,6 +9,7 @@ properties:
     x-type: Money
     x-label: Lifetime Revenue
     x-sortable: true
+    x-basic: true
     description: Revenue amount in Merchant's reporting currency.
     type: number
     format: double

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -16,9 +16,11 @@ properties:
     items:
       $ref: ./GlobalWebhookEventType.yaml
   status:
+    x-basic: true
     $ref: ./OnOff.yaml
   method:
     type: string
+    x-basic: true
     enum:
       - GET
       - POST

--- a/openapi/components/schemas/Invoices/Invoice.yaml
+++ b/openapi/components/schemas/Invoices/Invoice.yaml
@@ -5,6 +5,7 @@ allOf:
   - properties:
       customerId:
         description: The сustomer's ID.
+        x-basic: true
         allOf:
           - $ref: ../ResourceId.yaml
       transactions:

--- a/openapi/components/schemas/Invoices/InvoiceItem.yaml
+++ b/openapi/components/schemas/Invoices/InvoiceItem.yaml
@@ -11,6 +11,7 @@ properties:
   type:
     description: Invoice item's type.
     type: string
+    x-basic: true
     enum:
       - debit
       - credit

--- a/openapi/components/schemas/Subscription.yaml
+++ b/openapi/components/schemas/Subscription.yaml
@@ -9,6 +9,7 @@ properties:
     description: |
       Specifies the type of order, a subscription or a one-time purchase.
     type: string
+    x-basic: true
     enum:
       - subscription-order
       - one-time-order

--- a/openapi/components/schemas/Subscription/OrderTypes/OneTimeOrder.yaml
+++ b/openapi/components/schemas/Subscription/OrderTypes/OneTimeOrder.yaml
@@ -9,6 +9,7 @@ allOf:
   - properties:
       customerId:
         description: The customer identifier string.
+        x-basic: true
         allOf:
           - $ref: ../../ResourceId.yaml
   # Always keep the SubscriptionMetadata the latest merged schema,

--- a/openapi/components/schemas/Subscription/OrderTypes/SubscriptionOrder.yaml
+++ b/openapi/components/schemas/Subscription/OrderTypes/SubscriptionOrder.yaml
@@ -9,6 +9,7 @@ allOf:
   - properties:
       customerId:
         description: The customer identifier string.
+        x-basic: true
         allOf:
           - $ref: ../../ResourceId.yaml
       renewalReminderTime:

--- a/openapi/components/schemas/Subscription/SubscriptionCancellationState.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionCancellationState.yaml
@@ -4,6 +4,7 @@ properties:
     description: Subscription order canceled time.
     x-label: Cancellation time
     x-sortable: true
+    x-basic: true
     allOf:
       - $ref: ../ServerTimestamp.yaml
   canceledBy:

--- a/openapi/components/schemas/Tracking/ApiTracking.yaml
+++ b/openapi/components/schemas/Tracking/ApiTracking.yaml
@@ -7,9 +7,11 @@ properties:
       - $ref: ../ResourceId.yaml
   status:
     type: integer
+    x-basic: true
     description: HTTP response code.
   url:
     type: string
+    x-basic: true
     description: API request address.
   route:
     type: string
@@ -25,6 +27,7 @@ properties:
       - PUT
       - DELETE
       - PATCH
+    x-basic: true
   request:
     type: string
     description: Request JSON-string.
@@ -58,6 +61,7 @@ properties:
         type: string
       ipAddress:
         type: string
+        x-basic: true
         deprecated: true
         description: Client IP address.
         format: ipv4
@@ -89,9 +93,11 @@ properties:
           - $ref: ../ResourceId.yaml
   duration:
     type: integer
+    x-basic: true
     description: Request duration in milliseconds.
   createdTime:
     description: The log created time.
+    x-basic: true
     allOf:
       - $ref: ../ServerTimestamp.yaml
   _links:

--- a/openapi/components/schemas/Transactions/Transaction.yaml
+++ b/openapi/components/schemas/Transactions/Transaction.yaml
@@ -251,6 +251,7 @@ allOf:
         description: Transaction amount converted to organization selected report currency.
         type: number
         x-type: Money
+        x-sortable: true
         x-currency-field: reportCurrency
         format: double
         readOnly: true


### PR DESCRIPTION
We mark with `x-basic: true` properties used to generate default columns in both `data-tables` and `data-exports`.  

(We can easily change `x-basic` if we find a better name).