### PR TITLE
Define tracking id in KYC gatherer

### DIFF
--- a/openapi/components/schemas/KycDocument/Settings/KycSettingsTracking.yaml
+++ b/openapi/components/schemas/KycDocument/Settings/KycSettingsTracking.yaml
@@ -1,0 +1,27 @@
+type: object
+description: Various tracking system identifier strings.
+properties:
+  googleAnalytics:
+    description: The Google Analytics tracking identifier string.
+    type: string
+    example: UA-XXXXX-YY
+  googleTagManager:
+    description: The Google Tag Manager tracking identifier string.
+    type: string
+    example: GTM-XXXXX
+  gtagJs:
+    description: The Google Analytics tracking identifier string for Google's Global Site Tag (gtag.js) service.
+    type: string
+    example: UA-XXXXX-YY
+  facebookPixel:
+    description: The Facebook Pixel tracking identifier string.
+    type: string
+    example: 1234567890
+  segmentAnalytics:
+    description: The Segment Analytics tracking identifier string.
+    type: string
+    example: 1234567890
+  heapIo:
+    description: The Heap.io tracking identifier string.
+    type: string
+    example: 1234567890

--- a/openapi/components/schemas/Organizations/OrganizationSettings.yaml
+++ b/openapi/components/schemas/Organizations/OrganizationSettings.yaml
@@ -19,9 +19,11 @@ properties:
         description: The rate for flat tax calculation.
   kyc:
     type: object
-    description: The settings for tax calculation.
+    description: The settings for KYC config.
     properties:
       identity-proof:
         $ref: ../KycDocument/Settings/KycSettingsIdentity.yaml
       address-proof:
         $ref: ../KycDocument/Settings/KycSettingsAddress.yaml
+      tracking-id:
+        $ref: ../KycDocument/Settings/KycSettingsTracking.yaml

--- a/openapi/components/schemas/Organizations/OrganizationSettings.yaml
+++ b/openapi/components/schemas/Organizations/OrganizationSettings.yaml
@@ -25,8 +25,6 @@ properties:
         $ref: ../KycDocument/Settings/KycSettingsIdentity.yaml
       address-proof:
         $ref: ../KycDocument/Settings/KycSettingsAddress.yaml
-      tracking-id:
-        $ref: ../KycDocument/Settings/KycSettingsTracking.yaml
   tracking:
     type: object
     description: The tracking config.

--- a/openapi/components/schemas/Organizations/OrganizationSettings.yaml
+++ b/openapi/components/schemas/Organizations/OrganizationSettings.yaml
@@ -29,5 +29,5 @@ properties:
     type: object
     description: The tracking config.
     properties:
-      document-gatherer:
+      documentGatherer:
         $ref: ../KycDocument/Settings/KycSettingsTracking.yaml

--- a/openapi/components/schemas/Organizations/OrganizationSettings.yaml
+++ b/openapi/components/schemas/Organizations/OrganizationSettings.yaml
@@ -27,3 +27,9 @@ properties:
         $ref: ../KycDocument/Settings/KycSettingsAddress.yaml
       tracking-id:
         $ref: ../KycDocument/Settings/KycSettingsTracking.yaml
+  tracking:
+    type: object
+    description: The tracking config.
+    properties:
+      document-gatherer:
+        $ref: ../KycDocument/Settings/KycSettingsTracking.yaml

--- a/openapi/components/schemas/Organizations/OrganizationTracking.yaml
+++ b/openapi/components/schemas/Organizations/OrganizationTracking.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  tracking:
+    type: object
+    description: The tracking config.
+    properties:
+      document-gatherer:
+        $ref: ../KycDocument/Settings/KycSettingsTracking.yaml

--- a/openapi/components/schemas/Storefront/Account.yaml
+++ b/openapi/components/schemas/Storefront/Account.yaml
@@ -10,6 +10,11 @@ properties:
     readOnly: true
     allOf:
       - $ref: ../ResourceId.yaml
+  organizationId:
+    description: Organization ID.
+    readOnly: true
+    allOf:
+      - $ref: ../ResourceId.yaml
   username:
     type: string
     description: Username.

--- a/openapi/components/schemas/Storefront/StorefrontOrganization.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontOrganization.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - name
+properties:
+  id:
+    description: The organization identifier string.
+    readOnly: true
+    allOf:
+      - $ref: ../ResourceId.yaml
+  name:
+    description: The organization name.
+    type: string
+    maxLength: 60
+  settings:
+    $ref: ../Organizations/OrganizationSettings.yaml

--- a/openapi/components/schemas/Storefront/StorefrontOrganization.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontOrganization.yaml
@@ -12,4 +12,4 @@ properties:
     type: string
     maxLength: 60
   settings:
-    $ref: ../Organizations/OrganizationSettings.yaml
+    $ref: ../Organizations/OrganizationTracking.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -918,6 +918,8 @@ paths:
     $ref: paths/storefront/transactions@{id}.yaml
   '/storefront/websites/{id}':
     $ref: paths/storefront/websites@{id}.yaml
+  '/storefront/organizations/{id}':
+    $ref: paths/storefront/organizations@{id}.yaml
 
 x-webhooks:
   application-instance-disabled:

--- a/openapi/paths/storefront/organizations@{id}.yaml
+++ b/openapi/paths/storefront/organizations@{id}.yaml
@@ -1,0 +1,27 @@
+parameters:
+  - $ref: ../../components/parameters/resourceId.yaml
+get:
+  x-products:
+    - Storefront
+  tags:
+    - Organizations
+  summary: Retrieve an organization
+  operationId: StorefrontGetOrganization
+  x-sdk-operation-name: get
+  security:
+    - CustomerJWT: []
+  description: |
+    Retrieve a organization with specified identifier string.
+  responses:
+    '200':
+      description: Organization was retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/Storefront/StorefrontOrganization.yaml
+    401:
+      $ref: ../../components/responses/Unauthorized.yaml
+    403:
+      $ref: ../../components/responses/Forbidden.yaml
+    404:
+      $ref: ../../components/responses/NotFound.yaml

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -43,3 +43,4 @@ x-tagGroups:
   - name: System
     tags:
       - Websites
+      - Organizations


### PR DESCRIPTION
- Add `KycSettingsTracking` for PatchOrganization
- Return `organizationId` from StorefrontGetAccount
- Add a new endpoint `StorefrontGetOrganization`
