### PR TITLE
refactoring: `Transaction.paymentInstrument`

### DIFF
--- a/openapi/components/schemas/Common/CommonTransaction.yaml
+++ b/openapi/components/schemas/Common/CommonTransaction.yaml
@@ -134,8 +134,6 @@ properties:
     type: integer
     readOnly: true
     x-sortable: true
-  paymentInstrument:
-    $ref: ../Storefront/PaymentInstruments/InstrumentReference.yaml
   billingAddress:
     description: Billing address.
     allOf:

--- a/openapi/components/schemas/PaymentInstruments/ValueObjects/CheckInstrument.yaml
+++ b/openapi/components/schemas/PaymentInstruments/ValueObjects/CheckInstrument.yaml
@@ -7,7 +7,7 @@ properties:
   method:
     type: string
     enum:
-      - cash
+      - check
   reference:
     description: Reference data.
     type: string

--- a/openapi/components/schemas/Storefront/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontTransaction.yaml
@@ -1,6 +1,8 @@
 allOf:
   - $ref: ../Common/CommonTransaction.yaml
   - properties:
+      paymentInstrument:
+        $ref: ./PaymentInstruments/InstrumentReference.yaml
       approvalUrl:
         description: The URL to redirect the end-customer when transaction `status` is `waiting-approval` or `offsite`.
         type: string


### PR DESCRIPTION
Moved Storefront specific field definition down to the Storefront schema and fixed check `enum` definition.