### PR TITLE
Fix coupon restrictions description on minimumQuantity

### DIFF
--- a/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-plans.yaml
+++ b/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-plans.yaml
@@ -14,4 +14,4 @@ allOf:
       minimumQuantity:
         type: integer
         default: 1
-        description: Minimum quantity per item on which to apply the restriction and subsequent discount.
+        description: Minimum total quantity on which to apply the restriction and subsequent discount.

--- a/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-products.yaml
+++ b/openapi/components/schemas/Coupon/CouponRestrictions/restrict-to-products.yaml
@@ -14,4 +14,4 @@ allOf:
       minimumQuantity:
         type: integer
         default: 1
-        description: Minimum quantity per item on which to apply the restriction and subsequent discount.
+        description: Minimum total quantity on which to apply the restriction and subsequent discount.


### PR DESCRIPTION
Fix description on `minimumQuantity` parameter for `restrict-to-plans` and `restrict-to-products` Coupon restrictions. See #615 