### PR TITLE
feat: payment instrument setups

### DIFF
--- a/openapi/components/requestBodies/SetupRequest.yaml
+++ b/openapi/components/requestBodies/SetupRequest.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Common/CommonTransactionRequest.yaml
+description: Transaction resource.
+required: true

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -290,6 +290,42 @@ properties:
     description: Customer's payment instrument will "stick" to the gateway account for future transactions when enabled.
     type: boolean
     default: true
+  setupInstruction:
+    description: Instructions for processing a setup request.
+    type: object
+    properties:
+      continueOnFailure:
+        type: boolean
+        default: false
+        example: false
+        description: |
+          If set to continue on failure,
+          then it will proceed to execute the next step.
+          It will use the last step with a success in the result.
+      steps:
+        type: array
+        description: List of steps in the order they should execute.
+        items:
+          type: string
+          description: |
+              Many steps may ignore the amount from the request.
+              Most gateways will not support all of the types of steps.
+              In this case, check the gateway-specific definitions for available steps.
+              All gateways support `do-nothing`.
+          enum:
+              - authorize
+              - authorize-and-void
+              - gather-kyc
+              - use-sca
+              - get-billing-agreement
+              - do-nothing
+          x-enumDescriptions:
+            authorize: Will create an authorize transaction in the amount/currency of the request.
+            authorize-and-void: Will create an authorize transaction in the amount/currency of the request, followed by a void.
+            gather-kyc: Will collect proof of identity via the KYC document gatherer. Will ignore transaction amount/currency.
+            use-sca: Will use SCA (strong customer authentication) which includes 3dsv2, 3ds, and some specific wallets.
+            get-billing-agreement: Will get a billing agreement from a customer (for example, this is applicable to PayPal).
+            do-nothing: Will do nothing, and return an approved `setup` transaction. This is the default behavior.
   createdTime:
     description: Gateway Account created time.
     allOf:

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -399,6 +399,8 @@ paths:
     $ref: './paths/transactions@{id}.yaml'
   /payouts:
     $ref: ./paths/payouts.yaml
+  /setups:
+      $ref: ./paths/setups.yaml
   '/transactions/{id}/query':
     $ref: './paths/transactions@{id}@query.yaml'
   '/transactions/{id}/update':

--- a/openapi/paths/setups.yaml
+++ b/openapi/paths/setups.yaml
@@ -11,7 +11,7 @@ post:
     Ideas of setup instructions:
       - do a 3DS authentication, then $1 auth + void
       - do a $0 verification
-      - do nothing (some gateways don't support special types like `auth` and `void`)
+      - do nothing (some gateways don't support special types like `auth` and `void`).
   requestBody:
     $ref: ../components/requestBodies/SetupRequest.yaml
   responses:

--- a/openapi/paths/setups.yaml
+++ b/openapi/paths/setups.yaml
@@ -1,0 +1,31 @@
+parameters:
+  - $ref: ../components/parameters/organizationId.yaml
+post:
+  tags:
+    - Transactions
+  summary: Setup a payment instrument
+  operationId: PostSetup
+  x-sdk-operation-name: create
+  description: |
+    Create a transaction (or series of transactions) according to the gateway accounts setup instructions.
+    Ideas of setup instructions:
+      - do a 3DS authentication, then $1 auth + void
+      - do a $0 verification
+      - do nothing (some gateways don't support special types like `auth` and `void`)
+  requestBody:
+    $ref: ../components/requestBodies/SetupRequest.yaml
+  responses:
+    '201':
+      description: Transaction was created.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/Transactions/Transaction.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+    '409':
+      $ref: ../components/responses/Conflict.yaml
+    '422':
+      $ref: ../components/responses/ValidationError.yaml


### PR DESCRIPTION
This allows for a consistent integration flow even when some gateways (for example, fictitious cryptoworld) can do nothing setup related.

Within the gateway account settings, someone can specify the setup instructions (this part is not included in this PR).

Then, they have a simple integration:

1. POST /setups
2. POST /transactions

And no... well if the payment method selected is ___ then do ____.

Ideas of setup instructions:

- do a 3DS authentication, then $1 auth + void
- do a $0 verification
- do nothing (some gateways don't support special types like `auth` and `void`)