### PR TITLE
Add custom description part to product bundles

### DIFF
--- a/openapi/description.md
+++ b/openapi/description.md
@@ -1,4 +1,5 @@
 # Introduction
+[comment]: <> (x-product-description-placeholder)
 The Rebilly API is built on HTTP. Our API is RESTful. It has predictable
 resource URLs. It returns HTTP response codes to indicate errors. It also
 accepts and returns JSON in the HTTP body. You can use your favorite

--- a/plugins/products-bundler/bundler.js
+++ b/plugins/products-bundler/bundler.js
@@ -34,7 +34,7 @@ const decorators = {
             });
 
             // Override original definitions with the requested product settings
-            definitionRoot['info'] = getNewInfo(definitionRoot['info'], productMapping);
+            definitionRoot['info'] = getNewInfo(definitionRoot['info'], productMapping, ctx.resolve);
             definitionRoot['tags'] = getNewTags(definitionRoot, tagsNamesToInclude);
             definitionRoot['x-tagGroups'] = productMapping['x-tagGroups'];
             definitionRoot['paths'] = getNewPaths(definitionRoot['paths'], ctx, tagsNamesToInclude, availableMethods);
@@ -95,12 +95,18 @@ function getNewPaths(paths, ctx, tagsNamesToInclude, availableMethods) {
   return newPaths;
 }
 
-function getNewInfo(info, productMapping) {
+function getNewInfo(info, productMapping, resolve) {
   if ('info' in productMapping) {
     for (const [property, value] of Object.entries(productMapping.info)) {
       info[property] = value;
     }
   }
+
+  const productDescriptionAddon = 'descriptionAddon' in productMapping ? productMapping['descriptionAddon'] : '';
+  info.description = resolve(info.description).node.replace(
+    '[comment]: <> (x-product-description-placeholder)',
+    productDescriptionAddon
+  );
 
   return info;
 }

--- a/plugins/products-bundler/mapping/Billing.yaml
+++ b/plugins/products-bundler/mapping/Billing.yaml
@@ -1,5 +1,8 @@
 info:
   title: "Billing API"
+descriptionAddon: |
+  This API reference describes operations that are available for the Billing.
+  For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Products & pricing plans
     tags:

--- a/plugins/products-bundler/mapping/Billing.yaml
+++ b/plugins/products-bundler/mapping/Billing.yaml
@@ -1,7 +1,7 @@
 info:
   title: "Billing API"
 descriptionAddon: |
-  This API reference describes operations that are available for the Billing.
+  This API reference describes operations that are available for the Billing integration.
   For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Products & pricing plans

--- a/plugins/products-bundler/mapping/Payments.yaml
+++ b/plugins/products-bundler/mapping/Payments.yaml
@@ -1,7 +1,7 @@
 info:
   title: "Payments API"
 descriptionAddon: |
-  This API reference describes operations that are available for the Payments.
+  This API reference describes operations that are available for the Payments integration.
   For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Customers

--- a/plugins/products-bundler/mapping/Payments.yaml
+++ b/plugins/products-bundler/mapping/Payments.yaml
@@ -1,5 +1,8 @@
 info:
   title: "Payments API"
+descriptionAddon: |
+  This API reference describes operations that are available for the Payments.
+  For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Customers
     tags:

--- a/plugins/products-bundler/mapping/RiskManagement.yaml
+++ b/plugins/products-bundler/mapping/RiskManagement.yaml
@@ -1,5 +1,8 @@
 info:
   title: "Risk Management API"
+descriptionAddon: |
+  This API reference describes operations that are available for the Risk Management.
+  For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Customers
     tags:

--- a/plugins/products-bundler/mapping/RiskManagement.yaml
+++ b/plugins/products-bundler/mapping/RiskManagement.yaml
@@ -1,7 +1,7 @@
 info:
   title: "Risk Management API"
 descriptionAddon: |
-  This API reference describes operations that are available for the Risk Management.
+  This API reference describes operations that are available for the Risk Management integration.
   For the complete Rebilly REST API reference, see [https://api-reference.rebilly.com/](https://api-reference.rebilly.com/).
 x-tagGroups:
   - name: Customers


### PR DESCRIPTION
The description section is a big file and it is better to use some placeholder to insert per-product description rather than copy entire file
![image](https://user-images.githubusercontent.com/4003786/137962859-c456f1e2-d325-456b-b90c-76aa5d8ffe14.png)
