### PR TITLE
Add ARPC and CLTV dashboard metrics

### DIFF
--- a/openapi/components/schemas/DashboardResponse.yaml
+++ b/openapi/components/schemas/DashboardResponse.yaml
@@ -34,6 +34,8 @@ items:
         - upgradesCount
         - downgradesCount
         - monthlyRecurringRevenue
+        - averageRevenuePerCustomer
+        - customerLifetimeValue
     humanName:
       type: string
       description: Metric name to display.
@@ -53,21 +55,26 @@ items:
           value:
             type: number
             format: double
+            nullable: true
             description: Segment value for the given date range.
           previousValue:
             type: number
             format: double
+            nullable: true
             description: >-
               Segment value for the previous date range (relative to the given date range).
           humanValue:
             type: string
+            nullable: true
             description: Human readable segment value (formatted with a currency sign).
           changeRatio:
             type: number
             format: double
+            nullable: true
             description: Ratio of current value per previous value null is infinity.
           humanChangeRatio:
             type: string
+            nullable: true
             description: >-
               Human readable change ratio (formatted percentage with a "%"
               sign), null is infinity.
@@ -83,4 +90,5 @@ items:
                   description: Entry date-time.
                 value:
                   type: number
+                  nullable: true
                   description: Entry value.


### PR DESCRIPTION
`customerLifetimeValue` might be null if no churn is occurring in a given month, so some fields are marked as nullable now.