### PR TITLE
Revert "Move timelines to the users API"

### DIFF
--- a/openapi/core.yaml
+++ b/openapi/core.yaml
@@ -52,6 +52,9 @@ tags:
     description: |
       Customers are your customers, sometimes known as accounts, clients,
       members, patrons, or players in other systems.
+  - name: Customers Timeline
+    description: |
+      The customers timeline keeps an audit trail of changes and activity for each customer.
   - name: KYC Documents
     description: >
       Create a KYC Request to generate a gatherer link for the customer to upload KYC documents.
@@ -186,6 +189,7 @@ x-tagGroups:
       - Customers
       - Customer Authentication
       - Tags
+      - Customers Timeline
   - name: Payment Instruments
     tags:
       - Payment Instruments
@@ -262,8 +266,18 @@ paths:
     $ref: ./paths/customers.yaml
   '/customers/{id}':
     $ref: './paths/customers@{id}.yaml'
+  /customer-timeline-custom-events:
+    $ref: ./paths/customer-timeline-custom-events.yaml
+  '/customer-timeline-custom-events/{id}':
+    $ref: './paths/customer-timeline-custom-events@{id}.yaml'
+  /customer-timeline-events:
+    $ref: ./paths/customer-timeline-events.yaml
   '/customers/{id}/lead-source':
     $ref: './paths/customers@{id}@lead-source.yaml'
+  '/customers/{id}/timeline':
+    $ref: './paths/customers@{id}@timeline.yaml'
+  '/customers/{id}/timeline/{messageId}':
+    $ref: './paths/customers@{id}@timeline@{messageId}.yaml'
   /disputes:
     $ref: ./paths/disputes.yaml
   '/disputes/{id}':

--- a/openapi/users.yaml
+++ b/openapi/users.yaml
@@ -111,6 +111,7 @@ tags:
   - name: Gateway Accounts
     description: |
       Gateway accounts connect payment request to third party networks and platforms.
+  - name: Gateway Accounts Timeline
   - name: Lists
     description: |
       Lists contain sets of values and may be referenced within Rules criteria.
@@ -218,11 +219,6 @@ tags:
   - name: TaxJar credentials
   - name: Metadata
   - name: Custom domains
-  - name: Customers Timeline
-  - name: Gateway Accounts Timeline
-  - name: Transactions Timeline
-  - name: Orders Timeline
-  - name: Invoices Timeline
 ################################################################################
 x-tagGroups:
   - name: Security
@@ -262,6 +258,7 @@ x-tagGroups:
       - Billing Portals
       - Checkout Forms
       - Gateway Accounts
+      - Gateway Accounts Timeline
       - Payment Cards
       - Payment Instruments
       - Organizations
@@ -275,11 +272,6 @@ x-tagGroups:
       - TaxJar credentials
       - Metadata
       - Custom domains
-      - Customers Timeline
-      - Gateway Accounts Timeline
-      - Transactions Timeline
-      - Orders Timeline
-      - Invoices Timeline
   - name: Related docs
     tags:
       - Rebilly API
@@ -391,16 +383,6 @@ paths:
     $ref: ./paths/custom-domains.yaml
   '/custom-domains/{domain}':
     $ref: './paths/custom-domains@{domain}.yaml'
-  /customer-timeline-custom-events:
-    $ref: ./paths/customer-timeline-custom-events.yaml
-  '/customer-timeline-custom-events/{id}':
-    $ref: './paths/customer-timeline-custom-events@{id}.yaml'
-  /customer-timeline-events:
-    $ref: ./paths/customer-timeline-events.yaml
-  '/customers/{id}/timeline':
-    $ref: './paths/customers@{id}@timeline.yaml'
-  '/customers/{id}/timeline/{messageId}':
-    $ref: './paths/customers@{id}@timeline@{messageId}.yaml'
   '/email-delivery-setting-verifications/{token}':
     $ref: './paths/email-delivery-setting-verifications@{token}.yaml'
   /email-delivery-settings:
@@ -473,10 +455,6 @@ paths:
     $ref: ./paths/integrations.yaml
   '/integrations/{label}':
     $ref: './paths/integrations@{label}.yaml'
-  '/invoices/{id}/timeline':
-    $ref: './paths/invoices@{id}@timeline.yaml'
-  '/invoices/{id}/timeline/{messageId}':
-    $ref: './paths/invoices@{id}@timeline@{messageId}.yaml'
   /lists:
     $ref: ./paths/lists.yaml
   '/lists/{id}':
@@ -533,10 +511,6 @@ paths:
     $ref: ./paths/signup.yaml
   /status:
     $ref: ./paths/status.yaml
-  '/subscriptions/{id}/timeline':
-    $ref: './paths/subscriptions@{id}@timeline.yaml'
-  '/subscriptions/{id}/timeline/{messageId}':
-    $ref: './paths/subscriptions@{id}@timeline@{messageId}.yaml'
   /tracking/api:
     $ref: ./paths/tracking@api.yaml
   '/tracking/api/{id}':
@@ -549,10 +523,6 @@ paths:
     $ref: './paths/tracking@webhooks@{id}.yaml'
   '/tracking/webhooks/{id}/resend':
     $ref: './paths/tracking@webhooks@{id}@resend.yaml'
-  '/transactions/{id}/timeline':
-    $ref: './paths/transactions@{id}@timeline.yaml'
-  '/transactions/{id}/timeline/{messageId}':
-    $ref: './paths/transactions@{id}@timeline@{messageId}.yaml'
   /users:
     $ref: ./paths/users.yaml
   '/users/{id}':


### PR DESCRIPTION
Reverts Rebilly/api-definitions#735


It's incompatible with JS SDK generator