### PR TITLE
Add Worldpay alternative payments credentials

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -27,7 +27,6 @@ allOf:
           alternativePaymentsUsername:
             type: string
             description: Optional API username for alternative payments platform.
-            format: password
           alternativePaymentsPassword:
             type: string
             description: Optional API password for alternative payments platform.

--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -24,6 +24,14 @@ allOf:
             type: string
             description: Optional alternate merchant password for payouts.
             format: password
+          alternativePaymentsUsername:
+            type: string
+            description: Optional API username for alternative payments platform.
+            format: password
+          alternativePaymentsPassword:
+            type: string
+            description: Optional API password for alternative payments platform.
+            format: password
         required:
           - merchantCode
           - merchantPassword


### PR DESCRIPTION
This PR introduces two new credential values, named `alternativePaymentsUsername` and `alternativePaymentsPassword`,  for the Worldpay Gateway Accounts.

These values are used for calls to the Worldpay Alternative Payments (WPAP) platform, which is used for payment methods such as Sofort. The WPAP platform uses separate credentials than the WPG platform.