### PR TITLE
Add useHostedCheckoutForm and forceGuestCheckout PayPal settings

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
@@ -19,3 +19,11 @@ allOf:
             type: boolean
             default: false
             description: Allow users without PayPal accounts to pay using credit or debit cards.
+          useHostedCheckoutForm:
+            type: boolean
+            default: false
+            description: Use Rebilly's hosted PayPal form instead of redirecting customers to PayPal.
+          forceGuestCheckout:
+            type: boolean
+            default: false
+            description: Suppress PayPal payment method when Guest Checkout is available. Only applicable when useHostedCheckoutForm is enabled.


### PR DESCRIPTION
This PR introduces two new boolean settings for PayPal gateway accounts:

`useHostedCheckoutForm` - When enabled, customers will be redirected to a PayPal checkout form, hosted on Rebilly, which displays PayPal payment buttons.
`forceGuestCheckout` - When enabled, along with `useHostedCheckoutForm`, only the 'Pay with Credit/Debit' card payment button will display on the form and PayPal will not be shown as a payment method.

These settings aim to improve the user experience for PayPal payments and draw attention to the guest checkout option, if desired by merchants.