### PR TITLE
Fix problem link

### DIFF
--- a/openapi/components/schemas/Timelines/CustomerTimeline.yaml
+++ b/openapi/components/schemas/Timelines/CustomerTimeline.yaml
@@ -84,8 +84,8 @@ properties:
   customEventType:
     description: >-
       Timeline custom event type. Used with `custom-event` type. Must be defined
-      using [Customer Timeline custom event
-      API](#tag/Customers-Timeline/operation/PostCustomerTimelineCustomEventType).
+      using the Customer Timeline custom event
+      API.
     type: string
     nullable: true
     minLength: 1

--- a/openapi/components/schemas/Timelines/CustomerTimeline.yaml
+++ b/openapi/components/schemas/Timelines/CustomerTimeline.yaml
@@ -84,8 +84,8 @@ properties:
   customEventType:
     description: >-
       Timeline custom event type. Used with `custom-event` type. Must be defined
-      using the Customer Timeline custom event
-      API.
+      using the [Customer Timeline custom event
+      API](https://api-reference.rebilly.com/#tag/Customers-Timeline/operation/PostCustomerTimelineCustomEventType).
     type: string
     nullable: true
     minLength: 1


### PR DESCRIPTION
~~Removed a link that is being read as broken on the website repository.~~ Changed relative link to absolute link, for the reason described below. This is issue on the Redocly side, the link is correctly formed before the website is built.

Explanation:  If an API definition contains a valid link that includes a hashtag (#), [like here](https://github.com/Rebilly/api-definitions/pull/813/files#diff-fd41c48038329a6cf5db77e04707f365f8cad368d658d481206fda230f8b51d0R88), it is detected as a broken link in the portal and link-checker. It [fails validation](https://app.redocly.com/org/rebilly/portal/rebilly-website/build/4131/1) because Redocly adds its own hashtag to the URL. There currently is no alternative other than removing the problem link.

![image (6)](https://user-images.githubusercontent.com/85164331/160614768-a627b33c-e984-4820-a863-24dcadac00c2.png)