### PR TITLE
Resolve servers issue

### DIFF
--- a/plugins/products-bundler/bundler.js
+++ b/plugins/products-bundler/bundler.js
@@ -45,6 +45,9 @@ const decorators = {
             definitionRoot['info'] = getNewInfo(definitionRoot['info'], productMapping, ctx.resolve);
             definitionRoot['tags'] = getNewTags(definitionRoot, tagsNamesToInclude);
             definitionRoot['x-tagGroups'] = productMapping['x-tagGroups'];
+            if ('servers' in productMapping) {
+              definitionRoot['servers'] = productMapping['servers'];
+            }
             definitionRoot['paths'] = getNewPaths(definitionRoot['paths'], ctx, tagsNamesToInclude, availableMethods, includedXProducts);
             definitionRoot['x-webhooks'] = getNewPaths(definitionRoot['x-webhooks'], ctx, tagsNamesToInclude, ['post'], includedXProducts);
             if (Object.keys(definitionRoot['x-webhooks']).length === 0) {
@@ -123,7 +126,11 @@ function getNewPaths(paths, ctx, tagsNamesToInclude, availableMethods, includedX
     });
 
     if (hasAtLeastOneOperation) {
-      newPathsEntries.push([path, definition]);
+      newPathsEntries.push([
+        // Temporary workaround for servers with organization parameters included
+        path.replace('/storefront/', '/').replace('/experimental/', '/'),
+        definition
+      ]);
     }
   }
 

--- a/plugins/products-bundler/mapping/Reports.yaml
+++ b/plugins/products-bundler/mapping/Reports.yaml
@@ -29,6 +29,20 @@ info:
     within Github, and contains the installation and usage instructions in the Readme file.
     SDK code examples are included in these docs.
 
+servers:
+  - url: 'https://api-sandbox.rebilly.com/experimental/organizations/{organizationId}'
+    description: Sandbox server
+    variables:
+      organizationId:
+        default: unknown
+        description: Your organization ID.
+  - url: 'https://api.rebilly.com/experimental/organizations/{organizationId}'
+    description: Live server
+    variables:
+      organizationId:
+        default: unknown
+        description: Your organization ID.
+
 x-tagGroups:
   - name: Reports
     tags:

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -14,18 +14,6 @@ info:
     HTTP/REST library for your programming language to use Rebilly's Storefront API.
 
 servers:
-  - url: 'https://api-sandbox.rebilly.com/storefront/organizations/{organizationId}'
-    description: Sandbox server with organizationId.
-    variables:
-      organizationId:
-        default: unknown
-        description: Your organization ID.
-  - url: 'https://api.rebilly.com/storefront/organizations/{organizationId}'
-    description: Live server with organizationId.
-    variables:
-      organizationId:
-        default: unknown
-        description: Your organization ID.
   - url: 'https://api-sandbox.rebilly.com/storefront'
     description: Sandbox server
   - url: 'https://api.rebilly.com/storefront'

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -13,6 +13,24 @@ info:
     accepts and returns JSON in the HTTP body. You can use your favorite
     HTTP/REST library for your programming language to use Rebilly's Storefront API.
 
+servers:
+  - url: 'https://api-sandbox.rebilly.com/storefront/organizations/{organizationId}'
+    description: Sandbox server with organizationId.
+    variables:
+      organizationId:
+        default: unknown
+        description: Your organization ID.
+  - url: 'https://api.rebilly.com/storefront/organizations/{organizationId}'
+    description: Live server with organizationId.
+    variables:
+      organizationId:
+        default: unknown
+        description: Your organization ID.
+  - url: 'https://api-sandbox.rebilly.com/storefront'
+    description: Sandbox Server.
+  - url: 'https://api.rebilly.com/storefront'
+    description: Live Server.
+
 x-tagGroups:
   - name: Account management
     tags:

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -27,9 +27,9 @@ servers:
         default: unknown
         description: Your organization ID.
   - url: 'https://api-sandbox.rebilly.com/storefront'
-    description: Sandbox Server.
+    description: Sandbox server
   - url: 'https://api.rebilly.com/storefront'
-    description: Live Server.
+    description: Live server
 
 x-tagGroups:
   - name: Account management


### PR DESCRIPTION
This PR will resolve issue with servers configuration. Storefront and experimental APIs have a specific format where a prefix is put before the organization path in UR and cannot use common servers from `openapi.yaml`