### PR TITLE
Add MID brand name to CashToCode

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
@@ -23,6 +23,9 @@ allOf:
             type: string
             description: Merchant credentials password.
             format: password
+          brandName:
+            type: string
+            description: CashToCode brand name.
         required:
           - cashToCodeUsername
           - cashToCodePassword

--- a/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/CashToCode.yaml
@@ -23,9 +23,9 @@ allOf:
             type: string
             description: Merchant credentials password.
             format: password
-          brandName:
+          mid:
             type: string
-            description: CashToCode brand name.
+            description: CashToCode MID (brand name).
         required:
           - cashToCodeUsername
           - cashToCodePassword


### PR DESCRIPTION
It's used to set merchant sub-account to use for request.
If not provided it will fallback to merchant username.