### PR TITLE
Add a setup transaction field to Storefront payment instrument

### DIFF
--- a/openapi/components/requestBodies/storefront/PatchPaymentInstrument.yaml
+++ b/openapi/components/requestBodies/storefront/PatchPaymentInstrument.yaml
@@ -10,6 +10,8 @@ content:
           description: The billing address (if supplied – overrides billing address from token).
           allOf:
             - $ref: ../../schemas/Contact/ContactObject.yaml
+        setupTransaction:
+          $ref: ./SetupTransaction.yaml
         customFields:
           $ref: ../../schemas/ResourceCustomFields.yaml
 description: Payment instrument.

--- a/openapi/components/requestBodies/storefront/PostPaymentInstrument.yaml
+++ b/openapi/components/requestBodies/storefront/PostPaymentInstrument.yaml
@@ -8,6 +8,8 @@ content:
         token:
           description: Payment instrument token ID.
           type: string
+        setupTransaction:
+          $ref: ./SetupTransaction.yaml
         customFields:
           $ref: ../../schemas/ResourceCustomFields.yaml
 description: Payment instrument.

--- a/openapi/components/requestBodies/storefront/SetupTransaction.yaml
+++ b/openapi/components/requestBodies/storefront/SetupTransaction.yaml
@@ -21,7 +21,7 @@ properties:
     type: number
     format: double
     default: 0
-    example: 97.97
+    example: 1.00
   billingAddress:
     description: >-
       Billing address. If not supplied, we use the billing address associated

--- a/openapi/components/requestBodies/storefront/SetupTransaction.yaml
+++ b/openapi/components/requestBodies/storefront/SetupTransaction.yaml
@@ -1,0 +1,41 @@
+type: object
+description: |
+  Create the payment instrument's setup transaction.
+
+  This effectively makes the payment instrument available for further payments.
+  The response should be treated as a general transaction,
+  e.g. the approval links should be followed until the transaction is completed.
+required:
+  - websiteId
+  - currency
+properties:
+  websiteId:
+    description: The website identifier string.
+    allOf:
+      - $ref: ../../schemas/ResourceId.yaml
+  currency:
+    allOf:
+      - $ref: ../../schemas/CurrencyCode.yaml
+  amount:
+    description: The transaction amount.
+    type: number
+    format: double
+    default: 0
+    example: 97.97
+  billingAddress:
+    description: >-
+      Billing address. If not supplied, we use the billing address associated
+      with the payment instrument, and then customer.
+    nullable: true
+    allOf:
+      - $ref: ../../schemas/Contact/ContactObject.yaml
+  redirectUrl:
+    nullable: true
+    description: >-
+      The URL to redirect the end-user when an offsite transaction is completed.
+      Defaults to the website's configured URL.
+      You may use `{id}` or `{result}` as placeholders in the URL and we will replace them with the transaction's id and result accordingly.
+    type: string
+    format: uri
+  riskMetadata:
+    $ref: ../../schemas/RiskMetadata.yaml

--- a/openapi/components/schemas/Storefront/StorefrontPaymentInstrument.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontPaymentInstrument.yaml
@@ -4,6 +4,8 @@ oneOf:
   - $ref: ../Common/CommonPayPalAccount.yaml
   - $ref: ../Common/CommonAlternativeInstrument.yaml
 properties:
+    setupTransaction:
+      $ref: ./StorefrontTransaction.yaml
     _links:
       type: array
       description: The links related to resource.


### PR DESCRIPTION
Setting up a payment instrument with a setup transaction through `PaymentInstrument.setupTransaction` field.
It looks more REST, but the payment instrument becomes more bulky.
Alternative to #619 