### PR TITLE
Add billingPortalUrl to the PaymentCard schema

### DIFF
--- a/openapi/components/schemas/Common/CommonPaymentCard.yaml
+++ b/openapi/components/schemas/Common/CommonPaymentCard.yaml
@@ -74,6 +74,10 @@ properties:
     description: Allow using this payment instrument as a backup for invoice payment retries.
     type: boolean
     default: false
+  billingPortalUrl:
+    description: URL to the billing portal where the card can be updated.
+    type: string
+    readOnly: true
   createdTime:
     description: Payment instrument created time.
     allOf:


### PR DESCRIPTION
Adds a property named `billingPortalUrl` to PaymentCard resources.

This property contains a URL to the billing portal where a customer can update their card information.