### PR TITLE
Setups API

### DIFF
--- a/openapi/components/requestBodies/SetupRequest.yaml
+++ b/openapi/components/requestBodies/SetupRequest.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Common/CommonTransactionRequest.yaml
+description: Transaction resource.
+required: true

--- a/openapi/components/requestBodies/SetupRequest.yaml
+++ b/openapi/components/requestBodies/SetupRequest.yaml
@@ -1,6 +1,6 @@
 content:
   application/json:
     schema:
-      $ref: ../schemas/Common/CommonTransactionRequest.yaml
+      $ref: ../schemas/Common/CommonSetupRequest.yaml
 description: Transaction resource.
 required: true

--- a/openapi/components/schemas/Common/CommonSetupRequest.yaml
+++ b/openapi/components/schemas/Common/CommonSetupRequest.yaml
@@ -1,0 +1,68 @@
+type: object
+required:
+  - websiteId
+  - customerId
+  - currency
+properties:
+  websiteId:
+    description: The website identifier string.
+    allOf:
+      - $ref: ../ResourceId.yaml
+  customerId:
+    description: The customer identifier string.
+    allOf:
+      - $ref: ../ResourceId.yaml
+  currency:
+    allOf:
+      - $ref: ../CurrencyCode.yaml
+  amount:
+    description: The transaction amount.
+    type: number
+    format: double
+    example: 97.97
+  paymentInstruction:
+    description: >-
+      Payment instruction. If not supplied, customer's default payment instrument will be used.
+    allOf:
+      - $ref: ../PaymentInstruction.yaml
+  billingAddress:
+    description: >-
+      Billing address. If not supplied, we use the billing address associated
+      with the payment instrument, and then customer.
+    nullable: true
+    allOf:
+      - $ref: ../Contact/ContactObject.yaml
+  gatewayAccountId:
+    description: >-
+      Rebilly will select the appropriate payment gateway account for the transaction based on
+      the properties of the transaction and the `gateway-account-requested` event rules configurations.
+      If you wish to prevent Rebilly from making the gateway account selection, you may supply a
+      gateway account id here, and it will be used instead. Only use this field if you intend to override the settings.
+    nullable: true
+    allOf:
+      - $ref: ../ResourceId.yaml
+  description:
+    nullable: true
+    description: The setup description.
+    type: string
+    maxLength: 255
+  notificationUrl:
+    nullable: true
+    description: >
+      The URL where a server-to-server notification request type `POST` with a
+      transaction payload will be sent when the transaction's result is finalized. Do not trust the notification;
+      follow with a `GET` request to confirm the result of the transaction. Please respond with a `2xx`
+      HTTP status code, or we will reattempt the request again.
+      You may use `{id}` or `{result}` as placeholders in the URL and we will replace them with the transaction's id and result accordingly.
+    type: string
+    format: uri
+  redirectUrl:
+    nullable: true
+    description: >-
+      The URL to redirect the end-user when an offsite transaction is completed.
+      Defaults to the website's configured URL.
+      You may use `{id}` or `{result}` as placeholders in the URL and we will replace them with the transaction's id and result accordingly.
+    type: string
+    format: uri
+  riskMetadata:
+    $ref: ../RiskMetadata.yaml

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -399,6 +399,8 @@ paths:
     $ref: './paths/transactions@{id}.yaml'
   /payouts:
     $ref: ./paths/payouts.yaml
+  /setups:
+      $ref: ./paths/setups.yaml
   '/transactions/{id}/query':
     $ref: './paths/transactions@{id}@query.yaml'
   '/transactions/{id}/update':

--- a/openapi/paths/setups.yaml
+++ b/openapi/paths/setups.yaml
@@ -1,0 +1,31 @@
+parameters:
+  - $ref: ../components/parameters/organizationId.yaml
+post:
+  tags:
+    - Transactions
+  summary: Setup a payment instrument
+  operationId: PostSetup
+  x-sdk-operation-name: create
+  description: |
+    Create a transaction (or series of transactions) according to the gateway accounts setup instructions.
+    Ideas of setup instructions:
+      - do a 3DS authentication, then $1 auth + void
+      - do a $0 verification
+      - do nothing (some gateways don't support special types like `auth` and `void`)
+  requestBody:
+    $ref: ../components/requestBodies/SetupRequest.yaml
+  responses:
+    '201':
+      description: Transaction was created.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/Transactions/Transaction.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+    '409':
+      $ref: ../components/responses/Conflict.yaml
+    '422':
+      $ref: ../components/responses/ValidationError.yaml

--- a/openapi/paths/setups.yaml
+++ b/openapi/paths/setups.yaml
@@ -8,10 +8,6 @@ post:
   x-sdk-operation-name: create
   description: |
     Create a transaction (or series of transactions) according to the gateway accounts setup instructions.
-    Ideas of setup instructions:
-      - do a 3DS authentication, then $1 auth + void
-      - do a $0 verification
-      - do nothing (some gateways don't support special types like `auth` and `void`)
   requestBody:
     $ref: ../components/requestBodies/SetupRequest.yaml
   responses:


### PR DESCRIPTION
Alternative to https://github.com/Rebilly/api-definitions/pull/558

This allows for a consistent integration flow even when some gateways (for example, fictitious cryptoworld) can do nothing setup related.

Within the gateway account settings, someone can specify the setup instructions (this part is not included in this PR).

Then, they have a simple integration:

1. POST /setups
2. POST /transactions

And no... well if the payment method selected is ___ then do ____.

Ideas of setup instructions:

- do a 3DS authentication, then $1 auth + void
- do a $0 verification
- do nothing (some gateways don't support special types like `auth` and `void`)