### PR TITLE
Allow to use original plan without changing on order create

### DIFF
--- a/openapi/components/schemas/Common/CommonSubscription.yaml
+++ b/openapi/components/schemas/Common/CommonSubscription.yaml
@@ -64,7 +64,9 @@ properties:
           description: Number of units of the product on the given plan.
           type: integer
         plan:
-          $ref: ../Plans/FlexiblePlan.yaml
+          oneOf:
+            - $ref: ../Plans/OriginalPlan.yaml
+            - $ref: ../Plans/FlexiblePlan.yaml
         revision:
           type: integer
           readOnly: true

--- a/openapi/components/schemas/Plans/FlexiblePlan.yaml
+++ b/openapi/components/schemas/Plans/FlexiblePlan.yaml
@@ -3,7 +3,7 @@ allOf:
 properties:
   id:
     readOnly: false
-    description: The Plan identifier.
+    description: The ID of plan to modify with given settings.
     allOf:
       - $ref: ../ResourceId.yaml
 required:

--- a/openapi/components/schemas/Plans/OriginalPlan.yaml
+++ b/openapi/components/schemas/Plans/OriginalPlan.yaml
@@ -1,0 +1,11 @@
+type: object
+description:
+  Plan without changes.
+required:
+  - id
+properties:
+  id:
+    description: The ID of plan to use.
+    readOnly: false
+    allOf:
+      - $ref: ../ResourceId.yaml

--- a/openapi/components/schemas/SubscriptionChange.yaml
+++ b/openapi/components/schemas/SubscriptionChange.yaml
@@ -17,7 +17,9 @@ properties:
         - quantity
       properties:
         plan:
-          $ref: ./Plans/FlexiblePlan.yaml
+          oneOf:
+            - $ref: ./Plans/OriginalPlan.yaml
+            - $ref: ./Plans/FlexiblePlan.yaml
         quantity:
           description: Number of units of the product on the given plan.
           type: integer


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4003786/122212211-056d6f00-cec1-11eb-9976-b521256cc3b9.png)


Direct link to preview: [PostSubscription](https://preview.redoc.ly/rebilly-core/Allow-to-use-initial-plan-without-changes/tag/Orders#operation/PostSubscription)