### PR TITLE
Use tags names as in rest of APIs

### DIFF
--- a/openapi/paths/storefront/invoices.yaml
+++ b/openapi/paths/storefront/invoices.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Invoice
+    - Invoices
   summary: Retrieve a list of invoices
   operationId: StorefrontGetInvoiceCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/invoices@{id}.yaml
+++ b/openapi/paths/storefront/invoices@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Invoice
+    - Invoices
   summary: Retrieve a Invoice
   operationId: StorefrontGetInvoice
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - KYC Document
+    - KYC Documents
   summary: Retrieve a list of KYC documents
   operationId: StorefrontGetKycDocumentCollection
   x-sdk-operation-name: getAll
@@ -35,7 +35,7 @@ get:
       $ref: ../../components/responses/Forbidden.yaml
 post:
   tags:
-    - KYC Document
+    - KYC Documents
   summary: Create a KYC Document
   operationId: StorefrontPostKycDocument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/kyc-documents@{id}.yaml
+++ b/openapi/paths/storefront/kyc-documents@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - KYC Document
+    - KYC Documents
   summary: Retrieve a KYC Document
   operationId: StorefrontGetKycDocument
   x-sdk-operation-name: get
@@ -26,7 +26,7 @@ get:
       $ref: ../../components/responses/NotFound.yaml
 patch:
   tags:
-    - KYC Document
+    - KYC Documents
   summary: Update a KYC document
   operationId: StorefrontPatchKycDocument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/kyc-requests@{id}.yaml
+++ b/openapi/paths/storefront/kyc-requests@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - KYC Document
+    - KYC Documents
   summary: Retrieve a KYC request
   operationId: StorefrontGetKycRequest
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/orders.yaml
+++ b/openapi/paths/storefront/orders.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Order
+    - Orders
   summary: Retrieve a list of orders
   operationId: StorefrontGetOrderCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/orders@{id}.yaml
+++ b/openapi/paths/storefront/orders@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Order
+    - Orders
   summary: Retrieve an order
   operationId: StorefrontGetOrder
   x-sdk-operation-name: get
@@ -26,7 +26,7 @@ get:
       $ref: ../../components/responses/NotFound.yaml
 patch:
   tags:
-    - Order
+    - Orders
   summary: Update an order
   operationId: StorefrontPatchOrder
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/orders@{id}@cancellation.yaml
+++ b/openapi/paths/storefront/orders@{id}@cancellation.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 post:
   tags:
-    - Order
+    - Orders
   summary: Cancel an order
   operationId: StorefrontPostOrderCancellation
   x-sdk-operation-name: cancel

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Payment Instrument
+    - Payment Instruments
   summary: Retrieve a list of Payment Instruments
   operationId: StorefrontGetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
@@ -15,7 +15,7 @@ get:
     - $ref: ../../components/parameters/collectionSort.yaml
     - $ref: ../../components/parameters/collectionLimit.yaml
     - $ref: ../../components/parameters/collectionOffset.yaml
-    - $ref: ../../components/parameters/collectionQuery.yaml 
+    - $ref: ../../components/parameters/collectionQuery.yaml
   responses:
     200:
       description: A list of payment instrument was retrieved successfully.
@@ -38,7 +38,7 @@ get:
       $ref: ../../components/responses/Forbidden.yaml
 post:
   tags:
-    - Payment Instrument
+    - Payment Instruments
   summary: Create a Payment Instrument
   operationId: StorefrontPostPaymentInstrument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/payment-instruments@{id}.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Payment Instrument
+    - Payment Instruments
   summary: Retrieve a Payment Instrument
   operationId: StorefrontGetPaymentInstrument
   x-sdk-operation-name: get
@@ -36,7 +36,7 @@ get:
       $ref: ../../components/responses/NotFound.yaml
 patch:
   tags:
-    - Payment Instrument
+    - Payment Instruments
   summary: Update a Payment Instrument's values
   operationId: StorefrontPatchPaymentInstrument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 post:
   tags:
-    - Payment Instrument
+    - Payment Instruments
   summary: Deactivate a Payment Instrument
   operationId: StorefrontPostPaymentInstrumentDeactivation
   x-sdk-operation-name: deactivate

--- a/openapi/paths/storefront/payment.yaml
+++ b/openapi/paths/storefront/payment.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 post:
   tags:
-    - Purchase
+    - Purchases
   summary: Perform a payment
   operationId: StorefrontPostPayment
   x-sdk-operation-name: payment

--- a/openapi/paths/storefront/plans.yaml
+++ b/openapi/paths/storefront/plans.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Plan
+    - Plans
   summary: Retrieve a list of plans
   operationId: StorefrontGetPlanCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/plans@{id}.yaml
+++ b/openapi/paths/storefront/plans@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Plan
+    - Plans
   summary: Retrieve a plan
   operationId: StorefrontGetPlan
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/preview-purchase.yaml
+++ b/openapi/paths/storefront/preview-purchase.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 post:
   tags:
-    - Purchase
+    - Purchases
   summary: Preview a purchase
   operationId: StorefrontPostPreviewPurchase
   x-sdk-operation-name: preview

--- a/openapi/paths/storefront/products.yaml
+++ b/openapi/paths/storefront/products.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Product
+    - Products
   summary: Retrieve a list of products
   operationId: StorefrontGetProductCollection
   x-sdk-operation-name: getAll
@@ -13,7 +13,7 @@ get:
     - $ref: ../../components/parameters/collectionSort.yaml
     - $ref: ../../components/parameters/collectionLimit.yaml
     - $ref: ../../components/parameters/collectionOffset.yaml
-    - $ref: ../../components/parameters/collectionQuery.yaml 
+    - $ref: ../../components/parameters/collectionQuery.yaml
   responses:
     200:
       description: A list of products was retrieved successfully.

--- a/openapi/paths/storefront/products@{id}.yaml
+++ b/openapi/paths/storefront/products@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Product
+    - Products
   summary: Retrieve a product
   operationId: StorefrontGetProduct
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/purchase.yaml
+++ b/openapi/paths/storefront/purchase.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 post:
   tags:
-    - Purchase
+    - Purchases
   summary: Make a purchase
   operationId: StorefrontPostPurchase
   x-sdk-operation-name: purchase

--- a/openapi/paths/storefront/ready-to-pay.yaml
+++ b/openapi/paths/storefront/ready-to-pay.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 post:
   tags:
-    - Purchase
+    - Purchases
   summary: Ready to Pay
   operationId: StorefrontPostReadyToPay
   x-sdk-operation-name: readyToPay

--- a/openapi/paths/storefront/transactions.yaml
+++ b/openapi/paths/storefront/transactions.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/organizationId.yaml
 get:
   tags:
-    - Transaction
+    - Transactions
   summary: Retrieve a list of transactions
   operationId: StorefrontGetTransactionCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/transactions@{id}.yaml
+++ b/openapi/paths/storefront/transactions@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Transaction
+    - Transactions
   summary: Retrieve a Transaction
   operationId: StorefrontGetTransaction
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/websites@{id}.yaml
+++ b/openapi/paths/storefront/websites@{id}.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   tags:
-    - Website
+    - Websites
   summary: Retrieve a website
   operationId: StorefrontGetWebsite
   x-sdk-operation-name: get

--- a/openapi/storefront.yaml
+++ b/openapi/storefront.yaml
@@ -31,15 +31,15 @@ tags:
   - name: Checkout Forms
   - name: Email verification
   - name: Password reset
-  - name: KYC Document
-  - name: Payment Instrument
-  - name: Purchase
-  - name: Transaction
-  - name: Order
-  - name: Invoice
-  - name: Product
-  - name: Plan
-  - name: Website
+  - name: KYC Documents
+  - name: Payment Instruments
+  - name: Purchases
+  - name: Transactions
+  - name: Orders
+  - name: Invoices
+  - name: Products
+  - name: Plans
+  - name: Websites
 x-tagGroups:
   - name: Account management
     tags:
@@ -48,22 +48,22 @@ x-tagGroups:
       - Billing Portals
       - Email verification
       - Password reset
-      - KYC Document
+      - KYC Documents
   - name: Payments
     tags:
-      - Payment Instrument
-      - Transaction
+      - Payment Instruments
+      - Transactionss
   - name: Orders
     tags:
       - Checkout Forms
-      - Purchase
-      - Order
-      - Invoice
-      - Product
-      - Plan
+      - Purchases
+      - Orders
+      - Invoices
+      - Products
+      - Plans
   - name: System
     tags:
-      - Website
+      - Websites
 servers:
   - url: 'https://api-sandbox.rebilly.com/storefront'
     description: Sandbox Server.


### PR DESCRIPTION
This PR will change tags names in the `storefront` bundle to make them similar to `users` and `core` bundles (see [example](https://github.com/Rebilly/api-definitions/blob/9ab0d123794ea4037a8916470b939c645917f34f/openapi/core.yaml#L197-L200))