### PR TITLE
chore: remove superfluous rules already included in recommended ruleset

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -8,23 +8,16 @@ lint:
     - ./plugins/custom-rules.js
     - ./plugins/products-bundler/bundler.js
   rules:
-    tag-description: off
-    no-server-trailing-slash: error
-    operation-summary: error
-    no-unresolved-refs: error
+    no-ambiguous-paths: error
     no-unused-components: error
     operation-2xx-response: error
     operation-operationId: error
     operation-singular-tag: error
-    no-enum-type-mismatch: error
-    no-path-trailing-slash: error
-    path-not-include-query: error
-    no-identical-paths: error
-    no-ambiguous-paths: error
+    operation-4xx-response: off
+    tag-description: off
     custom-rules/description-punctuation: error
     custom-rules/has-sdk-operation-name: error
     custom-rules/no-unused-tags: warn
-    operation-4xx-response: off
   decorators:
     products-bundler/bundle: error
 features.openapi:
@@ -62,6 +55,8 @@ features.openapi:
       - lang: Java
       - lang: Go
       - lang: Ruby
-  schemaExpansionLevel: 2
+      - lang: PHP
+  schemaExpansionLevel: '2'
   maxDisplayedEnumValues: 10
   showConsole: true
+  expandResponses: '200,201'


### PR DESCRIPTION
This PR:

- Removes rules already included in the [recommended ruleset](https://github.com/Redocly/openapi-cli/blob/ed997e2586e7adb7e32d8107cac79c452891f765/packages/core/src/config/recommended.ts) with the same severity level.
- Reorders rules into alphabetical order.
- Toggles a few features:
  - PHP code samples
  - expand responses 200 or 201