### PR TITLE
Add Stripe Connect credentials

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
@@ -5,6 +5,17 @@ allOf:
     required:
       - settings
     properties:
+      credentials:
+        type: object
+        description: Stripe Connect credentials object. The credentials object may be provided in order to control the Stripe Connect account under which the gateway account is connected.
+        properties:
+          stripeClientId:
+            type: string
+            description: The Client ID under which to connect the Stripe account.
+          stripeSecret:
+            type: string
+            description: The secret key of the Stripe Connect account under which to connect the Stripe account.
+            format: password
       settings:
         type: object
         description: Stripe settings object.

--- a/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
@@ -8,6 +8,9 @@ allOf:
       credentials:
         type: object
         description: Stripe Connect credentials object. The credentials object may be provided in order to control the Stripe Connect account under which the gateway account is connected.
+        required:
+          - stripeClientId
+          - stripeSecret
         properties:
           stripeClientId:
             type: string

--- a/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
@@ -8,9 +8,6 @@ allOf:
       credentials:
         type: object
         description: Stripe Connect credentials object. The credentials object may be provided in order to control the Stripe Connect account under which the gateway account is connected.
-        required:
-          - stripeClientId
-          - stripeSecret
         properties:
           stripeClientId:
             type: string


### PR DESCRIPTION
Adds a `credentials` object to Stripe Gateway Accounts, which includes `stripeClientId` and `stripeSecret` properties. These credentials are used in order to control the Stripe Connect account under which the merchant's Stripe account is connected.