### PR TITLE
Updated PUT product summary and description from Create to Upsert

### DIFF
--- a/openapi/paths/products@{id}.yaml
+++ b/openapi/paths/products@{id}.yaml
@@ -36,11 +36,11 @@ get:
 put:
   tags:
     - Products
-  summary: Create a product with predefined ID
+  summary: Upsert a product with predefined ID
   operationId: PutProduct
   x-sdk-operation-name: update
   description: |
-    Create a product with predefined identifier string.
+    Create or update a product with predefined identifier string.
   requestBody:
     $ref: ../components/requestBodies/Product.yaml
   responses:


### PR DESCRIPTION
Based on feedback in Intercomm, I updated the [api/tag/Products/#tag/Products/operation/PutProduct](https://www.rebilly.com/docs/developer-docs/api/tag/Products/#tag/Products/operation/PutProduct) summary and description from _Create_ to _Upsert_. 