### PR TITLE
Add documentMatches to Storefront KYC resource

### DIFF
--- a/openapi/components/schemas/Common/CommonKycDocument.yaml
+++ b/openapi/components/schemas/Common/CommonKycDocument.yaml
@@ -65,6 +65,9 @@ properties:
     description: Processing date/time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
+  documentMatches:
+    type: object
+    readOnly: true
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Common/CommonKycDocument.yaml
+++ b/openapi/components/schemas/Common/CommonKycDocument.yaml
@@ -65,9 +65,6 @@ properties:
     description: Processing date/time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
-  documentMatches:
-    type: object
-    readOnly: true
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/KycDocument.yaml
+++ b/openapi/components/schemas/KycDocument.yaml
@@ -31,7 +31,7 @@ allOf:
         description: Reviewer notes.
         type: string
         nullable: true
-      tags: 
+      tags:
         description: A list of kyc document tags.
         readOnly: true
         type: array

--- a/openapi/components/schemas/Storefront/KycDocuments/ProofOfAddress.yaml
+++ b/openapi/components/schemas/Storefront/KycDocuments/ProofOfAddress.yaml
@@ -1,0 +1,16 @@
+allOf:
+  - $ref: ../../Common/CommonKycDocument.yaml
+  - properties:
+      documentMatches:
+        type: object
+        readOnly: true
+        properties:
+          score:
+            description: >-
+              The calculated score that represents the % of confidence that this proof of address
+              represents the given customer.
+            type: number
+            format: double
+            example: 0.75
+          data:
+            $ref: ../../KycDocument/AddressMatches.yaml

--- a/openapi/components/schemas/Storefront/KycDocuments/ProofOfFunds.yaml
+++ b/openapi/components/schemas/Storefront/KycDocuments/ProofOfFunds.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: ../../Common/CommonKycDocument.yaml

--- a/openapi/components/schemas/Storefront/KycDocuments/ProofOfIdentity.yaml
+++ b/openapi/components/schemas/Storefront/KycDocuments/ProofOfIdentity.yaml
@@ -1,0 +1,16 @@
+allOf:
+  - $ref: ../../Common/CommonKycDocument.yaml
+  - properties:
+      documentMatches:
+        type: object
+        readOnly: true
+        properties:
+          score:
+            description: >-
+              The calculated score that represents the % of confidence that this ID
+              represents the given customer.
+            type: number
+            format: double
+            example: 0.75
+          data:
+            $ref: ../../KycDocument/IdentityMatches.yaml

--- a/openapi/components/schemas/Storefront/KycDocuments/ProofOfPurchase.yaml
+++ b/openapi/components/schemas/Storefront/KycDocuments/ProofOfPurchase.yaml
@@ -1,0 +1,9 @@
+allOf:
+  - $ref: ../../Common/CommonKycDocument.yaml
+  - properties:
+      documentMatches:
+        type: object
+        readOnly: true
+        properties:
+          data:
+            $ref: ../../KycDocument/PurchaseMatches.yaml

--- a/openapi/components/schemas/Storefront/StorefrontKycDocument.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontKycDocument.yaml
@@ -1,0 +1,12 @@
+oneOf:
+  - $ref: ./KycDocuments/ProofOfIdentity.yaml
+  - $ref: ./KycDocuments/ProofOfAddress.yaml
+  - $ref: ./KycDocuments/ProofOfFunds.yaml
+  - $ref: ./KycDocuments/ProofOfPurchase.yaml
+discriminator:
+  propertyName: documentType
+  mapping:
+    identity-proof: ./KycDocuments/ProofOfIdentity.yaml
+    address-proof: ./KycDocuments/ProofOfAddress.yaml
+    funds-proof: ./KycDocuments/ProofOfFunds.yaml
+    purchase-proof: ./KycDocuments/ProofOfPurchase.yaml

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -28,7 +28,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+              $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     401:
       $ref: ../../components/responses/Unauthorized.yaml
     403:
@@ -49,7 +49,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+          $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     description: Kyc document resource.
     required: true
   responses:
@@ -58,7 +58,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+            $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     401:
       $ref: ../../components/responses/Unauthorized.yaml
     403:

--- a/openapi/paths/storefront/kyc-documents@{id}.yaml
+++ b/openapi/paths/storefront/kyc-documents@{id}.yaml
@@ -18,7 +18,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+            $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     401:
       $ref: ../../components/responses/Unauthorized.yaml
     403:
@@ -41,7 +41,7 @@ patch:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+          $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     description: KYC document resource.
     required: true
   responses:
@@ -50,7 +50,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/Common/CommonKycDocument.yaml
+            $ref: ../../components/schemas/Storefront/StorefrontKycDocument.yaml
     401:
       $ref: ../../components/responses/Unauthorized.yaml
     403:


### PR DESCRIPTION
Add `documentMatches` to response for StorefrontGetKycDocument

https://preview.redoc.ly/rebilly-storefront/kyc-storefront-document-matches/tag/KYC-Documents#operation/StorefrontGetKycDocument