### PR TITLE
chore: use UpdatedTime.yaml schema for updatedTime props

### DIFF
--- a/openapi/components/schemas/Applications/Application.yaml
+++ b/openapi/components/schemas/Applications/Application.yaml
@@ -79,7 +79,7 @@ properties:
       Outlines the settings that app users can fill in when installing.
       Accepts [JSON-schema](https://json-schema.org/) drafts 4, 6 and 7.
     type: object
-    example: 
+    example:
       type: object
       properties:
         email:
@@ -94,9 +94,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Application updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Applications/ApplicationInstance.yaml
+++ b/openapi/components/schemas/Applications/ApplicationInstance.yaml
@@ -23,9 +23,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Application instance updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Attachment.yaml
+++ b/openapi/components/schemas/Attachment.yaml
@@ -44,9 +44,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Latest update date/time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/BalanceTransactions/BalanceTransaction.yaml
+++ b/openapi/components/schemas/BalanceTransactions/BalanceTransaction.yaml
@@ -62,6 +62,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Entry updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Blocklist.yaml
+++ b/openapi/components/schemas/Blocklist.yaml
@@ -34,9 +34,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: The blocklist updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/BroadcastMessages/BroadcastMessage.yaml
+++ b/openapi/components/schemas/BroadcastMessages/BroadcastMessage.yaml
@@ -134,9 +134,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The broadcast message's updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to the resource.

--- a/openapi/components/schemas/CheckoutForm/CommonCheckoutForm.yaml
+++ b/openapi/components/schemas/CheckoutForm/CommonCheckoutForm.yaml
@@ -152,6 +152,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Checkout form updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Common/CommonAlternativeInstrument.yaml
+++ b/openapi/components/schemas/Common/CommonAlternativeInstrument.yaml
@@ -30,8 +30,6 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The payment instrument updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml

--- a/openapi/components/schemas/Common/CommonBankAccount.yaml
+++ b/openapi/components/schemas/Common/CommonBankAccount.yaml
@@ -66,8 +66,6 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Bank account updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml

--- a/openapi/components/schemas/Common/CommonBillingPortal.yaml
+++ b/openapi/components/schemas/Common/CommonBillingPortal.yaml
@@ -95,6 +95,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Billing portal updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Common/CommonInvoice.yaml
+++ b/openapi/components/schemas/Common/CommonInvoice.yaml
@@ -160,10 +160,9 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Invoice updated time.
     x-sortable: true
     allOf:
-      - $ref: ../ServerTimestamp.yaml
+      - $ref: ../UpdatedTime.yaml
   paymentFormUrl:
     type: string
     readOnly: true

--- a/openapi/components/schemas/Common/CommonKhelocardCard.yaml
+++ b/openapi/components/schemas/Common/CommonKhelocardCard.yaml
@@ -44,8 +44,6 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The payment instrument updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml

--- a/openapi/components/schemas/Common/CommonKycDocument.yaml
+++ b/openapi/components/schemas/Common/CommonKycDocument.yaml
@@ -60,9 +60,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Latest update date/time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   processedTime:
     description: Processing date/time.
     allOf:

--- a/openapi/components/schemas/Common/CommonKycRequest.yaml
+++ b/openapi/components/schemas/Common/CommonKycRequest.yaml
@@ -51,6 +51,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Latest update date-time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Common/CommonPayPalAccount.yaml
+++ b/openapi/components/schemas/Common/CommonPayPalAccount.yaml
@@ -36,8 +36,6 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: PayPal account updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml

--- a/openapi/components/schemas/Common/CommonPaymentCard.yaml
+++ b/openapi/components/schemas/Common/CommonPaymentCard.yaml
@@ -79,8 +79,6 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Payment instrument updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml

--- a/openapi/components/schemas/Common/CommonPaymentToken.yaml
+++ b/openapi/components/schemas/Common/CommonPaymentToken.yaml
@@ -26,9 +26,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Token updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   usageTime:
     description: Token usage time.
     allOf:

--- a/openapi/components/schemas/Common/CommonPlan.yaml
+++ b/openapi/components/schemas/Common/CommonPlan.yaml
@@ -82,13 +82,11 @@ properties:
     type: integer
     readOnly: true
     description: |
-      Increments when the plan is modified. 
+      Increments when the plan is modified.
       Compare to materialized subscription items revision.
   createdTime:
     description: Plan created time.
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Plan updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Common/CommonProduct.yaml
+++ b/openapi/components/schemas/Common/CommonProduct.yaml
@@ -47,6 +47,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The product updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Common/CommonTransaction.yaml
+++ b/openapi/components/schemas/Common/CommonTransaction.yaml
@@ -199,8 +199,8 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Transaction updated time.
     x-label: Last update time
     x-sortable: true
     allOf:
-      - $ref: ../ServerTimestamp.yaml
+      - $ref: ../UpdatedTime.yaml
+

--- a/openapi/components/schemas/Coupon/Coupon.yaml
+++ b/openapi/components/schemas/Coupon/Coupon.yaml
@@ -56,11 +56,10 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Coupon updated time.
     x-label: Last update time
     x-sortable: true
     allOf:
-      - $ref: ../ServerTimestamp.yaml
+      - $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/CreditMemos/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemos/CreditMemo.yaml
@@ -138,9 +138,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Credit memo updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/CreditMemos/CreditMemoAllocation.yaml
+++ b/openapi/components/schemas/CreditMemos/CreditMemoAllocation.yaml
@@ -26,10 +26,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Credit memo allocation update time.
-    readOnly: true
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to the resource.

--- a/openapi/components/schemas/CustomDomain.yaml
+++ b/openapi/components/schemas/CustomDomain.yaml
@@ -15,6 +15,4 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Custom domain updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -48,9 +48,8 @@ properties:
   updatedTime:
     x-sortable: true
     x-label: Last Update Time
-    description: The customer updated time.
     allOf:
-      - $ref: ./ServerTimestamp.yaml
+      - $ref: UpdatedTime.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   primaryAddress:

--- a/openapi/components/schemas/CustomerAuthentication/CustomerJWT.yaml
+++ b/openapi/components/schemas/CustomerAuthentication/CustomerJWT.yaml
@@ -48,9 +48,7 @@ properties:
     format: date-time
     readOnly: true
   updatedTime:
-    description: Session updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   expiredTime:
     description: Session expired time. Defaults to one hour.
     type: string

--- a/openapi/components/schemas/DataExports/DataExport.yaml
+++ b/openapi/components/schemas/DataExports/DataExport.yaml
@@ -104,9 +104,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Data export updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   status:
     description: Status of export request.
     readOnly: true

--- a/openapi/components/schemas/Dispute.yaml
+++ b/openapi/components/schemas/Dispute.yaml
@@ -259,9 +259,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Dispute updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Edd/Edd.yaml
+++ b/openapi/components/schemas/Edd/Edd.yaml
@@ -21,9 +21,7 @@ properties:
     format: date-time
     nullable: true
   updatedTime:
-    description: The EDD score updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+++ b/openapi/components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
@@ -51,6 +51,4 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/EmailMessages/EmailMessage.yaml
+++ b/openapi/components/schemas/EmailMessages/EmailMessage.yaml
@@ -102,9 +102,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The email message's updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to the resource.

--- a/openapi/components/schemas/Fees/BaseFee.yaml
+++ b/openapi/components/schemas/Fees/BaseFee.yaml
@@ -28,9 +28,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Fee updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Files/File.yaml
+++ b/openapi/components/schemas/Files/File.yaml
@@ -57,9 +57,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The latest update date/time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   isPublic:
     description: >-
       Is the file available publicly (without authentication). If true, the

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -335,9 +335,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Gateway Account updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   organizationId:
     deprecated: true
     readOnly: true

--- a/openapi/components/schemas/GatewayAccountLimit.yaml
+++ b/openapi/components/schemas/GatewayAccountLimit.yaml
@@ -57,9 +57,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Gateway account limit updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -44,10 +44,9 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: List updated time.
     x-label: Last update time
     allOf:
-      - $ref: ./ServerTimestamp.yaml
+      - $ref: UpdatedTime.yaml
   _links:
     type: array
     description: Links related to resource.

--- a/openapi/components/schemas/Invoices/InvoiceItem.yaml
+++ b/openapi/components/schemas/Invoices/InvoiceItem.yaml
@@ -55,9 +55,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Invoice item updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   tax:
     description: Invoice item tax.
     readOnly: true

--- a/openapi/components/schemas/OrganizationExports/OrganizationExport.yaml
+++ b/openapi/components/schemas/OrganizationExports/OrganizationExport.yaml
@@ -36,10 +36,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Time at which the organization data export is updated.
-    readOnly: true
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   retentionTime:
     description: Retention end date. After this date, files will be removed.
     readOnly: true

--- a/openapi/components/schemas/Organizations/Organization.yaml
+++ b/openapi/components/schemas/Organizations/Organization.yaml
@@ -69,9 +69,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The organization updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Role.yaml
+++ b/openapi/components/schemas/Role.yaml
@@ -37,9 +37,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: The role updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: The links related to a resource.

--- a/openapi/components/schemas/Rules/RuleSet.yaml
+++ b/openapi/components/schemas/Rules/RuleSet.yaml
@@ -17,7 +17,7 @@ properties:
     items:
       $ref: ./Rule.yaml
   updatedTime:
-    $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Rules/RuleSetDraft.yaml
+++ b/openapi/components/schemas/Rules/RuleSetDraft.yaml
@@ -49,7 +49,8 @@ properties:
   createdTime:
     $ref: ../ServerTimestamp.yaml
   updatedTime:
-    $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
+
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Session.yaml
+++ b/openapi/components/schemas/Session.yaml
@@ -29,9 +29,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: Session updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   expiredTime:
     description: Session expired time. Defaults to one hour.
     type: string

--- a/openapi/components/schemas/ShippingRates/ShippingRate.yaml
+++ b/openapi/components/schemas/ShippingRates/ShippingRate.yaml
@@ -22,6 +22,4 @@ allOf:
         allOf:
           - $ref: ../ServerTimestamp.yaml
       updatedTime:
-        description: The shipping rate updated time.
-        allOf:
-          - $ref: ../ServerTimestamp.yaml
+        $ref: ../UpdatedTime.yaml

--- a/openapi/components/schemas/Storefront/Account.yaml
+++ b/openapi/components/schemas/Storefront/Account.yaml
@@ -34,9 +34,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The customer updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Storefront/Orders/StorefrontOrderMetadata.yaml
+++ b/openapi/components/schemas/Storefront/Orders/StorefrontOrderMetadata.yaml
@@ -7,9 +7,7 @@ properties:
     allOf:
       - $ref: ../../ServerTimestamp.yaml
   updatedTime:
-    description: Order updated time.
-    allOf:
-      - $ref: ../../ServerTimestamp.yaml
+    $ref: ../../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Storefront/StorefrontCustomerJWT.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontCustomerJWT.yaml
@@ -14,9 +14,7 @@ properties:
     allOf:
         - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Session updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   expiredTime:
     description: Session expired time. Defaults to one hour.
     type: string

--- a/openapi/components/schemas/Subscription/SubscriptionMetadata.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionMetadata.yaml
@@ -25,11 +25,10 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Order updated time.
     x-label: Last update time
     x-sortable: true
     allOf:
-      - $ref: ../ServerTimestamp.yaml
+      - $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Subscription/SubscriptionPause.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionPause.yaml
@@ -71,10 +71,7 @@ properties:
     format: date-time
     readOnly: true
   updatedTime:
-    description: The time of resource update.
-    type: string
-    format: date-time
-    readOnly: true
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Tags/Tag.yaml
+++ b/openapi/components/schemas/Tags/Tag.yaml
@@ -26,9 +26,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: The tag's updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/Timelines/CustomerTimelineCustomEvent.yaml
+++ b/openapi/components/schemas/Timelines/CustomerTimelineCustomEvent.yaml
@@ -19,9 +19,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Customer Timeline Custom event updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   _links:
     type: array
     description: The links related to resource.

--- a/openapi/components/schemas/UpdatedTime.yaml
+++ b/openapi/components/schemas/UpdatedTime.yaml
@@ -1,0 +1,4 @@
+type: string
+description: Read-only timestamp updates when the resource is updated.
+format: date-time
+readOnly: true

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -44,9 +44,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: The user updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   loginTime:
     description: The user last login time.
     allOf:

--- a/openapi/components/schemas/ValueList.yaml
+++ b/openapi/components/schemas/ValueList.yaml
@@ -26,9 +26,7 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   updatedTime:
-    description: List updated time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: UpdatedTime.yaml
   _links:
     type: array
     description: Links related to resource.

--- a/openapi/components/schemas/Websites/Website.yaml
+++ b/openapi/components/schemas/Websites/Website.yaml
@@ -28,9 +28,7 @@ properties:
     allOf:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
-    description: Website updated time.
-    allOf:
-      - $ref: ../ServerTimestamp.yaml
+    $ref: ../UpdatedTime.yaml
   customFields:
     $ref: ../ResourceCustomFields.yaml
   settings:

--- a/openapi/paths/application-instances@{applicationId}.yaml
+++ b/openapi/paths/application-instances@{applicationId}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   description: |
     Retrieve a list of application instances.
-    You may sort by the id, name, status, createdTime, and updatedTime.
+    You may sort by the `id`, `name`, `status`, `createdTime`, and `updatedTime`.
   responses:
     '200':
       description: An application instance was retrieved successfully.

--- a/openapi/paths/applications.yaml
+++ b/openapi/paths/applications.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAll
   description: |
     Retrieve a list of applications.
-    You may sort by the id, name, status, createdTime, and updatedTime.
+    You may sort by the `id`, `name`, `status`, `createdTime`, and `updatedTime`.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml

--- a/openapi/paths/attachments.yaml
+++ b/openapi/paths/attachments.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAllAttachments
   description: |
     Retrieve a list of attachments.
-    You may sort by the id, name, relatedId, relatedType, fileId, createdTime, and updatedTime.
+    You may sort by the `id`, `name`, `relatedId`, `relatedType`, `fileId`, `createdTime`, and `updatedTime`.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml


### PR DESCRIPTION
Streamline the API definitions with specific schemas for specific fields. Saves almost 100 lines of yaml and is more clear to read and interpret.