### PR TITLE
Add ThreatMetrix session id to RiskMetaData ExtraData

### DIFF
--- a/openapi/components/schemas/ExtraData.yaml
+++ b/openapi/components/schemas/ExtraData.yaml
@@ -14,3 +14,10 @@ properties:
     minimum: 1
     maximum: 64
     example: dd65ratxc5qv15iph3vyoq7l6davuowa
+  threatMetrixSessionId:
+    description: A temporary identifier that is unique to the visitor’s session and passed to ThreatMetrix.
+    pattern: '[a-zA-Z0-9_-]*'
+    type: string
+    minimum: 1
+    maximum: 128
+    example: dd65ratxc5qv15iph3vyoq7l6davuowadd65ratxc5qv15iph3vyoq7l6davuowa

--- a/openapi/components/schemas/ExtraData.yaml
+++ b/openapi/components/schemas/ExtraData.yaml
@@ -16,7 +16,7 @@ properties:
     example: dd65ratxc5qv15iph3vyoq7l6davuowa
   threatMetrixSessionId:
     description: A temporary identifier that is unique to the visitor's session and passed to ThreatMetrix.
-    pattern: '[a-zA-Z0-9_-]*'
+    pattern: '[a-zA-Z0-9_-]+'
     type: string
     minimum: 1
     maximum: 128

--- a/openapi/components/schemas/ExtraData.yaml
+++ b/openapi/components/schemas/ExtraData.yaml
@@ -15,7 +15,7 @@ properties:
     maximum: 64
     example: dd65ratxc5qv15iph3vyoq7l6davuowa
   threatMetrixSessionId:
-    description: A temporary identifier that is unique to the visitor’s session and passed to ThreatMetrix.
+    description: A temporary identifier that is unique to the visitor's session and passed to ThreatMetrix.
     pattern: '[a-zA-Z0-9_-]*'
     type: string
     minimum: 1


### PR DESCRIPTION
Aka `thm_session_id` as passed to EMerchantPay.

This can be provided by the merchant or later supported by https://github.com/Rebilly/risk-data-collector.

This would be an alternative to the `thm_session_id` custom field currently supported for payment cards.