### PR TITLE
docs: poc remove deprecated servers and organization-id header from docs

### DIFF
--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -28,10 +28,6 @@ servers:
       organizationId:
         default: unknown
         description: Your organization ID.
-  - url: 'https://api-sandbox.rebilly.com'
-    description: Sandbox Server.
-  - url: 'https://api.rebilly.com'
-    description: Live Server.
 tags:
   - name: AML
     description: |

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -33,10 +33,6 @@ servers:
       organizationId:
         default: unknown
         description: Your organization ID.
-  - url: 'https://api-sandbox.rebilly.com'
-    description: Sandbox Server.
-  - url: 'https://api.rebilly.com'
-    description: Live Server.
 
 components:
   securitySchemes:

--- a/openapi/paths/aml.yaml
+++ b/openapi/paths/aml.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full
@@ -14,8 +13,7 @@ get:
     Search multiple PEP/Sanctions/Adverse Media lists with first and last name to find any blocklisted identities.
     Performs a fuzzy search including soundex. Not all fields are guaranteed to be filled.
   parameters:
-    - $ref: ../components/parameters/organizationId.yaml
-    - name: firstName
+      - name: firstName
       in: query
       required: true
       description: First name of individual to search.

--- a/openapi/paths/api-keys.yaml
+++ b/openapi/paths/api-keys.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/api-keys@{id}.yaml
+++ b/openapi/paths/api-keys@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/application-instances@{applicationId}.yaml
+++ b/openapi/paths/application-instances@{applicationId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/applicationId.yaml
 get:
   x-products:

--- a/openapi/paths/applications.yaml
+++ b/openapi/paths/applications.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Users

--- a/openapi/paths/applications@{id}.yaml
+++ b/openapi/paths/applications@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/applications@{id}@instances.yaml
+++ b/openapi/paths/applications@{id}@instances.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/applications@{id}@instances@{organizationId}.yaml
+++ b/openapi/paths/applications@{id}@instances@{organizationId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
   - $ref: ../components/parameters/organizationIdPathParam.yaml
 get:

--- a/openapi/paths/attachments.yaml
+++ b/openapi/paths/attachments.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/attachments@{id}.yaml
+++ b/openapi/paths/attachments@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/authentication-options.yaml
+++ b/openapi/paths/authentication-options.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/authentication-tokens.yaml
+++ b/openapi/paths/authentication-tokens.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/authentication-tokens@{token}.yaml
+++ b/openapi/paths/authentication-tokens@{token}.yaml
@@ -5,7 +5,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/authentication-tokens@{token}@exchange.yaml
+++ b/openapi/paths/authentication-tokens@{token}@exchange.yaml
@@ -5,7 +5,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/balance-transactions.yaml
+++ b/openapi/paths/balance-transactions.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/balance-transactions@{id}.yaml
+++ b/openapi/paths/balance-transactions@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/billing-portals.yaml
+++ b/openapi/paths/billing-portals.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/billing-portals@{id}.yaml
+++ b/openapi/paths/billing-portals@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/blocklists.yaml
+++ b/openapi/paths/blocklists.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/blocklists@{id}.yaml
+++ b/openapi/paths/blocklists@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/broadcast-messages.yaml
+++ b/openapi/paths/broadcast-messages.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/broadcast-messages@{id}.yaml
+++ b/openapi/paths/broadcast-messages@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/checkout-forms.yaml
+++ b/openapi/paths/checkout-forms.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/checkout-forms@{id}.yaml
+++ b/openapi/paths/checkout-forms@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/coupons-redemptions.yaml
+++ b/openapi/paths/coupons-redemptions.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/coupons-redemptions@{id}.yaml
+++ b/openapi/paths/coupons-redemptions@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/coupons-redemptions@{id}@cancel.yaml
+++ b/openapi/paths/coupons-redemptions@{id}@cancel.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/coupons.yaml
+++ b/openapi/paths/coupons.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/coupons@{id}.yaml
+++ b/openapi/paths/coupons@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/coupons@{id}@expiration.yaml
+++ b/openapi/paths/coupons@{id}@expiration.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@aws-ses.yaml
+++ b/openapi/paths/credential-hashes@aws-ses.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@aws-ses@{hash}.yaml
+++ b/openapi/paths/credential-hashes@aws-ses@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@emails.yaml
+++ b/openapi/paths/credential-hashes@emails.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@emails@{hash}.yaml
+++ b/openapi/paths/credential-hashes@emails@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@experian.yaml
+++ b/openapi/paths/credential-hashes@experian.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@experian@{hash}.yaml
+++ b/openapi/paths/credential-hashes@experian@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@mailgun.yaml
+++ b/openapi/paths/credential-hashes@mailgun.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@mailgun@{hash}.yaml
+++ b/openapi/paths/credential-hashes@mailgun@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@oauth2.yaml
+++ b/openapi/paths/credential-hashes@oauth2.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@oauth2@{hash}.yaml
+++ b/openapi/paths/credential-hashes@oauth2@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@oauth2@{hash}@items.yaml
+++ b/openapi/paths/credential-hashes@oauth2@{hash}@items.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@plaid.yaml
+++ b/openapi/paths/credential-hashes@plaid.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Users

--- a/openapi/paths/credential-hashes@plaid@{hash}.yaml
+++ b/openapi/paths/credential-hashes@plaid@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@postmark.yaml
+++ b/openapi/paths/credential-hashes@postmark.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@postmark@{hash}.yaml
+++ b/openapi/paths/credential-hashes@postmark@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@sendgrid.yaml
+++ b/openapi/paths/credential-hashes@sendgrid.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@sendgrid@{hash}.yaml
+++ b/openapi/paths/credential-hashes@sendgrid@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@taxjar.yaml
+++ b/openapi/paths/credential-hashes@taxjar.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@taxjar@{hash}.yaml
+++ b/openapi/paths/credential-hashes@taxjar@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credential-hashes@webhooks.yaml
+++ b/openapi/paths/credential-hashes@webhooks.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/credential-hashes@webhooks@{hash}.yaml
+++ b/openapi/paths/credential-hashes@webhooks@{hash}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/hash.yaml
 get:
   x-products:

--- a/openapi/paths/credentials.yaml
+++ b/openapi/paths/credentials.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/credentials@{id}.yaml
+++ b/openapi/paths/credentials@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/custom-domains.yaml
+++ b/openapi/paths/custom-domains.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Users

--- a/openapi/paths/custom-domains@{domain}.yaml
+++ b/openapi/paths/custom-domains@{domain}.yaml
@@ -7,7 +7,6 @@ parameters:
       type: string
       maxLength: 255
       pattern: '^[@~\-\.\w]+$'
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Users

--- a/openapi/paths/custom-fields@{resource}.yaml
+++ b/openapi/paths/custom-fields@{resource}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/customFieldResource.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/custom-fields@{resource}@{name}.yaml
+++ b/openapi/paths/custom-fields@{resource}@{name}.yaml
@@ -8,7 +8,6 @@ parameters:
       type: string
       maxLength: 60
       pattern: '^[\w-]+$'
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customer-timeline-custom-events.yaml
+++ b/openapi/paths/customer-timeline-custom-events.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/customer-timeline-custom-events@{id}.yaml
+++ b/openapi/paths/customer-timeline-custom-events@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customer-timeline-events.yaml
+++ b/openapi/paths/customer-timeline-events.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/customers.yaml
+++ b/openapi/paths/customers.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{customerId}@summary-metrics.yaml
+++ b/openapi/paths/customers@{customerId}@summary-metrics.yaml
@@ -20,7 +20,6 @@ parameters:
     description: Customer's ID.
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{id}.yaml
+++ b/openapi/paths/customers@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{id}@lead-source.yaml
+++ b/openapi/paths/customers@{id}@lead-source.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{id}@timeline.yaml
+++ b/openapi/paths/customers@{id}@timeline.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/customers@{id}@timeline@{messageId}.yaml
@@ -6,7 +6,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/customers@{id}@upcoming-invoices.yaml
+++ b/openapi/paths/customers@{id}@upcoming-invoices.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/data-exports.yaml
+++ b/openapi/paths/data-exports.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/data-exports@{id}.yaml
+++ b/openapi/paths/data-exports@{id}.yaml
@@ -15,7 +15,6 @@ servers:
   - url: 'https://api-sandbox.rebilly.com/experimental'
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/disputes.yaml
+++ b/openapi/paths/disputes.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/disputes@{id}.yaml
+++ b/openapi/paths/disputes@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/email-delivery-setting-verifications@{token}.yaml
+++ b/openapi/paths/email-delivery-setting-verifications@{token}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/token.yaml
 put:
   x-products:

--- a/openapi/paths/email-delivery-settings.yaml
+++ b/openapi/paths/email-delivery-settings.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/email-delivery-settings@{id}.yaml
+++ b/openapi/paths/email-delivery-settings@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
+++ b/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/email-messages.yaml
+++ b/openapi/paths/email-messages.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/email-messages@{id}.yaml
+++ b/openapi/paths/email-messages@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/email-notifications.yaml
+++ b/openapi/paths/email-notifications.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/events.yaml
+++ b/openapi/paths/events.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/events@{eventType}.yaml
+++ b/openapi/paths/events@{eventType}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
 get:
   x-products:

--- a/openapi/paths/events@{eventType}@rules.yaml
+++ b/openapi/paths/events@{eventType}@rules.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
 get:
   x-products:

--- a/openapi/paths/events@{eventType}@rules@drafts.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
 get:
   x-products:

--- a/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
   - $ref: ../components/parameters/resourceId.yaml
 get:

--- a/openapi/paths/events@{eventType}@rules@history.yaml
+++ b/openapi/paths/events@{eventType}@rules@history.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
 get:
   x-products:

--- a/openapi/paths/events@{eventType}@rules@history@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@history@{version}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
   - $ref: ../components/parameters/rulesVersion.yaml
 get:

--- a/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
   - $ref: ../components/parameters/rulesVersion.yaml
 get:

--- a/openapi/paths/events@{eventType}@timeline.yaml
+++ b/openapi/paths/events@{eventType}@timeline.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
 get:
   x-products:

--- a/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
+++ b/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/systemEventType.yaml
   - name: messageId
     in: path

--- a/openapi/paths/fees/fees.yaml
+++ b/openapi/paths/fees/fees.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/files.yaml
+++ b/openapi/paths/files.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/files@{id}.yaml
+++ b/openapi/paths/files@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/files@{id}@download.yaml
+++ b/openapi/paths/files@{id}@download.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
   - $ref: ../components/parameters/imageSize.yaml
 get:
   x-products:

--- a/openapi/paths/files@{id}@download{extension}.yaml
+++ b/openapi/paths/files@{id}@download{extension}.yaml
@@ -10,7 +10,6 @@ parameters:
         - .png
         - .jpg
         - .gif
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/gateway-accounts.yaml
+++ b/openapi/paths/gateway-accounts.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/gateway-accounts@{id}.yaml
+++ b/openapi/paths/gateway-accounts@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@check-credentials.yaml
+++ b/openapi/paths/gateway-accounts@{id}@check-credentials.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@close.yaml
+++ b/openapi/paths/gateway-accounts@{id}@close.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@disable.yaml
+++ b/openapi/paths/gateway-accounts@{id}@disable.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@downtime-schedules.yaml
+++ b/openapi/paths/gateway-accounts@{id}@downtime-schedules.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@downtime-schedules@{downtimeId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@downtime-schedules@{downtimeId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
   - name: downtimeId
     in: path

--- a/openapi/paths/gateway-accounts@{id}@enable.yaml
+++ b/openapi/paths/gateway-accounts@{id}@enable.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
+++ b/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@limits.yaml
+++ b/openapi/paths/gateway-accounts@{id}@limits.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@limits@{limitId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@limits@{limitId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
   - name: limitId
     in: path

--- a/openapi/paths/gateway-accounts@{id}@timeline.yaml
+++ b/openapi/paths/gateway-accounts@{id}@timeline.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/gateway-accounts@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@timeline@{messageId}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
   - name: messageId
     in: path

--- a/openapi/paths/grid-segments.yaml
+++ b/openapi/paths/grid-segments.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/grid-segments@{id}.yaml
+++ b/openapi/paths/grid-segments@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/histograms@transactions.yaml
+++ b/openapi/paths/histograms@transactions.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/integrations.yaml
+++ b/openapi/paths/integrations.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/integrations@{label}.yaml
+++ b/openapi/paths/integrations@{label}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/integrationLabel.yaml
 get:
   x-products:

--- a/openapi/paths/invoices.yaml
+++ b/openapi/paths/invoices.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}.yaml
+++ b/openapi/paths/invoices@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@abandon.yaml
+++ b/openapi/paths/invoices@{id}@abandon.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@issue.yaml
+++ b/openapi/paths/invoices@{id}@issue.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@items.yaml
+++ b/openapi/paths/invoices@{id}@items.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@items@{itemId}.yaml
+++ b/openapi/paths/invoices@{id}@items@{itemId}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
   - name: itemId
     in: path
     description: The invoice item ID.

--- a/openapi/paths/invoices@{id}@recalculate.yaml
+++ b/openapi/paths/invoices@{id}@recalculate.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@reissue.yaml
+++ b/openapi/paths/invoices@{id}@reissue.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@timeline.yaml
+++ b/openapi/paths/invoices@{id}@timeline.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/invoices@{id}@timeline@{messageId}.yaml
@@ -6,7 +6,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@transaction-allocations.yaml
+++ b/openapi/paths/invoices@{id}@transaction-allocations.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@transaction.yaml
+++ b/openapi/paths/invoices@{id}@transaction.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/invoices@{id}@void.yaml
+++ b/openapi/paths/invoices@{id}@void.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents.yaml
+++ b/openapi/paths/kyc-documents.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}.yaml
+++ b/openapi/paths/kyc-documents@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@acceptance.yaml
+++ b/openapi/paths/kyc-documents@{id}@acceptance.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@matches.yaml
+++ b/openapi/paths/kyc-documents@{id}@matches.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@rejection.yaml
+++ b/openapi/paths/kyc-documents@{id}@rejection.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@review.yaml
+++ b/openapi/paths/kyc-documents@{id}@review.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@start-review.yaml
+++ b/openapi/paths/kyc-documents@{id}@start-review.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-documents@{id}@stop-review.yaml
+++ b/openapi/paths/kyc-documents@{id}@stop-review.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/kyc-requests.yaml
+++ b/openapi/paths/kyc-requests.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/kyc-requests@{id}.yaml
+++ b/openapi/paths/kyc-requests@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/lists.yaml
+++ b/openapi/paths/lists.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/lists@{id}.yaml
+++ b/openapi/paths/lists@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/lists@{id}@{version}.yaml
+++ b/openapi/paths/lists@{id}@{version}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
   - name: version
     in: path

--- a/openapi/paths/password-tokens.yaml
+++ b/openapi/paths/password-tokens.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/password-tokens@{id}.yaml
+++ b/openapi/paths/password-tokens@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/payment-cards-bank-names.yaml
+++ b/openapi/paths/payment-cards-bank-names.yaml
@@ -12,8 +12,7 @@ get:
   description: |
     Retrieve a list of payment card issuing bank names.
   parameters:
-    - $ref: ../components/parameters/organizationId.yaml
-    - $ref: ../components/parameters/collectionLimit.yaml
+      - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
   responses:
     '200':

--- a/openapi/paths/payment-instruments.yaml
+++ b/openapi/paths/payment-instruments.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/payment-instruments@{id}.yaml
+++ b/openapi/paths/payment-instruments@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/payment-instruments@{id}@deactivation.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/payouts.yaml
+++ b/openapi/paths/payouts.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/plans.yaml
+++ b/openapi/paths/plans.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/plans@{id}.yaml
+++ b/openapi/paths/plans@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/previews@orders.yaml
+++ b/openapi/paths/previews@orders.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/previews@rule-actions@send-email.yaml
+++ b/openapi/paths/previews@rule-actions@send-email.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/previews@rule-actions@trigger-webhook.yaml
+++ b/openapi/paths/previews@rule-actions@trigger-webhook.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/previews@webhooks.yaml
+++ b/openapi/paths/previews@webhooks.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/products.yaml
+++ b/openapi/paths/products.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/products@{id}.yaml
+++ b/openapi/paths/products@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/ready-to-pay.yaml
+++ b/openapi/paths/ready-to-pay.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/reports@api-log-summary.yaml
+++ b/openapi/paths/reports@api-log-summary.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@cumulative-subscriptions.yaml
+++ b/openapi/paths/reports@cumulative-subscriptions.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@dashboard.yaml
+++ b/openapi/paths/reports@dashboard.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@dcc-markup.yaml
+++ b/openapi/paths/reports@dcc-markup.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@disputes.yaml
+++ b/openapi/paths/reports@disputes.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@events-triggered.yaml
+++ b/openapi/paths/reports@events-triggered.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
+++ b/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
@@ -20,7 +20,6 @@ parameters:
     description: The system event type.
     schema:
       $ref: ../components/schemas/EventType.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@future-renewals.yaml
+++ b/openapi/paths/reports@future-renewals.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@renewal-sales.yaml
+++ b/openapi/paths/reports@renewal-sales.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@retention-percentage.yaml
+++ b/openapi/paths/reports@retention-percentage.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@retention-value.yaml
+++ b/openapi/paths/reports@retention-value.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@subscription-cancellation.yaml
+++ b/openapi/paths/reports@subscription-cancellation.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@subscription-renewal.yaml
+++ b/openapi/paths/reports@subscription-renewal.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@time-series-transaction.yaml
+++ b/openapi/paths/reports@time-series-transaction.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@transactions-time-dispute.yaml
+++ b/openapi/paths/reports@transactions-time-dispute.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/reports@transactions.yaml
+++ b/openapi/paths/reports@transactions.yaml
@@ -13,8 +13,7 @@ servers:
         description: Your organization ID.
   - url: 'https://api.rebilly.com/experimental'
   - url: 'https://api-sandbox.rebilly.com/experimental'
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/roles.yaml
+++ b/openapi/paths/roles.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/roles@{id}.yaml
+++ b/openapi/paths/roles@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/search.yaml
+++ b/openapi/paths/search.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/send-through-attribution@{eventType}.yaml
+++ b/openapi/paths/send-through-attribution@{eventType}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/systemEventType.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/shipping-rates.yaml
+++ b/openapi/paths/shipping-rates.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   tags:
     - Shipping rates

--- a/openapi/paths/shipping-rates@{id}.yaml
+++ b/openapi/paths/shipping-rates@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   tags:
     - Shipping rates

--- a/openapi/paths/shipping-zones.yaml
+++ b/openapi/paths/shipping-zones.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/shipping-zones@{id}.yaml
+++ b/openapi/paths/shipping-zones@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/storefront/account.yaml
+++ b/openapi/paths/storefront/account.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/account@forgot-password.yaml
+++ b/openapi/paths/storefront/account@forgot-password.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/account@password.yaml
+++ b/openapi/paths/storefront/account@password.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 patch:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/account@resend-verification.yaml
+++ b/openapi/paths/storefront/account@resend-verification.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/account@reset-password@{token}.yaml
+++ b/openapi/paths/storefront/account@reset-password@{token}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/token.yaml
 post:
   x-products:

--- a/openapi/paths/storefront/account@verification@{token}.yaml
+++ b/openapi/paths/storefront/account@verification@{token}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/token.yaml
 post:
   x-products:

--- a/openapi/paths/storefront/checkout-forms@{id}.yaml
+++ b/openapi/paths/storefront/checkout-forms@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/invoices.yaml
+++ b/openapi/paths/storefront/invoices.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/invoices@{id}.yaml
+++ b/openapi/paths/storefront/invoices@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/kyc-documents@{id}.yaml
+++ b/openapi/paths/storefront/kyc-documents@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/kyc-requests@{id}.yaml
+++ b/openapi/paths/storefront/kyc-requests@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/login.yaml
+++ b/openapi/paths/storefront/login.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/logout.yaml
+++ b/openapi/paths/storefront/logout.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/orders.yaml
+++ b/openapi/paths/storefront/orders.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/payment-instruments@{id}.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/payment.yaml
+++ b/openapi/paths/storefront/payment.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/plans.yaml
+++ b/openapi/paths/storefront/plans.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/plans@{id}.yaml
+++ b/openapi/paths/storefront/plans@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/preview-purchase.yaml
+++ b/openapi/paths/storefront/preview-purchase.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/products.yaml
+++ b/openapi/paths/storefront/products.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/products@{id}.yaml
+++ b/openapi/paths/storefront/products@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/purchase.yaml
+++ b/openapi/paths/storefront/purchase.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/ready-to-pay.yaml
+++ b/openapi/paths/storefront/ready-to-pay.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/register.yaml
+++ b/openapi/paths/storefront/register.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/transactions.yaml
+++ b/openapi/paths/storefront/transactions.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Storefront

--- a/openapi/paths/storefront/transactions@{id}.yaml
+++ b/openapi/paths/storefront/transactions@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/storefront/websites@{id}.yaml
+++ b/openapi/paths/storefront/websites@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+
   - $ref: ../../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/subscription-cancellations.yaml
+++ b/openapi/paths/subscription-cancellations.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/subscription-cancellations@{id}.yaml
+++ b/openapi/paths/subscription-cancellations@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscription-reactivations.yaml
+++ b/openapi/paths/subscription-reactivations.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/subscription-reactivations@{id}.yaml
+++ b/openapi/paths/subscription-reactivations@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions.yaml
+++ b/openapi/paths/subscriptions.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}.yaml
+++ b/openapi/paths/subscriptions@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@change-items.yaml
+++ b/openapi/paths/subscriptions@{id}@change-items.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@interim-invoice.yaml
+++ b/openapi/paths/subscriptions@{id}@interim-invoice.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@timeline.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
@@ -6,7 +6,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@upcoming-invoices.yaml
+++ b/openapi/paths/subscriptions@{id}@upcoming-invoices.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
+++ b/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
@@ -6,7 +6,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{id}@void.yaml
+++ b/openapi/paths/subscriptions@{id}@void.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
+++ b/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
@@ -20,7 +20,6 @@ parameters:
     description: Order's ID.
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/tags@{tag}.yaml
+++ b/openapi/paths/tags@{tag}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/tag.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/tags@{tag}@customers.yaml
+++ b/openapi/paths/tags@{tag}@customers.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/tag.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/tags@{tag}@customers@{customerId}.yaml
+++ b/openapi/paths/tags@{tag}@customers@{customerId}.yaml
@@ -1,7 +1,6 @@
 parameters:
   - $ref: ../components/parameters/tag.yaml
   - $ref: ../components/parameters/customerId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/tags@{tag}@kyc-documents.yaml
+++ b/openapi/paths/tags@{tag}@kyc-documents.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/tag.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/tags@{tag}@kyc-documents@{kycDocumentId}.yaml
+++ b/openapi/paths/tags@{tag}@kyc-documents@{kycDocumentId}.yaml
@@ -1,7 +1,6 @@
 parameters:
   - $ref: ../components/parameters/tag.yaml
   - $ref: ../components/parameters/kycDocumentId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/tokens.yaml
+++ b/openapi/paths/tokens.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/tokens@{token}.yaml
+++ b/openapi/paths/tokens@{token}.yaml
@@ -5,7 +5,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/tracking@api.yaml
+++ b/openapi/paths/tracking@api.yaml
@@ -7,8 +7,7 @@ get:
   operationId: GetTrackingApiCollection
   x-sdk-operation-name: getAllApiLogs
   parameters:
-    - $ref: ../components/parameters/organizationId.yaml
-    - $ref: ../components/parameters/collectionLimit.yaml
+      - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionFilter.yaml

--- a/openapi/paths/tracking@api@{id}.yaml
+++ b/openapi/paths/tracking@api@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/tracking@lists.yaml
+++ b/openapi/paths/tracking@lists.yaml
@@ -7,8 +7,7 @@ get:
   operationId: GetTrackingListCollection
   x-sdk-operation-name: getAllListsChangesHistory
   parameters:
-    - $ref: ../components/parameters/organizationId.yaml
-    - $ref: ../components/parameters/collectionLimit.yaml
+      - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionFilter.yaml

--- a/openapi/paths/tracking@webhooks.yaml
+++ b/openapi/paths/tracking@webhooks.yaml
@@ -7,8 +7,7 @@ get:
   operationId: GetTrackingWebhookCollection
   x-sdk-operation-name: getAllWebhookTrackingLogs
   parameters:
-    - $ref: ../components/parameters/organizationId.yaml
-    - $ref: ../components/parameters/collectionLimit.yaml
+      - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionFilter.yaml

--- a/openapi/paths/tracking@webhooks@{id}.yaml
+++ b/openapi/paths/tracking@webhooks@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/tracking@webhooks@{id}@resend.yaml
+++ b/openapi/paths/tracking@webhooks@{id}@resend.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:

--- a/openapi/paths/transactions.yaml
+++ b/openapi/paths/transactions.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 post:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}.yaml
+++ b/openapi/paths/transactions@{id}.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}@query.yaml
+++ b/openapi/paths/transactions@{id}@query.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}@refund.yaml
+++ b/openapi/paths/transactions@{id}@refund.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}@timeline.yaml
+++ b/openapi/paths/transactions@{id}@timeline.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/transactions@{id}@timeline@{messageId}.yaml
@@ -6,7 +6,6 @@ parameters:
     required: true
     schema:
       type: string
-  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full

--- a/openapi/paths/transactions@{id}@update.yaml
+++ b/openapi/paths/transactions@{id}@update.yaml
@@ -1,6 +1,5 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
-  - $ref: ../components/parameters/organizationId.yaml
 post:
   x-products:
     - Full

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/users@{id}.yaml
+++ b/openapi/paths/users@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/webhooks.yaml
+++ b/openapi/paths/webhooks.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/webhooks@{id}.yaml
+++ b/openapi/paths/webhooks@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:

--- a/openapi/paths/websites.yaml
+++ b/openapi/paths/websites.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
 get:
   x-products:
     - Full

--- a/openapi/paths/websites@{id}.yaml
+++ b/openapi/paths/websites@{id}.yaml
@@ -1,5 +1,4 @@
-parameters:
-  - $ref: ../components/parameters/organizationId.yaml
+
   - $ref: ../components/parameters/resourceId.yaml
 get:
   x-products:


### PR DESCRIPTION
Removing the deprecated organization-id header and servers from the docs.

First, existing integrations should migrate to the new format even though we aren't discontinuing support. 

Second, the docs look a lot worse as they are now:

<img width="724" alt="2022-02-03_22-51-50" src="https://user-images.githubusercontent.com/1161871/152473850-811caf23-0e89-49f0-b8de-3bc09cf80c6b.png">

Third, there is chance new integrators will opt to use the deprecated options.