### PR TITLE
feat: trigger rebilly-js-sdk update when main updated

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yaml
+++ b/.github/workflows/trigger-downstream-updates.yaml
@@ -1,4 +1,4 @@
-name: Trigger Recomm update
+name: Trigger downstream updates
 
 on:
   push:

--- a/.github/workflows/trigger-recomm-update.yaml
+++ b/.github/workflows/trigger-recomm-update.yaml
@@ -6,20 +6,13 @@ on:
       - main
 
 jobs:
-  trigger-recomm-update:
-    name: Trigger Recomm update
+  generate-trigger-reason:
+    name: Generate the trigger reason
     runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      reason: ${{ steps.reason.outputs.value }}
     steps:
-
-      - name: Wait for Redocly to publish combined bundle
-        uses: Sibz/await-status-action@v1.0.1
-        with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          # Which status checks to wait for. We only care about the combined bundle.
-          contexts: 'Redocly Registry (combined/combined) bundle'
-          # How long to wait for the Redocly status to be posted, in seconds 
-          timeout: 600
-          notPresentTimeout: 600
 
       # The commit message are multiline. Use a regex to split out
       # just the first line, and the PR number into regex groups.
@@ -38,6 +31,23 @@ jobs:
         id: reason
         run: echo '::set-output name=value::${{steps.parse-commit.outputs.group1}} Rebilly/api-definitions${{steps.parse-commit.outputs.group2}}'
 
+
+  trigger-recomm-update:
+    name: Trigger Recomm update
+    runs-on: ubuntu-latest
+    needs: generate-trigger-reason
+    steps:
+
+      - name: Wait for Redocly to publish combined bundle
+        uses: Sibz/await-status-action@v1.0.1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          # Which status checks to wait for. We only care about the combined bundle.
+          contexts: 'Redocly Registry (combined/combined) bundle'
+          # How long to wait for the Redocly status to be posted, in seconds
+          timeout: 600
+          notPresentTimeout: 600
+
       - name: Trigger update workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
@@ -45,4 +55,19 @@ jobs:
           ref: main
           repo: Rebilly/frontend-recomm
           token: ${{ secrets.MACHINE_USER_PAT }}
-          inputs: '{ "trigger-reason": "${{steps.reason.outputs.value}}" }'
+          inputs: '{ "trigger-reason": "${{needs.generate-trigger-reason.outputs.reason}}" }'
+
+  trigger-rebilly-js-sdk-update:
+    name: Trigger JS SDK update
+    runs-on: ubuntu-latest
+    needs: generate-trigger-reason
+    steps:
+
+      - name: Trigger update workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Updates SDK resources based on api-definitions
+          ref: main
+          repo: Rebilly/rebilly-js-sdk
+          token: ${{ secrets.MACHINE_USER_PAT }}
+          inputs: '{ "trigger-reason": "${{needs.generate-trigger-reason.outputs.reason}}" }'


### PR DESCRIPTION
This PR triggers the update workflow inside `Rebilly/rebilly-js-sdk` on new commits to main.

## Details

This is very similar to https://github.com/Rebilly/api-definitions/pull/593, however the SDK does not use the live redocly data and instead checks out the api definitions repository. This means we do not need to wait for redocly to be published before we can trigger the `rebilly-js-sdk` update workflow.

You can see the workflow this triggers here:
- PR: https://github.com/Rebilly/rebilly-js-sdk/pull/342
- PR produced: https://github.com/Rebilly/rebilly-js-sdk/pull/343

Changes:
- Split the reason generation steps into a separate job, so we can reuse the output
- Create a new job to trigger the update workflow inside rebilly-js-sdk
- Renamed file/workflow name to `trigger-downstream-updates`

## Testing

I tested the job dependencies and output variable changes here:
- [workflow file](https://github.com/Weetbix/actions-test-3/blob/main/.github/workflows/test-workflow.yaml)
- [workflow run](https://github.com/Weetbix/actions-test-3/runs/4044535382)

