### PR TITLE
Add KYC document rejection reason types

### DIFF
--- a/openapi/components/schemas/KycDocument/KycDocumentRejectionReasonTypes.yaml
+++ b/openapi/components/schemas/KycDocument/KycDocumentRejectionReasonTypes.yaml
@@ -4,4 +4,9 @@ enum:
   - document-expired
   - document-not-matching
   - underage-person
+  - third-party-or-mismatch
+  - expiration-date-missing
+  - issue-date-missing
+  - dob-mismatch
+  - name-mismatch
   - other


### PR DESCRIPTION
Updates KYC document rejection reason types to include the following:

- `third-party-or-mismatch`
- `expiration-date-missing`
- `issue-date-missing`
- `dob-mismatch`
- `name-mismatch`