### PR TITLE
fix: specify kyc-request-fulfilled event type

### DIFF
--- a/openapi/components/requestBodies/Webhooks/KycRequest.yaml
+++ b/openapi/components/requestBodies/Webhooks/KycRequest.yaml
@@ -9,7 +9,10 @@ content:
           description: The KYC request ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Rebilly webhooks event type.
+          enum:
+            - kyc-request-fulfilled
         _embedded:
           type: object
           properties:


### PR DESCRIPTION
The KYC request fulfilled webhook can have one and only one event type value. It cannot have over 70 different possible values.