### PR TITLE
chore: Clarify that a SecretApiKey is required to perform passworldes…

### DIFF
--- a/openapi/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
+++ b/openapi/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
@@ -10,7 +10,7 @@ properties:
     type: string
     readOnly: true
   mode:
-    description: The token's generation mode.
+    description: The token's generation mode. A SecretApiKey must be used to login in passwordless mode.
     type: string
     enum:
       - password


### PR DESCRIPTION
…s customer authentication