### PR TITLE
Add copyCredentialsFrom Stripe Gateway Account setting

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Stripe.yaml
@@ -34,5 +34,8 @@ allOf:
             type: boolean
             description: If `true`, `off_session` param will always be `true` in Stripe requests.
             default: false
+          copyCredentialsFrom:
+            type: string
+            description: The ID of an existing Stripe gateway account from which credentials will be copied in order to skip the onboarding process.
       threeDSecureServer:
         $ref: ../ThreeDSecureServers/Stripe3dsServers/Stripe3dsServers.yaml


### PR DESCRIPTION
Adds a setting named `copyCredentialsFrom` to Stripe Gateway Accounts. This setting accepts the ID of an existing active Stripe gateway account. When provided while creating a new Stripe gateway account, the credentials from the gateway account provided will be copied to the new gateway account and the new gateway account will be marked as `active` in order to skip the onboarding process.