### PR TITLE
chore: update to latest openapi-cli 1.0.0-beta.94

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rebilly-openapi-spec",
       "version": "0.0.3",
       "dependencies": {
-        "@redocly/openapi-cli": "1.0.0-beta.89"
+        "@redocly/openapi-cli": "1.0.0-beta.94"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -27,11 +27,11 @@
       }
     },
     "node_modules/@redocly/openapi-cli": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.89.tgz",
-      "integrity": "sha512-kQxBdHKKVOaV3jfWMTsqlgvDAidm31wG5dD6DifDKZphQWqZam1gHXRMnF1mWyN4V9U4xza1cP3KIzCwb7vd1Q==",
+      "version": "1.0.0-beta.94",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.94.tgz",
+      "integrity": "sha512-VHPVIP4K+KgYLDbQXIONS6GRMLsYz7tKa3QVVk83KS7X58fFC/N48hB1Ap2vnryj8HLSrG0yP9y6ZGH1t7kv7g==",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.89",
+        "@redocly/openapi-core": "1.0.0-beta.94",
         "@types/node": "^14.11.8",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.89.tgz",
-      "integrity": "sha512-3+k9oIBhCcs7LJ50eCWB6FdwV4pDH06d613pwFo5F2TmDPviNVWothj3CO/BheDz24tc9K8xR5pQuECE65qr/w==",
+      "version": "1.0.0-beta.94",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.94.tgz",
+      "integrity": "sha512-xTklcobv+51bQVkUOpUiNY0GztL+0u3yGsy2BtldaHpcnNGMu3lu/utsoOHkiNTpgVEGyEWVZzBtF6Sz5v/Fkg==",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
@@ -90,9 +90,9 @@
       "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -920,11 +920,11 @@
       }
     },
     "@redocly/openapi-cli": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.89.tgz",
-      "integrity": "sha512-kQxBdHKKVOaV3jfWMTsqlgvDAidm31wG5dD6DifDKZphQWqZam1gHXRMnF1mWyN4V9U4xza1cP3KIzCwb7vd1Q==",
+      "version": "1.0.0-beta.94",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.94.tgz",
+      "integrity": "sha512-VHPVIP4K+KgYLDbQXIONS6GRMLsYz7tKa3QVVk83KS7X58fFC/N48hB1Ap2vnryj8HLSrG0yP9y6ZGH1t7kv7g==",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.89",
+        "@redocly/openapi-core": "1.0.0-beta.94",
         "@types/node": "^14.11.8",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
@@ -938,9 +938,9 @@
       }
     },
     "@redocly/openapi-core": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.89.tgz",
-      "integrity": "sha512-3+k9oIBhCcs7LJ50eCWB6FdwV4pDH06d613pwFo5F2TmDPviNVWothj3CO/BheDz24tc9K8xR5pQuECE65qr/w==",
+      "version": "1.0.0-beta.94",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.94.tgz",
+      "integrity": "sha512-xTklcobv+51bQVkUOpUiNY0GztL+0u3yGsy2BtldaHpcnNGMu3lu/utsoOHkiNTpgVEGyEWVZzBtF6Sz5v/Fkg==",
       "requires": {
         "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
@@ -974,9 +974,9 @@
       "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1010,9 +1010,9 @@
       }
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -1267,9 +1267,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rebilly-openapi-spec",
   "version": "0.0.3",
   "dependencies": {
-    "@redocly/openapi-cli": "1.0.0-beta.89"
+    "@redocly/openapi-cli": "1.0.0-beta.94"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
https://redocly.com/docs/cli/changelog/

To prepare for using newer features including assertions released in beta.92.