### PR TITLE
Add property to InvoiceDiscount schema

### DIFF
--- a/openapi/components/schemas/Coupon/InvoiceDiscount.yaml
+++ b/openapi/components/schemas/Coupon/InvoiceDiscount.yaml
@@ -18,3 +18,7 @@ properties:
     description: Discount description.
   context:
     $ref: ./DiscountContext.yaml
+  included:
+    type: boolean
+    default: false
+    description: Whether or not the given `amount` was included in calculations.


### PR DESCRIPTION
Add a property to `InvoiceDiscount` schema to explain whether or not a discount was pre-calculated into total or not. By default it isn't. But this is to account for BxGy added item.

I'm open to suggestions. :)