### PR TITLE
Add merchant fields property to Skrill

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Skrill.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Skrill.yaml
@@ -29,4 +29,4 @@ allOf:
           merchantFields:
             type: string
             description: >-
-              A comma-separated list of name-value merchant field pairs (key1:value1, key2:value2).
+              A comma-separated list of name-value merchant field pairs (key1:value1,key2:value2).

--- a/openapi/components/schemas/GatewayAccountConfig/Skrill.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Skrill.yaml
@@ -23,3 +23,10 @@ allOf:
         required:
           - accountEmail
           - secretWord
+      settings:
+        type: object
+        properties:
+          merchantFields:
+            type: string
+            description: >-
+              A comma-separated list of name-value merchant field pairs (key1:value1, key2:value2).


### PR DESCRIPTION
There is a request to add `digitalShopId` field to the gateway account settings.

Skrill allows to send extra fields with `merchant_fields`. Instead of hardcoding `digitalShopId`, introduce merchant fields property where merchant can specify any custom fields: `digitalShopId:123,anotherField:456`