### PR TITLE
Add storefront nav item

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -349,6 +349,10 @@ tags:
     description: |
       The Rebilly Reporting API is currently experimental.  You may see
       the [Reports API Documentation here](https://reports-api-docs.rebilly.com).
+  - name: Storefront API
+    description: |
+      The Rebilly Storefront API is currently experimental.  You may see
+      the [Storefront API Documentation here](https://storefront-api-docs.rebilly.com/).
   - name: Users API
     description: >
       The Rebilly User API is primarily for our GUI apps.  You may see

--- a/plugins/products-bundler/mapping/Core.yaml
+++ b/plugins/products-bundler/mapping/Core.yaml
@@ -41,3 +41,4 @@ x-tagGroups:
     tags:
       - Users API
       - Reports API
+      - Storefront API

--- a/plugins/products-bundler/mapping/Users.yaml
+++ b/plugins/products-bundler/mapping/Users.yaml
@@ -127,3 +127,4 @@ x-tagGroups:
     tags:
       - Rebilly API
       - Reports API
+      - Storefront API

--- a/plugins/rules/no-unused-tags.js
+++ b/plugins/rules/no-unused-tags.js
@@ -1,6 +1,6 @@
 module.exports = NoUnusedTag
 
-const ignoredTags = ['Rebilly API', 'Users API', 'Reports API'];
+const ignoredTags = ['Rebilly API', 'Users API', 'Reports API', 'Storefront API'];
 
 function validate() {
   return (definitionRoot, {report, location, resolve}) => {


### PR DESCRIPTION
Added a link, in the "Related docs" section of the left navigation, to the Storefront API.

![Screenshot 2022-03-22 at 10 20 16](https://user-images.githubusercontent.com/85164331/159451925-da603f6a-85c8-4329-be9c-27a8dcdb32e4.png)

### [Preview](https://preview.redoc.ly/rebilly-users/add-link/tag/Storefront-API)


