### PR TITLE
Fix ApiKey descriptions

### DIFF
--- a/openapi/paths/api-keys.yaml
+++ b/openapi/paths/api-keys.yaml
@@ -6,18 +6,18 @@ get:
     - Users
   tags:
     - API Keys
-  summary: Retrieve a list of api keys
+  summary: Retrieve a list of API keys
   operationId: GetApiKeyCollection
   x-sdk-operation-name: getAll
   description: |
-    Retrieve a list of api keys.
+    Retrieve a list of API keys.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionSort.yaml
   responses:
     '200':
-      description: A list of api keys was retrieved successfully.
+      description: A list of API keys was retrieved successfully.
       headers:
         Pagination-Total:
           $ref: ../components/headers/Pagination-Total.yaml
@@ -48,16 +48,16 @@ post:
     - Users
   tags:
     - API Keys
-  summary: Create an api key
+  summary: Create an API key
   operationId: PostApiKey
   x-sdk-operation-name: create
   description: |
-    Create an api key.
+    Create an API key.
   requestBody:
     $ref: ../components/requestBodies/ApiKey.yaml
   responses:
     '201':
-      description: Api Key was created.
+      description: API key was created.
       content:
         application/json:
           schema:

--- a/openapi/paths/api-keys@{id}.yaml
+++ b/openapi/paths/api-keys@{id}.yaml
@@ -7,14 +7,14 @@ get:
     - Users
   tags:
     - API Keys
-  summary: Retrieve api key
+  summary: Retrieve API key
   operationId: GetApiKey
   x-sdk-operation-name: get
   description: |
-    Retrieve api key with specified identifier string.
+    Retrieve API key with specified identifier string.
   responses:
     '200':
-      description: Api key was retrieved successfully.
+      description: API key was retrieved successfully.
       content:
         application/json:
           schema:
@@ -38,20 +38,20 @@ put:
     - Users
   tags:
     - API Keys
-  summary: Create or update api key with predefined ID
+  summary: Create or update API key with predefined ID
   operationId: PutApiKey
   x-sdk-operation-name: update
   description: |
-    Create or update api key with predefined identifier string.
+    Create or update API key with predefined identifier string.
   responses:
     '200':
-      description: ApiKey was updated.
+      description: API key was updated.
       content:
         application/json:
           schema:
             $ref: ../components/schemas/ApiKey.yaml
     '201':
-      description: ApiKey was created.
+      description: API key was created.
       content:
         application/json:
           schema:
@@ -79,14 +79,14 @@ delete:
     - Users
   tags:
     - API Keys
-  summary: Delete api key
+  summary: Delete API key
   operationId: DeleteApiKey
   x-sdk-operation-name: delete
   description: |
-    Delete api key with predefined identifier string.
+    Delete API key with predefined identifier string.
   responses:
     '204':
-      description: ApiKey was deleted.
+      description: API key was deleted.
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':


### PR DESCRIPTION
`textlint` terminology check is failing:

```
 Incorrect usage of the term: “api”, use “API” instead  terminology
```