### PR TITLE
Add rule to warn about unused tags

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -25,6 +25,7 @@ lint:
     no-ambiguous-paths: error
     custom-rules/description-punctuation: error
     custom-rules/has-sdk-operation-name: error
+    custom-rules/no-unused-tags: warn
 referenceDocs:
   pagination: section
   theme:

--- a/openapi/combined.yaml
+++ b/openapi/combined.yaml
@@ -21,11 +21,6 @@ servers:
   - url: 'https://api.rebilly.com'
     description: Live Server.
 tags:
-  - name: 3D Secure
-    description: |
-      3D Secure is a way to authenticate and protect transactions.  Typically,
-      it's only possible to protect the initial transaction in an order
-      with 3D Secure.
   - name: Blocklists
     description: |
       Your blocklists contains values of customerIds, email addresses,
@@ -150,10 +145,6 @@ tags:
       optionally at the appropriate scheduled intervals.
       A subscription order may also determine if the payment
       is collected automatically (with autopay set true).
-  - name: Taxes
-    description: |
-      You can map a product to a tax category.  The tax category is used by
-      tax providers to calculate taxes for invoices.
   - name: Transactions
     description: |
       Get and refund transactions.
@@ -186,9 +177,6 @@ tags:
   - name: Data Exports
     description: |
       Data exports.
-  - name: Activity Feed
-    description: |
-      Activity Feed is holding various events that occurred in the app.
   - name: Websites
   - name: Webhooks
   - name: Status
@@ -211,6 +199,7 @@ tags:
   - name: Billing Portals
   - name: Checkout Forms
   - name: API Keys
+  - name: Plaid credentials
   - name: Experian credentials
   - name: TaxJar credentials
   - name: Metadata

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -133,7 +133,7 @@ tags:
       A product determines how what you sell appears on invoices and receipts.
       The pricing for products is set in Plans.  One product can have many
       plans.
-  - name: Reports
+  - name: Reports API
     description: >
       The Rebilly Reporting API is currently experimental. You may see
 
@@ -155,14 +155,10 @@ tags:
   - name: Tags
     description: |
       Tag customers to better organize your data.
-  - name: Taxes
-    description: |
-      You can map a product to a tax category.  The tax category is used by
-      tax providers to calculate taxes for invoices.
   - name: Transactions
     description: |
       Get and refund transactions.
-  - name: Users
+  - name: Users API
     description: >
       The Rebilly User API is primarily for our GUI apps.  You may see
 

--- a/openapi/paths/payment-cards-bank-names.yaml
+++ b/openapi/paths/payment-cards-bank-names.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - Payment Cards
+    - Payment Instruments
   summary: Retrieve a list of payment card issuing bank names
   operationId: GetPaymentCardBankNameCollection
   x-sdk-operation-name: getAll

--- a/openapi/reports.yaml
+++ b/openapi/reports.yaml
@@ -20,6 +20,7 @@ info:
     feedback.
 
     # Authentication
+
     When you sign up for an account, you are given your first API key.
     You can generate additional API keys, and delete API keys (as you may
     need to rotate your keys in the future). You authenticate to the

--- a/openapi/reports.yaml
+++ b/openapi/reports.yaml
@@ -19,6 +19,21 @@ info:
     This API is experimental and likely to change.  We would appreciate
     feedback.
 
+    # Authentication
+    When you sign up for an account, you are given your first API key.
+    You can generate additional API keys, and delete API keys (as you may
+    need to rotate your keys in the future). You authenticate to the
+    Rebilly API by providing your secret key in the request header.
+
+    Rebilly offers three forms of authentication:  secret key, publishable key, JSON Web Tokens, and public signature key.
+    - [Secret API key](#section/Authentication/SecretApiKey): used for requests made from the server side. Never share these keys. Keep them guarded and secure
+    - [Publishable API key](#section/Authentication/PublishableApiKey): used for requests from the client side.
+    - [JWT](#section/Authentication/JWT): short lifetime tokens that can be assigned a specific expiration time
+
+    Never share your secret keys. Keep them guarded and secure.
+
+    <!-- ReDoc-Inject: <security-definitions> -->
+
     ## Javascript SDK
 
     The [Javascript SDK](https://github.com/Rebilly/rebilly-js-sdk) is maintained
@@ -26,32 +41,6 @@ info:
     SDK code examples are included in these docs.
 
 tags:
-  - name: Authentication
-    description: |
-      When you sign up for an account, you are given your first API key.
-      You can generate additional API keys, and delete API keys (as you may
-      need to rotate your keys in the future). You authenticate to the
-      Rebilly API by providing your secret key in the request header.
-
-      Rebilly offers three forms of authentication:  private key, JSON Web
-      Tokens, and public key.
-      - private key: authenticates each request by searching for the presence
-      of an HTTP header: REB-APIKEY.
-      - JWT: authenticates each request by the HTTP header: Authorization.
-      - public key: authenticates by the HTTP header: REB-AUTH (read more on
-      this below).
-
-      Rebilly also offers JSON Web Tokens (JWT) authentication, where you can
-      control the specific granular permissions and expiration for that JWT.  We call
-      our resource for generating JWT [Sessions](#tag/Sessions).
-
-      Rebilly also has a client-side authentication scheme that uses an
-      apiUser and HMAC-SHA1 signature (only for the Tokens resource), so
-      that you may safely create tokens from the client-side without
-      compromising your secret keys.
-
-      Never share your secret keys. Keep them guarded and secure.
-      The client-side authentication scheme uses one HTTP header named REB-AUTH.
   - name: Histograms
     description: |
       Histograms are for particular kinds of reports with cohorts and periods.
@@ -62,9 +51,6 @@ tags:
   - name: Data Exports
     description: |
       Data exports.
-  - name: Activity Feed
-    description: |
-      Activity Feed is holding various events that occurred in the app.
   - name: Orders
   - name: Customers
 security:

--- a/openapi/storefront.yaml
+++ b/openapi/storefront.yaml
@@ -25,7 +25,6 @@ info:
     accepts and returns JSON in the HTTP body. You can use your favorite
     HTTP/REST library for your programming language to use Rebilly's Storefront API.
 tags:
-  - name: Account management
   - name: Account
   - name: Authentication
   - name: Billing Portals
@@ -33,7 +32,6 @@ tags:
   - name: Email verification
   - name: Password reset
   - name: KYC Document
-  - name: Payments
   - name: Payment Instrument
   - name: Purchase
   - name: Transaction
@@ -41,7 +39,6 @@ tags:
   - name: Invoice
   - name: Product
   - name: Plan
-  - name: System
   - name: Website
 x-tagGroups:
   - name: Account management

--- a/openapi/users.yaml
+++ b/openapi/users.yaml
@@ -113,9 +113,6 @@ tags:
 
       You may grant permissions to edit Lists to different people than those who can edit Rules.
       It may be useful if your workflow involves frequent updates to value sets used in criteria.
-  - name: Payment Cards
-    description: |
-      Payment cards are a type of payment instrument used for credit and debit card sales.
   - name: Organizations
     description: |
       Organization is an entity that represents you, or your company, as a merchant. You can have multiple organizations.
@@ -203,10 +200,12 @@ tags:
       Roles are an implementation of the general hierarchical RBAC. A senior role inherits all of it's juniors' ACLs plus its own ACL.
       Junior roles are not influenced by the senior role.
   - name: Integrations
+  - name: Payment Instruments
   - name: Broadcast Messages
   - name: Email Delivery Settings
   - name: Email Messages
   - name: Email Notifications
+  - name: Plaid credentials
   - name: Experian credentials
   - name: TaxJar credentials
   - name: Metadata

--- a/plugins/custom-rules.js
+++ b/plugins/custom-rules.js
@@ -1,5 +1,6 @@
 const DescriptionPunctuation = require('./rules/description-punctuation');
 const HasSDKOperationName = require('./rules/has-sdk-operation-name');
+const NoUnusedTags = require('./rules/no-unused-tags');
 const id = 'custom-rules';
 
 /** @type {import('@redocly/openapi-cli').CustomRulesConfig} */
@@ -7,6 +8,7 @@ const rules = {
     oas3: {
         'description-punctuation': DescriptionPunctuation,
         'has-sdk-operation-name': HasSDKOperationName,
+        'no-unused-tags': NoUnusedTags,
     },
 };
 

--- a/plugins/rules/no-unused-tags.js
+++ b/plugins/rules/no-unused-tags.js
@@ -1,0 +1,50 @@
+module.exports = NoUnusedTag
+
+const ignoredTags = ['Rebilly API', 'Users API', 'Reports API'];
+
+function validate() {
+  return (definitionRoot, {report, location, resolve}) => {
+    const tags = {};
+    definitionRoot.tags.forEach((tagDefinition) => {
+      tags[tagDefinition.name] = 0;
+    })
+
+    const availableMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+    for (const [path, pathRef] of Object.entries(definitionRoot.paths)) {
+      const pathDefinition = resolve(pathRef).node;
+      availableMethods.forEach((method) => {
+        if (!(method in pathDefinition)) {
+          return;
+        }
+
+        const operation = pathDefinition[method];
+        if (!('tags' in operation)) {
+          return;
+        }
+
+        operation.tags.forEach((tagName) => {
+          if (!(tagName in tags) && ignoredTags.indexOf(tagName) === -1) {
+            report({message: `Tag "${tagName}" is used in ${path}, but not declared`});
+
+            return;
+          }
+          tags[tagName]++;
+        });
+      })
+    }
+
+    for (const [tagName, usagesCount] of Object.entries(tags)) {
+      if (usagesCount > 0 || ignoredTags.indexOf(tagName) !== -1) {
+        continue;
+      }
+      report({message: `Tag "${tagName}" declared, but never used`});
+    }
+  };
+}
+
+/** @type {import('@redocly/openapi-cli').OasRule} */
+function NoUnusedTag() {
+  return {
+    DefinitionRoot: validate(),
+  }
+}


### PR DESCRIPTION
This PR will add a rule to warn about unused tags from the `tags` section and about tags in operations, that are not declared in `tags` section. (tags on screenshot are just examples)

![image](https://user-images.githubusercontent.com/4003786/136957504-9d614092-f91f-4e09-9aff-7edd0ed871f0.png)

Definition adjusted according to the rule warnings.

The rule is of `warn` level and won't block merging.