### PR TITLE
Add 3DS setting for AsiaPaymentGateway

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/AsiaPaymentGateway.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/AsiaPaymentGateway.yaml
@@ -19,3 +19,9 @@ allOf:
         required:
           - merchantNumber
           - secretKey
+      settings:
+        type: object
+        properties:
+          use3DS:
+            type: boolean
+            description: Use 3DS authentication.

--- a/openapi/components/schemas/GatewayAccountConfig/AsiaPaymentGateway.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/AsiaPaymentGateway.yaml
@@ -22,6 +22,6 @@ allOf:
       settings:
         type: object
         properties:
-          use3DS:
+          use3DSEndpoint:
             type: boolean
-            description: Use 3DS authentication.
+            description: Use 3DS endpoint.


### PR DESCRIPTION
Adds a setting to enable 3DS authentication for AsiaPaymentGateway.