### PR TITLE
refactor: standardize fees file organization

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -28,6 +28,7 @@ lint:
     custom-rules/description-punctuation: error
     custom-rules/has-sdk-operation-name: error
     custom-rules/no-unused-tags: warn
+    operation-4xx-response: off
   decorators:
     products-bundler/bundle: error
 referenceDocs:

--- a/openapi/combined.yaml
+++ b/openapi/combined.yaml
@@ -316,9 +316,9 @@ paths:
   '/disputes/{id}':
     $ref: './paths/disputes@{id}.yaml'
   '/fees':
-    $ref: './paths/fees/fees.yaml'
+    $ref: './paths/fees.yaml'
   '/fees/{id}':
-    $ref: './paths/fees/fees@{id}.yaml'
+    $ref: './paths/fees@{id}.yaml'
   /files:
     $ref: ./paths/files.yaml
   '/files/{id}':

--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -419,9 +419,9 @@ paths:
   '/transactions/{id}/refund':
     $ref: './paths/transactions@{id}@refund.yaml'
   '/fees':
-    $ref: './paths/fees/fees.yaml'
+    $ref: './paths/fees.yaml'
   '/fees/{id}':
-    $ref: './paths/fees/fees@{id}.yaml'
+    $ref: './paths/fees@{id}.yaml'
 components:
   securitySchemes:
     JWT:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -587,9 +587,9 @@ paths:
   '/transactions/{id}/timeline/{messageId}':
     $ref: './paths/transactions@{id}@timeline@{messageId}.yaml'
   '/fees':
-    $ref: './paths/fees/fees.yaml'
+    $ref: './paths/fees.yaml'
   '/fees/{id}':
-    $ref: './paths/fees/fees@{id}.yaml'
+    $ref: './paths/fees@{id}.yaml'
   '/activation/{token}':
     $ref: './paths/activation@{token}.yaml'
   /api-keys:

--- a/openapi/paths/fees.yaml
+++ b/openapi/paths/fees.yaml
@@ -1,5 +1,5 @@
 parameters:
-  - $ref: ../../components/parameters/organizationId.yaml
+  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full
@@ -15,28 +15,28 @@ get:
   operationId: GetFeeCollection
   x-sdk-operation-name: getAll
   parameters:
-    - $ref: ../../components/parameters/collectionLimit.yaml
-    - $ref: ../../components/parameters/collectionOffset.yaml
+    - $ref: ../components/parameters/collectionLimit.yaml
+    - $ref: ../components/parameters/collectionOffset.yaml
   responses:
     '200':
       description: A fees list was retrieved successfully.
       headers:
         Pagination-Total:
-          $ref: ../../components/headers/Pagination-Total.yaml
+          $ref: ../components/headers/Pagination-Total.yaml
         Pagination-Limit:
-          $ref: ../../components/headers/Pagination-Limit.yaml
+          $ref: ../components/headers/Pagination-Limit.yaml
         Pagination-Offset:
-          $ref: ../../components/headers/Pagination-Offset.yaml
+          $ref: ../components/headers/Pagination-Offset.yaml
       content:
         application/json:
           schema:
             type: array
             items:
-              $ref: ../../components/schemas/Fees/Fee.yaml
+              $ref: ../components/schemas/Fees/Fee.yaml
     '401':
-      $ref: ../../components/responses/Unauthorized.yaml
+      $ref: ../components/responses/Unauthorized.yaml
     '403':
-      $ref: ../../components/responses/Forbidden.yaml
+      $ref: ../components/responses/Forbidden.yaml
 post:
   x-products:
     - Full
@@ -56,21 +56,21 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/Fees/Fee.yaml
+          $ref: ../components/schemas/Fees/Fee.yaml
         examples:
-          $ref: ../../components/examples/fee-request.yaml
+          $ref: ../components/examples/fee-request.yaml
   responses:
     '201':
       description: Fee entry was created successfully.
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Fees/Fee.yaml
+            $ref: ../components/schemas/Fees/Fee.yaml
           examples:
-            $ref: ../../components/examples/fee-response.yaml
+            $ref: ../components/examples/fee-response.yaml
     '401':
-      $ref: ../../components/responses/Unauthorized.yaml
+      $ref: ../components/responses/Unauthorized.yaml
     '403':
-      $ref: ../../components/responses/Forbidden.yaml
+      $ref: ../components/responses/Forbidden.yaml
     '422':
-      $ref: ../../components/responses/ValidationError.yaml
+      $ref: ../components/responses/ValidationError.yaml

--- a/openapi/paths/fees@{id}.yaml
+++ b/openapi/paths/fees@{id}.yaml
@@ -1,6 +1,6 @@
 parameters:
-  - $ref: ../../components/parameters/resourceId.yaml
-  - $ref: ../../components/parameters/organizationId.yaml
+  - $ref: ../components/parameters/resourceId.yaml
+  - $ref: ../components/parameters/organizationId.yaml
 get:
   x-products:
     - Full
@@ -21,15 +21,15 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Fees/Fee.yaml
+            $ref: ../components/schemas/Fees/Fee.yaml
           examples:
-            $ref: ../../components/examples/fee-response.yaml
+            $ref: ../components/examples/fee-response.yaml
     '401':
-      $ref: ../../components/responses/Unauthorized.yaml
+      $ref: ../components/responses/Unauthorized.yaml
     '403':
-      $ref: ../../components/responses/Forbidden.yaml
+      $ref: ../components/responses/Forbidden.yaml
     '404':
-      $ref: ../../components/responses/NotFound.yaml
+      $ref: ../components/responses/NotFound.yaml
 put:
   x-products:
     - Full
@@ -49,32 +49,32 @@ put:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/Fees/Fee.yaml
+          $ref: ../components/schemas/Fees/Fee.yaml
         examples:
-          $ref: ../../components/examples/fee-request.yaml
+          $ref: ../components/examples/fee-request.yaml
   responses:
     '200':
       description: Fee entry was updated successfully.
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Fees/Fee.yaml
+            $ref: ../components/schemas/Fees/Fee.yaml
           examples:
-            $ref: ../../components/examples/fee-response.yaml
+            $ref: ../components/examples/fee-response.yaml
     '201':
       description: Fee entry was created successfully.
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Fees/Fee.yaml
+            $ref: ../components/schemas/Fees/Fee.yaml
           examples:
-            $ref: ../../components/examples/fee-response.yaml
+            $ref: ../components/examples/fee-response.yaml
     '401':
-      $ref: ../../components/responses/Unauthorized.yaml
+      $ref: ../components/responses/Unauthorized.yaml
     '403':
-      $ref: ../../components/responses/Forbidden.yaml
+      $ref: ../components/responses/Forbidden.yaml
     '422':
-      $ref: ../../components/responses/ValidationError.yaml
+      $ref: ../components/responses/ValidationError.yaml
 patch:
   x-products:
     - Full
@@ -94,21 +94,21 @@ patch:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/Fees/FeePatch.yaml
+          $ref: ../components/schemas/Fees/FeePatch.yaml
         examples:
-          $ref: ../../components/examples/fee-request.yaml
+          $ref: ../components/examples/fee-request.yaml
   responses:
     '200':
       description: Fee entry was patched successfully.
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Fees/Fee.yaml
+            $ref: ../components/schemas/Fees/Fee.yaml
           examples:
-            $ref: ../../components/examples/fee-response.yaml
+            $ref: ../components/examples/fee-response.yaml
     '401':
-      $ref: ../../components/responses/Unauthorized.yaml
+      $ref: ../components/responses/Unauthorized.yaml
     '403':
-      $ref: ../../components/responses/Forbidden.yaml
+      $ref: ../components/responses/Forbidden.yaml
     '422':
-      $ref: ../../components/responses/ValidationError.yaml
+      $ref: ../components/responses/ValidationError.yaml


### PR DESCRIPTION
- disables `operation-4xx-response` for now due to this: https://github.com/Redocly/openapi-cli/issues/546
- fees were in a folder (like storefront) but they are no different from the other core APIs. I moved them to be consistent in their location