### PR TITLE
Require a billing address for a payment card

### DIFF
--- a/openapi/components/schemas/PaymentTokens/PaymentCardToken.yaml
+++ b/openapi/components/schemas/PaymentTokens/PaymentCardToken.yaml
@@ -5,6 +5,7 @@ allOf:
 required:
   - method
   - paymentInstrument
+  - billingAddress
 properties:
   method:
     description: The token payment method.


### PR DESCRIPTION
This is already the current behaviour. Other payment methods also require it.