### PR TITLE
Add detail to tag descriptions

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -26,13 +26,22 @@ servers:
     variables:
       organizationId:
         default: unknown
-        description: Your organization ID.
+        description: |-
+          Your organization ID. The organization ID describes your
+          organization in Rebilly. For information on how to obtain
+          your organization ID, see
+          [Obtain your organization ID and website ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
   - url: 'https://api.rebilly.com/organizations/{organizationId}'
     description: Live server
     variables:
       organizationId:
         default: unknown
-        description: Your organization ID.
+        description: |-
+          Your organization ID. The organization ID describes your
+          organization in Rebilly. For information on how to obtain
+          your organization ID, see
+          [Obtain your organization ID and website ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
+  - url: 'https://api.rebilly.com/organizations/{organizationId}'
 
 components:
   securitySchemes:
@@ -49,381 +58,613 @@ components:
 
 tags:
   - name: AML
-    description: |
-      AML, also known as Anti-Money-Laundering is an endpoint that searches multiple
-      PEP, Sanctions, and Adverse Media lists for listed identities or media for screening
-      purposes. Used during some transaction processing and on Contact creation, it helps
-      determine whether someone is blocklisted or has political or economic sanctions against
-      them.
+    description: |-
+      Anti-Money Laundering (AML) operations screen customers
+      to help prevent your business from becoming directly or
+      indirectly involved in criminal activity.
+
+      Use AML operations during customer creation, and some
+      transaction processing, to help determine if a potential
+      customer, or customer, has political or economic sanctions
+      against them.
+
+      AML operations search the following for screening purposes:
+      Politically Exposed Persons (PEPs) lists, sanction lists,
+      and adverse media lists.
   - name: Blocklists
-    description: |
-      Your blocklists contains values of customerIds, email addresses,
-      ipAddresses, bank identification numbers, countries or payment cards that
-      you do NOT want to do business with. They are a good tool for managing
-      risk. A blocklist entry that expires after a period of time we call a
-      greylist.
+    description: |-
+      Use blocklists help to prevent fraud and criminal activity.
+
+      Blocklists are lists of customer attribute values that are
+      blocked from buying from you. For example, if a customer
+      attempts to make a purchase from you with a credit card or
+      fingerprint that is in a blocklist, the transaction is blocked
+      and will not be processed.
+
+      Before a new transaction is processed in Rebilly, blocklists
+      are examined to check for attributes related to the entity.
+      If a match is detected, the operation is aborted. A blocklist
+      that expires after a period of time is called a greylist.
   - name: Coupons
-    description: >
-      Coupons allows to apply different types of discounts to Invoices,
-      Orders and Plans. Redeemed Coupons will be applied only to Invoices
-      with the same currency.
-  - name: Customers
-    description: |
-      Customers are your customers, sometimes known as accounts, clients,
-      members, patrons, or players in other systems.
-  - name: Customers Timeline
-    description: |
-      The customers timeline keeps an audit trail of changes and activity for each customer.
-  - name: Orders Timeline
-    description: |
-      The orders timeline keeps an audit trail of changes and activity for each order.
-  - name: Invoices Timeline
-    description: |
-      The invoices timeline keeps an audit trail of changes and activity for each invoice.
-  - name: Transactions Timeline
-    description: |
-      The transactions timeline keeps an audit trail of changes and activity for each transaction.
-  - name: Credit memos Timeline
-    description: |
-      The credit memos timeline keeps an audit trail of changes and activity for each credit memo.
-  - name: Rules Timeline
-    description: |
-      The rules timeline keeps an audit trail of changes and activity for each rule.
-  - name: Gateway Accounts Timeline
-    description: |
-      The gateway accounts timeline keeps an audit trail of changes and activity for each gateway account.
-  - name: KYC Documents
-    description: >
-      Request KYC documents from customers using the KYC request API which generates a signed link to the KYC document gatherer.
-      The types of documents to request:
-        - identity-proof
-        - address-proof
-        - purchase-proof
-        - funds-proof
-        - credit-file-proof
-
-      In the case that a `credit-file-proof` is requested in combination with `identity-proof` and `address-proof`, the `credit-file-proof` is attempted first.
-      If it is successful in validating the identity and address, then the KYC request is considered instantly fulfilled.
-      If it is not, or if you the `credit-file-proof` isn't requested, then redirect your customer to the KYC document gatherer to collect their KYC documents.
-      Rebilly parses and analyzes the documents and accepts or rejects them according to a configurable scoring algorithm.
-      When all of the document types in the KYC request are accepted, the status is considered fulfilled and the KYC request fulfilled webhook will be triggered.
-      If a document is accepted while unreviewed documents of the same type exist, the unreviewed documents will be archived and the archived webhook will be triggered.
-  - name: Customer Authentication
-    description: >
-      Create authentication credentials, login, logout, and verify your
-      customers.
-  - name: Custom Fields
-    description: |
-      Create additional custom fields for particular resources.  You may name,
-      describe, and determine the type of the schema.
-  - name: Disputes
-    description: |
-      Handle disputes (chargebacks and retrievals).
-  - name: Files
-    description: >
-      A File is an entity that can store a physical file and some metadata. It
-      also provides an easy access to
-
-      its size, mime-type, user-defined tags and description thus allowing easy
-      sorting and searching among stored
-
-      files.
-
-      There are several methods of file uploading available: multipart/form-data
-      encoded form, RAW POST (by sending
-
-      file contents as POST body), fetching from URL (by providing the file URL
-      via 'url' param)
-
-      Attachment is an entity that is used to link a File to one or multiple
-      objects like Customer, Dispute, Payment,
-
-      Transaction, Order, Plan, Product, Invoice, Note. That allows to
-      quickly find and use files related to
-
-      those specific entities.
-  - name: Invoices
-    description: >
-      Invoices leave a record for both you and your customer of the products
-      sold.
-  - name: Credit memos
-    description: >
-      A credit memo is a means of providing a customer with store credit.
-      A common use case for using a credit memo is to provide a customer with store credit, rather than a refund,
-      if the customer pays more than they owe or returns a product.
-  - name: Payment Instruments
-    description: >
-      The Payment Instrument allows you to accept a variety of payment methods through a single API.
-  - name: Payment Tokens
-    description: >
-      Payment tokens are used to reduce the scope of PCI DSS compliance.  A
-      payment
-
-      token can be made using a different authentication scheme (refer to the
-      public key
-
-      authentication scheme in the Authentication section), which allows you to
-
-      create a payment token directly from the browser, bypassing the need to
-      send
-
-      sensitive cardholder info to your servers.  We recommend using this with
-      our
-
-      Rebilly.js library, which helps you wire a form into this API resource and
-      create
-
-      payment tokens.
-  - name: Products
-    description: |
-      A product describes what you sell (goods or services).
-      A product determines how what you sell appears on invoices and receipts.
-      The pricing for products is set in Plans.  One product can have many
+    description: |-
+      Use coupons to reward customers, generate sales, or to test
+      new pricing strategies. Coupons enable you to apply different
+      types of discounts to invoices, subscriptions, and pricing
       plans.
+
+      Redeemed coupons are attached to a customer's account.
+      Depending on the coupon's restrictions, the redeemed coupons
+      are then applied from the customer's account to subsequent
+      invoices or subscriptions. Redeemed coupons can only be applied
+      to invoices of the same currency.
+
+      Once a coupon is redeemed it cannot be modified. You may
+      deactivate a coupon or create a new coupon, but you cannot
+      reuse the same coupon code. If you have a use case where you
+      must reuse the same code,
+      [contact Rebilly](https://www.rebilly.com/contact/).
+  - name: Customers
+    description: |-
+      A customer is an entity that purchases goods or services from
+      you (a merchant), and is the payee in any transaction that is
+      credited to you. Customers are associated with payment
+      instruments, subscriptions, invoices, and other miscellaneous
+      relationship models.
+
+      In other systems, customers may be referred to as accounts,
+      clients, members, patrons, or players. For information on the
+      customer resource, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Customers Timeline
+    description: >-
+      Customer timelines maintain an audit trail of changes and
+      activity for each customer.
+  - name: Orders Timeline
+    description: >-
+      Order timelines maintain an audit trail of changes and activity
+      for each order.
+  - name: Invoices Timeline
+    description: >-
+      Invoice timelines maintain an audit trail of changes and
+      activity for each invoice.
+  - name: Transactions Timeline
+    description: >-
+      Transaction timelines maintain an audit trail of changes and
+      activity for each transaction.
+  - name: Credit memos Timeline
+    description: >-
+      Credit memo timelines keeps an audit trail of changes and
+      activity for each credit memo.
+  - name: Rules Timeline
+    description: >-
+      Rule timelines maintain an audit trail of changes and activity
+      for each rule.
+  - name: Gateway Accounts Timeline
+    description: >-
+      Gateway account timelines maintain an audit trail of changes
+      and activity for each gateway account.
+  - name: KYC Documents
+    description: |-
+      Verify your customers identity by requesting Know Your Customer
+      (KYC) documents. The KYC document operations generate a signed
+      link to the Rebilly
+      [KYC document gatherer](https://www.rebilly.com/docs/kyc-and-aml/kyc-document-gatherer/).
+
+      Document types:
+        - `identity-proof`: Validates a customer's identity.
+        - `address-proof`: Validates a customer's address.
+        - `purchase-proof`: Validates a customer's purchase.
+        - `funds-proof`: Validates that a customer has funds.
+        - `credit-file-proof`: Verifies that there is an existing
+        credit file with two sources that match the customer's name,
+        DOB, and address.
+
+      Rebilly parses and analyzes the documents and accepts or
+      rejects them according to a configurable scoring algorithm.
+      When all document types in a KYC request are accepted,
+      the status is fulfilled, and the
+      [KYC request fulfilled webhook](https://www.rebilly.com/docs/dev-docs/api/operation/kyc-request-fulfilled/)
+      is emitted.
+
+      ## Credit file proof
+
+      The `credit-file-proof` KYC document request type is only
+      available in the API, this option is not available in the
+      [KYC document gatherer](https://www.rebilly.com/docs/kyc-and-aml/kyc-document-gatherer/).
+      This request verifies that there is an existing credit
+      file with two sources that match the person's name, DOB, and
+      address.
+
+      In Canada, to meet FINTRAC requirements, the `credit-file-proof`
+      KYC document request verifies the customer's name, address,
+      and date of birth with a credit agency.
+
+      If `credit-file-proof` is requested in combination with
+      `identity-proof` and `address-proof`, `credit-file-proof`
+      is validated first, then the customer's identity and address
+      are validated. If all three forms of proof are valid, the
+      KYC request is fulfilled. If `identity-proof` or `address-proof`
+      documents do not pass validation, redirect your customer to the
+      KYC document gatherer to collect their KYC documents.
+  - name: Customer Authentication
+    description: >-
+      Validate the identity of users and manage authentication
+      credentials.
+  - name: Custom Fields
+    description: |-
+      Use custom fields to extend a resource scheme to include custom
+      data that is not provided as a common field. Depending on the
+      resource on which the custom field is added, it will be
+      available in all related forms.
+
+      Example: A custom field called `preferredCommunicationChannel`
+      is added to the customer resource. It has two allowed values,
+      which are 'email' and 'phone'. When new customers are added,
+      they will be prompted to provide this information.
+      Alternatively, if the customer is manually added, a field for
+      this value is provided.
+
+      ```yaml
+      {
+        "customFields": {
+            "preferredCommunicationChannel": "email"
+        }
+      }
+      ```
+
+      For detailed information on Rebilly resources, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Disputes
+    description: |-
+      Use thes operations to manage disputes. A dispute occurs when a
+      customer contests a charge to their account. The dispute and
+      related information is made available to the merchant by the
+      bank or credit card company. The merchant then has the option to
+      represent the charge and win the case. This process is called
+      dispute resolution. If the merchant is unable to represent the
+      charge, the card issuer will typically rescind the sale and add
+      fees on top of the charge. This process is called a chargeback.
+  - name: Files
+    description: |-
+      Use the file entity to store files and related metadata. Files
+      can be sorted by size, MIME-type, user-defined tags, and
+      description.
+
+      The following methods are available to upload files:
+      multipart/form-data encoded form, RAW POST &mdash; by sending
+      the file contents as the POST body, and fetching from URL
+      &mdash; by providing the file URL using the 'url' parameter.
+
+      Use the attachments entity to link a file to one or multiple
+      objects, such as: customer, dispute, payment, transaction,
+      order, plan, product, invoice, or note. Attachments enable you
+      to quickly find and use files related to specific entities.
+  - name: Invoices
+    description: |-
+      An invoice is a bill for a list of goods or services provided.
+      If your invoice includes subscription items, it also includes
+      the corresponding service periods and prices. For information on
+      the invoice resource, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Credit Memos
+    description: |-
+      A credit memo is a means of providing a customer with store
+      credit. A common use case for using a credit memo is to provide
+      a customer with store credit, rather than a refund, if the
+      customer pays more than they owe or returns a product. For
+      information on the credit memo resource, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Payment Instruments
+    description: |-
+      Payment instrument is a term which describes any means of making
+      a digital payment, such as: credit cards, debit cards,
+      direct debits, payment service providers, and digital wallets.
+
+      A payment instrument is not a resource. It is a term used to
+      describe a specific set of resources, such as payment cards
+      and bank accounts. For more information on the payment
+      instruments, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Payment Tokens
+    description: |-
+      Use payment tokens to reduce the scope of
+      [PCI DSS compliance](https://www.rebilly.com/docs/pci-compliance/).
+
+      A payment token can be made using a different authentication
+      scheme, which enables you to create a payment token directly
+      from the browser, and bypasses the need to send
+      sensitive cardholder info to your servers. We recommend using
+      this with the Rebilly.js library, which helps you set a form
+      into this API resource and create payment tokens. For more
+      information, see the public key authentication scheme in the
+      [Authentication section](#section/Authentication).
+  - name: Products
+    description: |-
+      Products are the goods and services that your business sells. A
+      product also describes sales items on invoices and receipts.
+      Product pricing is defined in
+      [plans](https://www.rebilly.com/docs/dev-docs/api/tag/Plans/).
+      A product may have one or many plans.
+
+      For information on the product resource, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Plans
-    description: >
-      Plans are a template for making a subscription.  For example, you may have
-      a plan
+    description: |-
+      Pricing plans describe how the customer must pay for
+      [products](https://www.rebilly.com/docs/dev-docs/api/tag/Products/).
 
-      that has a 30-day free trial followed by a recurring charge of $19.95 per
-      month
+      Rebilly provides the following plan types:
 
-      until canceled.  The combination of the plan and a request to make an
-      order
+      - Trial only: Use this plan to create and offer a free or
+      discounted trial period for your product. For example, a free 2
+      week trail of an internet service. After the trial, the customer
+      can choose to sign up for a paid subscription, or stop using the
+      service.
+      - Recurring: Use this plan to create and offer a subscription
+      for your product. For example, a monthly subscription to an
+      internet service that is charged at 20 USD per month.
+      - One time sale: Use this plan to create and offer a one-off
+      sale for your products. For example, a one time purchase of two
+      bags of coffee.
 
-      will apply those instructions to create the invoices according to the
-      plan's
+      For information on the plans resource, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
 
-      schedule.
+      For information on plan pricing, see
+      [Pricing formulas](https://www.rebilly.com/docs/settings/pricing-formulas/).
   - name: Search
-    description: |
-      Search data including customers, invoices, orders, transactions and more.
-  - name: Shipping rates
-    description: >
-      A shipping rate contains a filter and a pricing for a specific shipping destination.
+    description: >-
+      Use search operations to search data on customers, invoices,
+      orders, transactions and more.
+  - name: Shipping Rates
+    description: >-
+      Use these operations to manage shipping rates. A shipping rate
+      contains a filter and a pricing for a specific shipping
+      destination.
   - name: Orders
-    description: >
-      An order applies a plan's template to create invoice(s) for a customer,
-      optionally at the appropriate scheduled intervals.
-      A subscription order may also determine if the payment
-      is collected automatically (with autopay set true).
+    description: |-
+      An order is a customer's request to purchase items. It can
+      contain subscription and one-time sale items. When an order
+      contains one or more subscription items, it is a subscription
+      order.
+
+      An order generates an invoice. A subscription order generates an
+      invoice for each service period.
+      For more information, see
+      [Orders](https://www.rebilly.com/docs/dev-docs/concepts/#orders).
   - name: Tags
-    description: |
-      Tag customers to better organize your data.
+    description: >-
+      Use tags to organize and categorize customers or KYC documents
+      based on keywords.
   - name: Transactions
     description: |-
-      Set up payment instruments for payments.
-      Authorize and hold funds.
-      Capture funds.
-      Make payments and payouts.
-      Refund transactions.
+      Use these operations to set up payment instruments for payments,
+      authorize and hold funds, capture funds, make payments, make
+      payouts, and refund transactions.
   - name: Fees
-    description: |
-      Buy and sell fees.
+    description: |-
+      Use fees to reconcile transactions with applicable fees and
+      discount rates. Fees are not applied to directly to transaction
+      amounts, they do not modify the transaction amount. Fees help to
+      describe each part of the transaction amount.
 
-      This API is experimental and not guaranteed to be backward compatible.
+      This API is experimental and not guaranteed to be backward
+      compatible.
   - name: API Keys
-    description: |
-      Always keep your API Keys private. When creating your API keys,
+    description: |-
+      Always keep your API keys private. When creating API keys,
       you can restrict them to a given set of permissions.
-      In addition to your API Keys, you may use
-      JSON Web Tokens (JWT) to authenticate to the API.  See
-      our [Sessions](https://user-api-docs.rebilly.com/#tag/JWT-Session) resource for more information.
-  - name: Balance transactions
-    description: |
-      Balance transactions API.
+      For information on how to create and manage API keys,
+      see [API keys](https://www.rebilly.com/docs/dev-docs/api-keys/).
 
-      This API is experimental and not guaranteed to be backward compatible.
+      In addition to API keys, you may use JSON Web Tokens (JWT)
+      to authenticate to the API. For more information, see
+      [JWT session](https://user-api-docs.rebilly.com/#tag/JWT-Session).
+  - name: Balance Transactions
+    description: >-
+      Use these operations to view and manage balance
+      transactions
+
+      This API is experimental and not guaranteed to be backward
+      compatible.
   - name: Billing Portals
-    description: |
-      Customer billing portals can be configured here. You can customize various
-      options that appear on your billing portals.
+    description: |-
+      Rebilly hosted billing portals provide secure, Rebilly hosted
+      pages, where customers can: view invoices, cancel subscriptions,
+      update payment instruments, and update their address.
   - name: Checkout Forms
-    description: |
-      Hosted checkout forms can be configured here. You can customize various
-      options that appear on your hosted checkout forms.
+    description: |-
+      Rebilly hosted checkout forms provide secure and compliant
+      checkouts. Checkout forms are customizable, and use fully
+      responsive design, built-in error messaging, validation, and
+      expedited checkout for returning customers.
   - name: Email Credentials
-    description: |
-      Get and create SMTP credential hashes.
+    description: >-
+      Use these operations to get, create, and manage SMTP credential
+      hashes.
   - name: Gateway Accounts
-    description: |
-      Gateway accounts connect payment request to third party networks and platforms.
+    description: |-
+      A payment gateway is a service which enables merchants to
+      receive payments from their customers to their merchant account.
+      A merchant account is a bank account that enables businesses to
+      receive payments. Use payment gateway accounts to connect
+      payment requests to third party networks and platforms.
   - name: Lists
-    description: |
-      Lists contain sets of values and may be referenced within Rules criteria.
+    description: |-
+      Lists contain sets of values that may be referenced when setting
+      conditions for rules. Commonly used lists contain values related
+      to conditions that target specific properties such as: customers,
+      transactions, or BINs.
 
-      List order may not be maintained and duplicates may be removed.
+      You may grant edit lists permission to members of your team
+      without enabling them to edit rules. This may be useful if your
+      workflow involves frequent updates to value sets that are used
+      in rule or bind conditions. List order may not be maintained and
+      duplicates may be removed.
 
-      You may grant permissions to edit Lists to different people than those who can edit Rules.
-      It may be useful if your workflow involves frequent updates to value sets used in criteria.
+      For more information, see
+      Value lists](https://www.rebilly.com/docs/automations/create-a-value-list/#value-lists).
   - name: Organizations
-    description: |
-      Organization is an entity that represents you, or your company, as a merchant. You can have multiple organizations.
+    description: |-
+      An organization is an entity that represents you, or your
+      company, as a merchant. You can have multiple organizations.
+      For more information, see
+      [My organizations and websites](https://www.rebilly.com/docs/settings/organizations-and-websites/).
 
-      Note: Organizations are shared between "Live" and "Sandbox" environments.
+      Note: Organizations are shared between the live and sandbox
+      environments.
   - name: Profile
-    description: |
-      A Profile represents the person currently logged in to Rebilly.
-  - name: Reset password
-    description: |
-      When a password reset is requested, an email with a token is sent. Upon receiving the email
-      the user then needs to click a link and choose a new password.
+    description: >-
+      A profile represents the person that is signed in to Rebilly.
+  - name: Reset Password
+    description: >-
+      When a password reset is requested, an email with a token is
+      sent. In the email the user must click a reset link, and then
+      create a new password.
   - name: Rules
-    description: |
-      "Don't conform to the rules. Create the rules."
-      Rather than adapt your workflow and business, Rebilly can align with your business
-      objectives by giving you the power to automate certain behaviors when key events happen.
-      You can use this to your advantage to mitigate risk, maximize conversions and minimize costs.
-      You have the controls at your fingertips here. If you need more control,
-      or help dialing in on a strategy, feel free to contact us.
+    description: |-
+      In the Rebilly rules engine, an action is an operation that
+      executes when an event occurs. Action and event conditions are
+      defined in rules. Rulesets are collections of rules that are
+      associated with an event. The order in which the rules are
+      placed within a ruleset specifies the execution order.
 
-      When an event happens, it triggers the evaluation of conditions (that you set up),
-      in order from top to bottom. If the condition is met, the corresponding actions are executed.
-      The conditions continue to be checked until either all of the conditions have been executed,
-      or a special "stop" action is executed.
+      For information a list of events and related actions, see
+      [Events](https://www.rebilly.com/docs/automations/event-types/).
   - name: JWT Session
     description: |
-      A session contains a token, which is a JSON Web Token.  The token is created
-      with a user's sign in credentials.
+      A session contains a token, which is a JSON Web Token. The token
+      is created  with a user's sign in credentials.
 
-      This token can be used to authenticate to the API.  In addition, the session can be set to
-      expire at a particular time. Use the token to then authenticate for further requests to the Rebilly API.
+      This token can be used to authenticate to the API. In addition,
+      the session can be set to expire at a particular time. Use the
+      token to authenticate for further requests to the Rebilly API.
 
-      The token should be kept private, but could be stored on the user's browser
-      client to simulate a "session".
+      The token must be kept private, but can be stored on the
+      user's browser client to simulate a "session".
   - name: Status
-    description: |
-      Check the status of the Rebilly API (no authentication required).
+    description: >-
+      Check the status of the Rebilly API. No authentication is
+      required.
   - name: Tracking
-    description: |
-      Tracking is a layer for accessing all the activity (API requests,
-      subscriptions, webhooks, events, etc.), thus providing easier
-      debugging and issues auditing.
+    description: >-
+      Tracking is a layer for accessing all activity such as: API
+      requests, subscriptions, webhooks, events, and more. Use
+      tracking when debugging and auditing issues.
   - name: Users
-    description: |
-      A User represents a person who can login to Rebilly, and take actions subject to
-      their granted permissions.
+    description: >-
+      A user is a person who can login to Rebilly, and take actions
+      based on their granted permissions.
   - name: Websites
-    description: |
-      A Website represents the website/brand that customers interact with... You
-      could think of it like a brand.  For example, Nestle owns Perrier and Purina
-      and PowerBar.
+    description: |-
+      A website is where your organization obtains a customer. It is
+      also the processor account and billing descriptor used for
+      payment transactions. You can create multiple websites.
 
-      We recognize that some enterprises have more than one website (or brand).  The
-      website is related to each invoice and each payment gateway account.  This feature
-      would allow you to have gateway accounts that are related to multiple websites, or
-      exclusive to particular websites.  And gives you more control over your business.
+      Websites are related to each invoice and each payment
+      gateway account. This enables you to associate gateway accounts
+      with multiple websites, or make them exclusive to particular
+      websites. For more information, see
+      [My organizations and websites](https://www.rebilly.com/docs/settings/organizations-and-websites/).
   - name: Webhook Credentials
-    description: |
-      Get and create Webhook credential hashes.
+    description: >-
+      Use these operations to manage webhook credential hashes.
   - name: Webhooks
-    description: |
-      Webhooks are designed to notify your systems when certain/all registered events happen in near real-time.
-      They allow you to collect information about those events. Rebilly can send these information via
-      POST to an URL of your choice.
+    description: |-
+      Use these operations to manage webhooks. Webhooks notify your
+      systems in real-time when certain events occur. For example,
+      when a new transaction occurs or a new subscription is created.
+      Webhooks enable you to collect information about events. Rebilly
+      sends this information by HTTP POST request to a defined URL of
+      your choice.
   - name: Segments
-    description: |
-      Segments are grid UI settings that can be shared with other users. They are like a custom view.
-      For example, one may set up a transaction grid to show specific columns and sort a certain way, and share it with
-      others in their organization.
+    description: |-
+      Use these operations to manage UI segments. A segment is a
+      filtered view of a data set that can be shared with other users.
+      For example, you may create a transactions segment that displays
+      specific columns that are filtered and sorted based on certain
+      criteria, and share it with others in your organization.
   - name: Memberships
-    description: |
-      Membership describe the relationships between organizations and users.
-      For example, one user could have more than one organization.
+    description: |-
+      Use these operations to manage user membership within your
+      organizations. Membership describes the relationship between
+      organizations and users. For example, one user could be a member
+      of more than one organization.
   - name: Roles
-    description: |
-      Roles are an implementation of the general hierarchical RBAC. A senior role inherits all of it's juniors' ACLs plus its own ACL.
-      Junior roles are not influenced by the senior role.
+    description: |-
+      Use these operations to manage user roles within your team or
+      organization. Roles are an implementation of the general
+      hierarchical (Role Based Access Control) RBAC. A senior role
+      inherits all of its juniors' Access Control Lists (ACLs) and its
+      own ACL. Junior roles are not influenced by the senior role.
   - name: Integrations
-    description: |
-      Several applications can be integrated into Rebilly, such as: Google Sheets, Infusionsoft, QuickBooks Online, Wordpress, TaxJar, Plaid, Experian, MailChimp, Slack, Salesforce, and Xero. If you are PCI compliant, you can also integrate directly with Rebilly. For more information, see [Create a direct integration](https://www.rebilly.com/docs/billing/tutorial/create-a-direct-integration/#payment-integration).
+    description: |-
+      Use these operations to manage third-party apps that are
+      integrated to your Rebilly account. For more information on
+      third-party apps, and how to integrate them, see
+      [Integrations](https://www.rebilly.com/docs/automations/integrations/).
   - name: Broadcast Messages
-    description: |
-      Broadcast messages are emails that are sent to a specific group of customers, or all customers. Use broadcast messages to notify customers and leads about upcoming promotions, service updates, and local events. For more information, see [Create a broadcast message](https://www.rebilly.com/docs/concepts-and-features/tutorial/email-notifications/#create-a-broadcast-messages).
+    description: |-
+      Broadcast messages are emails that are sent to a specific group
+      of customers, or all customers. Use broadcast messages to notify
+      customers and leads about upcoming promotions, service updates,
+      and local events. For more information, see
+      [Create a broadcast message](https://www.rebilly.com/docs/automations/email-notifications/#create-a-broadcast-messages).
   - name: Email Delivery Settings
-    description: |
-      Use email delivery settings to configure from which email address notifications and broadcast message are sent. In Rebilly, this email address is referred to as a "From address". Supported email service providers are: SMPT, Mailgun, SendGrid, AWS SES, Postmark, and Rebilly.
+    description: |-
+      Use email delivery settings to configure from which email
+      address notifications and broadcast message are sent. In
+      Rebilly, this email address is referred to as a "From address".
+      Supported email service providers are: SMPT, Mailgun, SendGrid,
+      AWS SES, Postmark, and Rebilly.
   - name: Email Messages
-    description: |
-      Use email messages to email customers directly. For more information, see [Email messages](https://user-api-docs.rebilly.com/tag/Email-Messages).
+    description: >-
+      Use email messages to email customers directly.
   - name: Email Notifications
-    description: |
-      Email notifications are targeted email messages that can be plain text or HTML. Use email notifications to keep customers informed on events, and to inform them of events that may require action on their end. For more information, see [Email notifications](https://www.rebilly.com/docs/concepts-and-features/tutorial/email-notifications/).
-  - name: Plaid credentials
-    description: |
-      Plaid account credentials. Use the Plaid integration to verify a customer's bank credentials, and simplify the process of providing credentials for your customers. For more information, see [Plaid integration](enables merchants to verify a customer's bank credentials, and simplifies the process of providing these credentials for the customer).
-  - name: Experian credentials
-    description: |
-      Experian account credentials. Use the Experian integration for identity verification. For more information, see [Experian integration](https://www.rebilly.com/docs/risk/tutorial/experian-integration/#experian-integration).
-  - name: TaxJar credentials
-    description: |
-      TaxJar account credentials. Use the TaxJar integration to calculate taxes and create transactions for the Sales Tax AutoFile feature in your TaxJar account. For more information, see [TaxJar integration](https://www.rebilly.com/docs/billing/concept/taxes/#taxjar-integration).
+    description: |-
+      Email notifications are targeted email messages that can be
+      plain text or HTML. Use email notifications to keep customers
+      informed on events, and to inform them of events that may
+      require action on their end.
+
+      Email notifications can also be used to notify teammates about
+      new customers, blocklist matches, risk score changes, and more.
+      For more information, see [Email notifications](https://www.rebilly.com/docs/automations/email-notifications/).
+  - name: Plaid Credentials
+    description: |-
+      Use these operations to manage your Plaid account credentials.
+      The Plaid integration provides customer bank credential
+      verification, and simplifies the process of providing
+      credentials for your customers. For more information, see
+      [Plaid integration](https://www.rebilly.com/docs/automations/plaid-integration/).
+  - name: Experian Credentials
+    description: |-
+      Use these operations to manage your Experian account
+      credentials. The Experian integration provides identity
+      verification. For more information, see
+      [Experian integration](https://www.rebilly.com/docs/automations/experian-integration/#experian-integration).
+  - name: TaxJar Credentials
+    description: |-
+      Use these operations to manage your TaxJar account credentials.
+      The TaxJar integration enables you to calculate taxes and create
+      transactions for the Sales Tax AutoFile feature in your TaxJar
+      account. For more information, see
+      [TaxJar integration](https://www.rebilly.com/docs/automations/tax-jar-integration/#taxjar-integration).
   - name: Metadata
-    description: |
-      Metadata is data that provides structured information on other data.
-  - name: Custom domains
-    description: |
-      Custom domains enable you to use your own domain for forms and billing portals instead the default Rebilly domain:`portal.secure-payments.app`. For more information, see [Configure a custom domain](https://www.rebilly.com/docs/concepts-and-features/organizations-and-websites#configure-a-custom-domain).
+    description: >-
+      Metadata is data that structured information on other data.
+  - name: Custom Domains
+    description: |-
+      Custom domains enable you to use your own domain for forms and
+      billing portals, instead of the default Rebilly
+      domain:`portal.secure-payments.app`. For more information, see
+      [Configure a custom domain](https://www.rebilly.com/docs/settings/organizations-and-websites#configure-a-custom-domain).
   - name: Histograms
-    description: |
-      Histograms are for particular kinds of reports with cohorts and periods.
+    description: >-
+      Generate transaction histogram reports with cohorts and periods.
   - name: Reports
-    description: >
+    description: >-
       Retrieve summary information about your customers, subscriptions,
       transactions, and more.
   - name: Data Exports
-    description: |
-      Data exports allows you to export and schedule exports for different types of data.
-  - name: Organization data exports
-    description: |
-      Organization data exports allows you to export your organization's data which you may want to do as a business continuity practice.
-      In addition, it allows you to export data if you decide to migrate to a different payments solution.
+    description: |-
+      Use data export operations to manage the export of resource
+      data, such as: transactions, customers, subscriptions, invoices,
+      invoice item data, or revenue audit. Common data export use
+      cases are: accounting, data analysis, reporting, or importing
+      into other databases.
+
+      For detailed information on Rebilly resources, see
+      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+  - name: Organization Data Exports
+    description: |-
+      Use organization data exports to export your organization's data
+      which you may want to do as a business continuity practice.
+      These may also be used to to export data if you decide to
+      migrate to a different payments solution.
   - name: Rebilly API
-    description: |
-      The Rebilly API is the main API commonly integrated by 3rd parties.  You may see
-      the [Rebilly API Documentation here](https://api-reference.rebilly.com).
+    description: |-
+      The Rebilly API is a collection of the most commonly used
+      endpoints and operations.
+
+      Every action in the Rebilly
+      [frontend GUI application](https://app.rebilly.com/) is
+      supported by an API. These APIs are documented and you can use
+      them to automate any workflow.
+
+      For more information, see the
+      [Rebilly API](https://api-reference.rebilly.com).
   - name: Reports API
-    description: |
-      The Rebilly Reporting API is currently experimental.  You may see
-      the [Reports API Documentation here](https://reports-api-docs.rebilly.com).
+    description: |-
+      The Reports API is a collection of report related
+      endpoints and operations. This API is currently experimental.
+
+      Every action in the Rebilly
+      [frontend GUI application](https://app.rebilly.com/) is
+      supported by an API. These APIs are documented and you can use
+      them to automate any workflow.
+
+      For more information, see the
+      [Reports API](https://reports-api-docs.rebilly.com).
   - name: Storefront API
-    description: |
-      The Rebilly Storefront API is currently experimental.  You may see
-      the [Storefront API Documentation here](https://storefront-api-docs.rebilly.com/).
+    description: |-
+      The Storefront API is a collection of transaction related
+      endpoints and operations. This API is currently experimental.
+
+      Every action in the Rebilly
+      [frontend GUI application](https://app.rebilly.com/) is
+      supported by an API. These APIs are documented and you can use
+      them to automate any workflow.
+
+      For more information, see the
+      [Storefront API](https://storefront-api-docs.rebilly.com/).
   - name: Users API
-    description: >
-      The Rebilly User API is primarily for our GUI apps.  You may see
+    description: |-
+      The Users API is a collection of user related endpoints and
+      operations. A user represents a person who can log in to
+      Rebilly, and take actions based on their granted permissions,
+      and role.
 
-      the [User API Documentation
-      here](https://user-api-docs.rebilly.com).
+      Every action in the Rebilly
+      [frontend GUI application](https://app.rebilly.com/) is
+      supported by an API. These APIs are documented and you can use
+      them to automate any workflow.
 
-      A User represents a person who can login to Rebilly, and take actions
-      subject to
-
-      their granted permissions.  It has resources less commonly integrated by
-
-      3rd parties.
+      For more information, see the
+      [Rebilly User API](https://user-api-docs.rebilly.com).
   - name: Account
-    description: >
-      An account in which you are subscribed to in order to use the Rebilly product.
+    description: >-
+      An account in which you are subscribed to in order to use the
+      Rebilly product.
   - name: Authentication
+    description: >-
+      Process of confirming the identity of users that are attempting
+      to access resources on a server.
+  - name: Email Verification
     description: >
-      Process of confirming the identity of users that are attempting to access resources on a server.
-  - name: Email verification
-    description: >
-      Process of confirming that an email address exists and is associated with an individual.
-  - name: Password reset
-    description: >
+      Process of confirming that an email address exists and is
+      associated with an individual.
+  - name: Password Reset
+    description: >-
       Process of resetting a password for a user or organization.
   - name: Purchases
-    description: >
-      Transactions that have been executed related to the purchase of goods or services.
-  - name: Application owners
-    description: |
-      Creators of an organizations and organization owners in Rebilly.
-  - name: Application users
-    description: |
-      Users of an organization in Rebilly.
+    description: >-
+      Purchases are transactions that have been executed related to
+      the purchase of goods or services.
+  - name: Application Owners
+    description: |-
+      Application owners are members of your company or team that
+      create and manage one or more
+      [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
+      in Rebilly. For information on how to set user permissions, see
+      [Users](https://www.rebilly.com/docs/settings/users/).
+  - name: Application Users
+    description: |-
+      Application users are members of your company or team that use
+      one or more
+      [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
+      in Rebilly. For information on how to set user permissions, see
+      [Users](https://www.rebilly.com/docs/settings/users/).
 
 x-tagGroups: []
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -276,8 +276,7 @@ tags:
       sensitive cardholder info to your servers. We recommend using
       this with the Rebilly.js library, which helps you set a form
       into this API resource and create payment tokens. For more
-      information, see public key authentication scheme in the
-      [Authentication section](/#section/Authentication).
+      information, see the public key authentication scheme in the Authentication.
   - name: Products
     description: |-
       Products are the goods and services that your business sells. A

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -200,8 +200,7 @@ tags:
 
       Example: A custom field called `preferredCommunicationChannel`
       is added to the customer resource. It has two allowed values,
-      which are 'email' and 'phone'. When new customers are added,
-      they will be prompted to provide this information.
+      which are 'email' and 'phone'.
 
       ```yaml
       {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -41,7 +41,6 @@ servers:
           organization in Rebilly. For information on how to obtain
           your organization ID, see
           [Obtain your organization ID and website ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
-  - url: 'https://api.rebilly.com/organizations/{organizationId}'
 
 components:
   securitySchemes:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -274,7 +274,8 @@ tags:
       sensitive cardholder info to your servers. We recommend using
       this with the FramePay library, which helps you set a form
       into this API resource and create payment tokens. For more
-      information, see the public key authentication scheme in the Authentication.
+      information, see the public key authentication scheme in the 
+      [Authentication section](./overview/#section/Authentication/).
   - name: Products
     description: |-
       Use products to describe the goods and services that your

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -276,8 +276,8 @@ tags:
       sensitive cardholder info to your servers. We recommend using
       this with the Rebilly.js library, which helps you set a form
       into this API resource and create payment tokens. For more
-      information, see the public key authentication scheme in the
-      [Authentication section](#section/Authentication).
+      information, see public key authentication scheme in the
+      [Authentication section](/#section/Authentication).
   - name: Products
     description: |-
       Products are the goods and services that your business sells. A

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -115,35 +115,35 @@ tags:
       clients, members, patrons, or players. For information on the
       customer resource, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
-  - name: Customers Timeline
+  - name: Customers timeline
     description: >-
       Customer timelines maintain an audit trail of changes and
       activity for each customer.
-  - name: Orders Timeline
+  - name: Orders timeline
     description: >-
       Order timelines maintain an audit trail of changes and activity
       for each order.
-  - name: Invoices Timeline
+  - name: Invoices timeline
     description: >-
       Invoice timelines maintain an audit trail of changes and
       activity for each invoice.
-  - name: Transactions Timeline
+  - name: Transactions timeline
     description: >-
       Transaction timelines maintain an audit trail of changes and
       activity for each transaction.
-  - name: Credit memos Timeline
+  - name: Credit memos timeline
     description: >-
       Credit memo timelines keeps an audit trail of changes and
       activity for each credit memo.
-  - name: Rules Timeline
+  - name: Rules timeline
     description: >-
       Rule timelines maintain an audit trail of changes and activity
       for each rule.
-  - name: Gateway Accounts Timeline
+  - name: Gateway accounts timeline
     description: >-
       Gateway account timelines maintain an audit trail of changes
       and activity for each gateway account.
-  - name: KYC Documents
+  - name: KYC documents
     description: |-
       Verify your customers identity by requesting Know Your Customer
       (KYC) documents. The KYC document operations generate a signed
@@ -186,11 +186,11 @@ tags:
       KYC request is fulfilled. If `identity-proof` or `address-proof`
       documents do not pass validation, redirect your customer to the
       KYC document gatherer to collect their KYC documents.
-  - name: Customer Authentication
+  - name: Customer authentication
     description: >-
       Validate the identity of users and manage authentication
       credentials.
-  - name: Custom Fields
+  - name: Custom fields
     description: |-
       Use custom fields to extend a resource scheme to include custom
       data that is not provided as a common field. Depending on the
@@ -246,7 +246,7 @@ tags:
       the corresponding service periods and prices. For information on
       the invoice resource, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
-  - name: Credit Memos
+  - name: Credit memos
     description: |-
       A credit memo is a means of providing a customer with store
       credit. A common use case for using a credit memo is to provide
@@ -254,7 +254,7 @@ tags:
       customer pays more than they owe or returns a product. For
       information on the credit memo resource, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
-  - name: Payment Instruments
+  - name: Payment instruments
     description: |-
       Payment instrument is a term which describes any means of making
       a digital payment, such as: credit cards, debit cards,
@@ -265,7 +265,7 @@ tags:
       and bank accounts. For more information on the payment
       instruments, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
-  - name: Payment Tokens
+  - name: Payment tokens
     description: |-
       Use payment tokens to reduce the scope of
       [PCI DSS compliance](https://www.rebilly.com/docs/pci-compliance/).
@@ -316,7 +316,7 @@ tags:
     description: >-
       Use search operations to search data on customers, invoices,
       orders, transactions and more.
-  - name: Shipping Rates
+  - name: Shipping rates
     description: >-
       Use these operations to manage shipping rates. A shipping rate
       contains a filter and a pricing for a specific shipping
@@ -360,29 +360,29 @@ tags:
       In addition to API keys, you may use JSON Web Tokens (JWT)
       to authenticate to the API. For more information, see
       [JWT session](https://user-api-docs.rebilly.com/#tag/JWT-Session).
-  - name: Balance Transactions
+  - name: Balance transactions
     description: >-
       Use these operations to view and manage balance
       transactions
 
       This API is experimental and not guaranteed to be backward
       compatible.
-  - name: Billing Portals
+  - name: Billing portals
     description: |-
       Rebilly hosted billing portals provide secure, Rebilly hosted
       pages, where customers can: view invoices, cancel subscriptions,
       update payment instruments, and update their address.
-  - name: Checkout Forms
+  - name: Checkout forms
     description: |-
       Rebilly hosted checkout forms provide secure and compliant
       checkouts. Checkout forms are customizable, and use fully
       responsive design, built-in error messaging, validation, and
       expedited checkout for returning customers.
-  - name: Email Credentials
+  - name: Email credentials
     description: >-
       Use these operations to get, create, and manage SMTP credential
       hashes.
-  - name: Gateway Accounts
+  - name: Gateway accounts
     description: |-
       A payment gateway is a service which enables merchants to
       receive payments from their customers to their merchant account.
@@ -416,7 +416,7 @@ tags:
   - name: Profile
     description: >-
       A profile represents the person that is signed in to Rebilly.
-  - name: Reset Password
+  - name: Reset password
     description: >-
       When a password reset is requested, an email with a token is
       sent. In the email the user must click a reset link, and then
@@ -431,7 +431,7 @@ tags:
 
       For information a list of events and related actions, see
       [Events](https://www.rebilly.com/docs/automations/event-types/).
-  - name: JWT Session
+  - name: JWT session
     description: |
       A session contains a token, which is a JSON Web Token. The token
       is created  with a user's sign in credentials.
@@ -466,7 +466,7 @@ tags:
       with multiple websites, or make them exclusive to particular
       websites. For more information, see
       [My organizations and websites](https://www.rebilly.com/docs/settings/organizations-and-websites/).
-  - name: Webhook Credentials
+  - name: Webhook credentials
     description: >-
       Use these operations to manage webhook credential hashes.
   - name: Webhooks
@@ -503,24 +503,24 @@ tags:
       integrated to your Rebilly account. For more information on
       third-party apps, and how to integrate them, see
       [Integrations](https://www.rebilly.com/docs/automations/integrations/).
-  - name: Broadcast Messages
+  - name: Broadcast messages
     description: |-
       Broadcast messages are emails that are sent to a specific group
       of customers, or all customers. Use broadcast messages to notify
       customers and leads about upcoming promotions, service updates,
       and local events. For more information, see
       [Create a broadcast message](https://www.rebilly.com/docs/automations/email-notifications/#create-a-broadcast-messages).
-  - name: Email Delivery Settings
+  - name: Email delivery settings
     description: |-
       Use email delivery settings to configure from which email
       address notifications and broadcast message are sent. In
       Rebilly, this email address is referred to as a "From address".
       Supported email service providers are: SMPT, Mailgun, SendGrid,
       AWS SES, Postmark, and Rebilly.
-  - name: Email Messages
+  - name: Email messages
     description: >-
       Use email messages to email customers directly.
-  - name: Email Notifications
+  - name: Email notifications
     description: |-
       Email notifications are targeted email messages that can be
       plain text or HTML. Use email notifications to keep customers
@@ -530,20 +530,20 @@ tags:
       Email notifications can also be used to notify teammates about
       new customers, blocklist matches, risk score changes, and more.
       For more information, see [Email notifications](https://www.rebilly.com/docs/automations/email-notifications/).
-  - name: Plaid Credentials
+  - name: Plaid credentials
     description: |-
       Use these operations to manage your Plaid account credentials.
       The Plaid integration provides customer bank credential
       verification, and simplifies the process of providing
       credentials for your customers. For more information, see
       [Plaid integration](https://www.rebilly.com/docs/automations/plaid-integration/).
-  - name: Experian Credentials
+  - name: Experian credentials
     description: |-
       Use these operations to manage your Experian account
       credentials. The Experian integration provides identity
       verification. For more information, see
       [Experian integration](https://www.rebilly.com/docs/automations/experian-integration/#experian-integration).
-  - name: TaxJar Credentials
+  - name: TaxJar credentials
     description: |-
       Use these operations to manage your TaxJar account credentials.
       The TaxJar integration enables you to calculate taxes and create
@@ -553,7 +553,7 @@ tags:
   - name: Metadata
     description: >-
       Metadata is data that structured information on other data.
-  - name: Custom Domains
+  - name: Custom domains
     description: |-
       Custom domains enable you to use your own domain for forms and
       billing portals, instead of the default Rebilly
@@ -566,7 +566,7 @@ tags:
     description: >-
       Retrieve summary information about your customers, subscriptions,
       transactions, and more.
-  - name: Data Exports
+  - name: Data exports
     description: |-
       Use data export operations to manage the export of resource
       data, such as: transactions, customers, subscriptions, invoices,
@@ -576,7 +576,7 @@ tags:
 
       For detailed information on Rebilly resources, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
-  - name: Organization Data Exports
+  - name: Organization data exports
     description: |-
       Use organization data exports to export your organization's data
       which you may want to do as a business continuity practice.
@@ -640,25 +640,25 @@ tags:
     description: >-
       Process of confirming the identity of users that are attempting
       to access resources on a server.
-  - name: Email Verification
+  - name: Email verification
     description: >
       Process of confirming that an email address exists and is
       associated with an individual.
-  - name: Password Reset
+  - name: Password reset
     description: >-
       Process of resetting a password for a user or organization.
   - name: Purchases
     description: >-
       Purchases are transactions that have been executed related to
       the purchase of goods or services.
-  - name: Application Owners
+  - name: Application owners
     description: |-
       Application owners are members of your company or team that
       create and manage one or more
       [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
       in Rebilly. For information on how to set user permissions, see
       [Users](https://www.rebilly.com/docs/settings/users/).
-  - name: Application Users
+  - name: Application users
     description: |-
       Application users are members of your company or team that use
       one or more

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -275,7 +275,7 @@ tags:
       this with the FramePay library, which helps you set a form
       into this API resource and create payment tokens. For more
       information, see the public key authentication scheme in the 
-      [Authentication section](/tags#section/Authentication).
+      Authentication section.
   - name: Products
     description: |-
       Use products to describe the goods and services that your

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -64,7 +64,7 @@ tags:
 
       Use AML operations during customer creation, and some
       transaction processing, to help determine if a potential
-      customer, or customer, has political or economic sanctions
+      customer (lead), or customer, has political or economic sanctions
       against them.
 
       AML operations search the following for screening purposes:
@@ -72,7 +72,7 @@ tags:
       and adverse media lists.
   - name: Blocklists
     description: |-
-      Use blocklists help to prevent fraud and criminal activity.
+      Use blocklists to prevent fraud and criminal activity.
 
       Blocklists are lists of customer attribute values that are
       blocked from buying from you. For example, if a customer
@@ -108,8 +108,7 @@ tags:
       entity that purchases goods or services from you (a merchant),
       and is the payee in any transaction that is credited to you.
       Customers are associated with payment instruments,
-      subscriptions, invoices, and other miscellaneous relationship
-      models.
+      subscriptions, invoices, and other related resources.
 
       In other systems, customers may be referred to as accounts,
       clients, members, patrons, or players. For information on the

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -172,7 +172,7 @@ tags:
       available in the API, this option is not available in the
       [KYC document gatherer](https://www.rebilly.com/docs/kyc-and-aml/kyc-document-gatherer/).
       This request verifies that there is an existing credit
-      file with two sources that match the person's name, DOB, and
+      file with two sources that match the person's name, date of birth, and
       address.
 
       In Canada, to meet FINTRAC requirements, the `credit-file-proof`
@@ -398,7 +398,7 @@ tags:
       values related to conditions that target specific properties
       such as: customers, transactions, or BINs.
 
-      You may grant edit lists permission to members of your team
+      You may grant list edit permissions to members of your team
       without enabling them to edit rules. This may be useful if your
       workflow involves frequent updates to value sets that are used
       in rule or bind conditions. List order may not be maintained and
@@ -522,7 +522,7 @@ tags:
       Use email delivery settings to configure from which email
       address notifications and broadcast message are sent. In
       Rebilly, this email address is referred to as a "From address".
-      Supported email service providers are: SMPT, Mailgun, SendGrid,
+      Supported email service providers are: SMTP, Mailgun, SendGrid,
       AWS SES, Postmark, and Rebilly.
   - name: Email messages
     description: >-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -58,8 +58,8 @@ components:
 tags:
   - name: AML
     description: |-
-      Anti-Money Laundering (AML) operations screen customers
-      to help prevent your business from becoming directly or
+      Use Anti-Money Laundering (AML) operations to screen customers
+      and help prevent your business from becoming directly or
       indirectly involved in criminal activity.
 
       Use AML operations during customer creation, and some
@@ -76,9 +76,9 @@ tags:
 
       Blocklists are lists of customer attribute values that are
       blocked from buying from you. For example, if a customer
-      attempts to make a purchase from you with a credit card or
-      fingerprint that is in a blocklist, the transaction is blocked
-      and will not be processed.
+      attempts to make a purchase from you with a credit card that is
+      in a blocklist, the transaction is blocked and will not be
+      processed.
 
       Before a new transaction is processed in Rebilly, blocklists
       are examined to check for attributes related to the entity.
@@ -104,11 +104,12 @@ tags:
       [contact Rebilly](https://www.rebilly.com/contact/).
   - name: Customers
     description: |-
-      A customer is an entity that purchases goods or services from
-      you (a merchant), and is the payee in any transaction that is
-      credited to you. Customers are associated with payment
-      instruments, subscriptions, invoices, and other miscellaneous
-      relationship models.
+      Use these operations to manage customers. A customer is an
+      entity that purchases goods or services from you (a merchant),
+      and is the payee in any transaction that is credited to you.
+      Customers are associated with payment instruments,
+      subscriptions, invoices, and other miscellaneous relationship
+      models.
 
       In other systems, customers may be referred to as accounts,
       clients, members, patrons, or players. For information on the
@@ -116,37 +117,38 @@ tags:
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Customers timeline
     description: >-
-      Customer timelines maintain an audit trail of changes and
+      Use customer timelines to maintain an audit trail of changes and
       activity for each customer.
   - name: Orders timeline
     description: >-
-      Order timelines maintain an audit trail of changes and activity
-      for each order.
+      Use order timelines to maintain an audit trail of changes and
+      activity for each order.
   - name: Invoices timeline
     description: >-
-      Invoice timelines maintain an audit trail of changes and
+      Use invoice timelines to maintain an audit trail of changes and
       activity for each invoice.
   - name: Transactions timeline
     description: >-
-      Transaction timelines maintain an audit trail of changes and
-      activity for each transaction.
+      Use transaction timelines to maintain an audit trail of changes
+      and activity for each transaction.
   - name: Credit memos timeline
     description: >-
-      Credit memo timelines keeps an audit trail of changes and
-      activity for each credit memo.
+      Use credit memo timelines to maintain an audit trail of changes
+      and activity for each credit memo. Credit memos are a means of
+      providing a customer with store credit.
   - name: Rules timeline
     description: >-
-      Rule timelines maintain an audit trail of changes and activity
-      for each rule.
+      Use rule timelines to maintain an audit trail of changes and
+      activity for each rule.
   - name: Gateway accounts timeline
     description: >-
-      Gateway account timelines maintain an audit trail of changes
-      and activity for each gateway account.
+      Use gateway account timelines to maintain an audit trail of
+      changes and activity for each gateway account.
   - name: KYC documents
     description: |-
-      Verify your customers identity by requesting Know Your Customer
-      (KYC) documents. The KYC document operations generate a signed
-      link to the Rebilly
+      Use Know Your Customer (KYC) documents to verify your customers
+      identity. The KYC document operations generate a signed link to
+      the Rebilly
       [KYC document gatherer](https://www.rebilly.com/docs/kyc-and-aml/kyc-document-gatherer/).
 
       Document types:
@@ -179,29 +181,27 @@ tags:
       and date of birth with a credit agency.
 
       If `credit-file-proof` is requested in combination with
-      `identity-proof` and `address-proof`, `credit-file-proof`
-      is validated first, then the customer's identity and address
-      are validated. If all three forms of proof are valid, the
-      KYC request is fulfilled. If `identity-proof` or `address-proof`
-      documents do not pass validation, redirect your customer to the
-      KYC document gatherer to collect their KYC documents.
+      `identity-proof` and `address-proof`, `credit-file-proof` is
+      attempted first. If `credit-file-proof` validates the identity
+      and address, the KYC request is considered fulfilled. If the
+      request is not fulfilled, redirect your customer to the KYC
+      document gatherer to collect their KYC documents.
+
   - name: Customer authentication
     description: >-
-      Validate the identity of users and manage authentication
-      credentials.
+      Use these operations to validate the identity of users and
+      manage authentication credentials.
   - name: Custom fields
     description: |-
       Use custom fields to extend a resource scheme to include custom
       data that is not provided as a common field. Depending on the
       resource on which the custom field is added, it will be
-      available in all related forms.
+      available in the Rebilly UI.
 
       Example: A custom field called `preferredCommunicationChannel`
       is added to the customer resource. It has two allowed values,
       which are 'email' and 'phone'. When new customers are added,
       they will be prompted to provide this information.
-      Alternatively, if the customer is manually added, a field for
-      this value is provided.
 
       ```yaml
       {
@@ -215,7 +215,7 @@ tags:
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Disputes
     description: |-
-      Use thes operations to manage disputes. A dispute occurs when a
+      Use these operations to manage disputes. A dispute occurs when a
       customer contests a charge to their account. The dispute and
       related information is made available to the merchant by the
       bank or credit card company. The merchant then has the option to
@@ -235,19 +235,19 @@ tags:
       &mdash; by providing the file URL using the 'url' parameter.
 
       Use the attachments entity to link a file to one or multiple
-      objects, such as: customer, dispute, payment, transaction,
-      order, plan, product, invoice, or note. Attachments enable you
+      objects, such as: customer, dispute, transaction,
+      order, plan, product, invoice, or timeline comment. Attachments enable you
       to quickly find and use files related to specific entities.
   - name: Invoices
     description: |-
-      An invoice is a bill for a list of goods or services provided.
+      Use invoices to bill for the goods or services that you provide.
       If your invoice includes subscription items, it also includes
       the corresponding service periods and prices. For information on
       the invoice resource, see
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Credit memos
     description: |-
-      A credit memo is a means of providing a customer with store
+      Use credit memos to provide a customer with store
       credit. A common use case for using a credit memo is to provide
       a customer with store credit, rather than a refund, if the
       customer pays more than they owe or returns a product. For
@@ -255,7 +255,8 @@ tags:
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Payment instruments
     description: |-
-      Payment instrument is a term which describes any means of making
+      Use these operation to manage payment instruments. Payment
+      instrument is a term which describes any means of making
       a digital payment, such as: credit cards, debit cards,
       direct debits, payment service providers, and digital wallets.
 
@@ -273,22 +274,22 @@ tags:
       scheme, which enables you to create a payment token directly
       from the browser, and bypasses the need to send
       sensitive cardholder info to your servers. We recommend using
-      this with the Rebilly.js library, which helps you set a form
+      this with the FramePay library, which helps you set a form
       into this API resource and create payment tokens. For more
       information, see the public key authentication scheme in the Authentication.
   - name: Products
     description: |-
-      Products are the goods and services that your business sells. A
-      product also describes sales items on invoices and receipts.
-      Product pricing is defined in
+      Use products to describe the goods and services that your
+      business sells. A product also describes sales items on invoices
+      and receipts. Product pricing is defined in
       [plans](https://www.rebilly.com/docs/dev-docs/api/tag/Plans/).
       A product may have one or many plans.
 
       For information on the product resource, see
-      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+      [Product](https://www.rebilly.com/docs/dev-docs/concepts/#products).
   - name: Plans
     description: |-
-      Pricing plans describe how the customer must pay for
+      Use pricing plans to describe how the customer must pay for
       [products](https://www.rebilly.com/docs/dev-docs/api/tag/Products/).
 
       Rebilly provides the following plan types:
@@ -306,7 +307,7 @@ tags:
       bags of coffee.
 
       For information on the plans resource, see
-      [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
+      [Plans](https://www.rebilly.com/docs/dev-docs/concepts/#plans).
 
       For information on plan pricing, see
       [Pricing formulas](https://www.rebilly.com/docs/settings/pricing-formulas/).
@@ -348,8 +349,9 @@ tags:
 
       This API is experimental and not guaranteed to be backward
       compatible.
-  - name: API Keys
+  - name: API keys
     description: |-
+      Use API keys to identify and authenticate applications and users.
       Always keep your API keys private. When creating API keys,
       you can restrict them to a given set of permissions.
       For information on how to create and manage API keys,
@@ -367,11 +369,13 @@ tags:
       compatible.
   - name: Billing portals
     description: |-
+      Use these operations to create and manage billing portals.
       Rebilly hosted billing portals provide secure, Rebilly hosted
       pages, where customers can: view invoices, cancel subscriptions,
       update payment instruments, and update their address.
   - name: Checkout forms
     description: |-
+      Use these operations to create and manage checkout forms.
       Rebilly hosted checkout forms provide secure and compliant
       checkouts. Checkout forms are customizable, and use fully
       responsive design, built-in error messaging, validation, and
@@ -382,17 +386,18 @@ tags:
       hashes.
   - name: Gateway accounts
     description: |-
-      A payment gateway is a service which enables merchants to
+      Use these operations to manage payment gateway accounts. A
+      payment gateway is a service which enables merchants to
       receive payments from their customers to their merchant account.
       A merchant account is a bank account that enables businesses to
       receive payments. Use payment gateway accounts to connect
       payment requests to third party networks and platforms.
   - name: Lists
     description: |-
-      Lists contain sets of values that may be referenced when setting
-      conditions for rules. Commonly used lists contain values related
-      to conditions that target specific properties such as: customers,
-      transactions, or BINs.
+      Use lists to create and maintain sets of values that may be
+      referenced in rule conditions. Commonly used lists contain
+      values related to conditions that target specific properties
+      such as: customers, transactions, or BINs.
 
       You may grant edit lists permission to members of your team
       without enabling them to edit rules. This may be useful if your
@@ -401,9 +406,10 @@ tags:
       duplicates may be removed.
 
       For more information, see
-      Value lists](https://www.rebilly.com/docs/automations/create-a-value-list/#value-lists).
+      [Value lists](https://www.rebilly.com/docs/automations/create-a-value-list/#value-lists).
   - name: Organizations
     description: |-
+      Use these operations to manage your organizations in Rebilly.
       An organization is an entity that represents you, or your
       company, as a merchant. You can have multiple organizations.
       For more information, see
@@ -413,26 +419,28 @@ tags:
       environments.
   - name: Profile
     description: >-
-      A profile represents the person that is signed in to Rebilly.
+      Use these operations to manage user profiles. A profile
+      represents the person that is signed in to Rebilly.
   - name: Reset password
     description: >-
-      When a password reset is requested, an email with a token is
-      sent. In the email the user must click a reset link, and then
-      create a new password.
+      Use these operations to manage password resets. When a password
+      reset is requested, an email with a token is sent. In the email
+      the user must click a reset link, and then create a new password.
   - name: Rules
     description: |-
-      In the Rebilly rules engine, an action is an operation that
-      executes when an event occurs. Action and event conditions are
-      defined in rules. Rulesets are collections of rules that are
-      associated with an event. The order in which the rules are
-      placed within a ruleset specifies the execution order.
+      Use rules to automate. In the Rebilly rules engine, an action
+      is an operation that executes when an event occurs. Action and
+      event conditions are defined in rules. Rulesets are collections
+      of rules that are associated with an event. The order in which
+      the rules are placed within a ruleset specifies the execution order.
 
-      For information a list of events and related actions, see
+      For a list of events and related actions, see
       [Events](https://www.rebilly.com/docs/automations/event-types/).
   - name: JWT session
     description: |
-      A session contains a token, which is a JSON Web Token. The token
-      is created  with a user's sign in credentials.
+      Use these operations to manage JWT sessions. A session contains
+      a token, which is a JSON Web Token. The token is created  with a
+      user's sign in credentials.
 
       This token can be used to authenticate to the API. In addition,
       the session can be set to expire at a particular time. Use the
@@ -442,22 +450,24 @@ tags:
       user's browser client to simulate a "session".
   - name: Status
     description: >-
-      Check the status of the Rebilly API. No authentication is
-      required.
+      Use this operation to check the status of the Rebilly API. No
+      authentication is required.
   - name: Tracking
     description: >-
-      Tracking is a layer for accessing all activity such as: API
-      requests, subscriptions, webhooks, events, and more. Use
-      tracking when debugging and auditing issues.
+      Use tracking when debugging and auditing issues. Tracking is a
+      layer for accessing all activity such as: API requests,
+      subscriptions, webhooks, events, and more.
   - name: Users
     description: >-
-      A user is a person who can login to Rebilly, and take actions
-      based on their granted permissions.
+      Use these operations to manage users. A user is a person who
+      can login to Rebilly, and take actions based on their granted
+      permissions.
   - name: Websites
     description: |-
-      A website is where your organization obtains a customer. It is
-      also the processor account and billing descriptor used for
-      payment transactions. You can create multiple websites.
+      Use these operations to manage websites. A website is where
+      your organization obtains a customer. It is also the processor
+      account and billing descriptor used for payment transactions.
+      You can create multiple websites.
 
       Websites are related to each invoice and each payment
       gateway account. This enables you to associate gateway accounts
@@ -473,7 +483,7 @@ tags:
       systems in real-time when certain events occur. For example,
       when a new transaction occurs or a new subscription is created.
       Webhooks enable you to collect information about events. Rebilly
-      sends this information by HTTP POST request to a defined URL of
+      can send this information by HTTP POST request to a defined URL of
       your choice.
   - name: Segments
     description: |-
@@ -503,10 +513,10 @@ tags:
       [Integrations](https://www.rebilly.com/docs/automations/integrations/).
   - name: Broadcast messages
     description: |-
+      Use broadcast messages to notify customers and leads about
+      upcoming promotions, service updates, and events.
       Broadcast messages are emails that are sent to a specific group
-      of customers, or all customers. Use broadcast messages to notify
-      customers and leads about upcoming promotions, service updates,
-      and local events. For more information, see
+      of customers, or all customers. For more information, see
       [Create a broadcast message](https://www.rebilly.com/docs/automations/email-notifications/#create-a-broadcast-messages).
   - name: Email delivery settings
     description: |-
@@ -520,14 +530,15 @@ tags:
       Use email messages to email customers directly.
   - name: Email notifications
     description: |-
-      Email notifications are targeted email messages that can be
-      plain text or HTML. Use email notifications to keep customers
+      Use email notifications to keep customers
       informed on events, and to inform them of events that may
-      require action on their end.
+      require action on their end. Email notifications are targeted
+      email messages that can be plain text or HTML.
 
       Email notifications can also be used to notify teammates about
       new customers, blocklist matches, risk score changes, and more.
-      For more information, see [Email notifications](https://www.rebilly.com/docs/automations/email-notifications/).
+      For more information, see
+      [Email notifications](https://www.rebilly.com/docs/automations/email-notifications/).
   - name: Plaid credentials
     description: |-
       Use these operations to manage your Plaid account credentials.
@@ -550,20 +561,22 @@ tags:
       [TaxJar integration](https://www.rebilly.com/docs/automations/tax-jar-integration/#taxjar-integration).
   - name: Metadata
     description: >-
-      Metadata is data that structured information on other data.
+      Use these operations to retrieve and manage metadata. Metadata
+      is data that structured information on other data.
   - name: Custom domains
     description: |-
-      Custom domains enable you to use your own domain for forms and
-      billing portals, instead of the default Rebilly
+      Use custom domains to configure and use your own domain for
+      forms and billing portals, instead of the default Rebilly
       domain:`portal.secure-payments.app`. For more information, see
       [Configure a custom domain](https://www.rebilly.com/docs/settings/organizations-and-websites#configure-a-custom-domain).
   - name: Histograms
     description: >-
-      Generate transaction histogram reports with cohorts and periods.
+      Use histograms operations to generate transaction histogram reports
+      with cohorts and periods.
   - name: Reports
     description: >-
-      Retrieve summary information about your customers, subscriptions,
-      transactions, and more.
+      Use reports operations to retrieve summary information about
+      your customers, subscriptions, transactions, and more.
   - name: Data exports
     description: |-
       Use data export operations to manage the export of resource
@@ -632,34 +645,39 @@ tags:
       [Rebilly User API](https://user-api-docs.rebilly.com).
   - name: Account
     description: >-
-      An account in which you are subscribed to in order to use the
-      Rebilly product.
+      Use these operations to manage Rebilly accounts. An account in
+      which you are subscribed to in order to use the Rebilly product.
   - name: Authentication
     description: >-
-      Process of confirming the identity of users that are attempting
-      to access resources on a server.
+      Use these operations to manage the process of confirming the
+      identity of users that are attempting to access resources.
   - name: Email verification
     description: >
-      Process of confirming that an email address exists and is
-      associated with an individual.
+      Use these operations to manage email verification. Email
+      verification is the process of confirming that an email address
+      exists and is associated with an individual.
   - name: Password reset
     description: >-
-      Process of resetting a password for a user or organization.
+      Use these operations to manage password resets for a user or
+      organization.
   - name: Purchases
     description: >-
-      Purchases are transactions that have been executed related to
-      the purchase of goods or services.
+      Use these operations to manage purchases. Purchases are
+      transactions that have been executed related to the purchase of
+      goods or services.
   - name: Application owners
     description: |-
-      Application owners are members of your company or team that
-      create and manage one or more
+      Use these operations to manage application owners in your
+      organization or team. Application owners are members of your
+      company or team that create and manage one or more
       [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
       in Rebilly. For information on how to set user permissions, see
       [Users](https://www.rebilly.com/docs/settings/users/).
   - name: Application users
     description: |-
-      Application users are members of your company or team that use
-      one or more
+      Use these operations to manage application users in
+      your organization or team. Application users are members of your
+      company or team that use one or more
       [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
       in Rebilly. For information on how to set user permissions, see
       [Users](https://www.rebilly.com/docs/settings/users/).

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -165,7 +165,7 @@ tags:
       [KYC request fulfilled webhook](https://www.rebilly.com/docs/dev-docs/api/operation/kyc-request-fulfilled/)
       is emitted.
 
-      ## Credit file proof
+      ### Credit file proof
 
       The `credit-file-proof` KYC document request type is only
       available in the API, this option is not available in the

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -254,7 +254,7 @@ tags:
       [Resources](https://www.rebilly.com/docs/dev-docs/concepts/#resources).
   - name: Payment instruments
     description: |-
-      Use these operation to manage payment instruments. Payment
+      Use these operations to manage payment instruments. Payment
       instrument is a term which describes any means of making
       a digital payment, such as: credit cards, debit cards,
       direct debits, payment service providers, and digital wallets.
@@ -618,7 +618,7 @@ tags:
       [Reports API](https://reports-api-docs.rebilly.com).
   - name: Storefront API
     description: |-
-      The Storefront API is a collection of transaction related
+      The Storefront API is a collection of customer related
       endpoints and operations. This API is currently experimental.
 
       Every action in the Rebilly

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -665,20 +665,24 @@ tags:
       goods or services.
   - name: Application owners
     description: |-
-      Use these operations to manage application owners in your
-      organization or team. Application owners are members of your
-      company or team that create and manage one or more
+      To use these operations, you must be an
+      application owner. Application owners are members of your company
+      or team that create and manage one or more
       [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
-      in Rebilly. For information on how to set user permissions, see
-      [Users](https://www.rebilly.com/docs/settings/users/).
+      in Rebilly.
+
+      If you are an application owner, use these operations to manage
+      the applications that you own.
   - name: Application users
     description: |-
-      Use these operations to manage application users in
-      your organization or team. Application users are members of your
-      company or team that use one or more
+      To use these operations, you must be an
+      application user. Application users are members of your company
+      or team that use one or more
       [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
-      in Rebilly. For information on how to set user permissions, see
-      [Users](https://www.rebilly.com/docs/settings/users/).
+      in Rebilly.
+
+      If you are an application user, use these operations to manage
+      the applications that you use.
 
 x-tagGroups: []
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -665,24 +665,19 @@ tags:
       goods or services.
   - name: Application owners
     description: |-
-      To use these operations, you must be an
-      application owner. Application owners are members of your company
-      or team that create and manage one or more
-      [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
-      in Rebilly.
-
-      If you are an application owner, use these operations to manage
-      the applications that you own.
+      Use these operations to register applications to the Rebilly
+      Apps Store and manage application instances. An application
+      owner is a person or organization that has submitted an app to
+      the Rebilly App Store. For more information, see
+      [Submit an app](https://www.rebilly.com/docs/dev-docs/submit-a-rebilly-app/).
   - name: Application users
     description: |-
-      To use these operations, you must be an
-      application user. Application users are members of your company
-      or team that use one or more
-      [organizations](https://www.rebilly.com/docs/settings/organizations-and-websites/)
-      in Rebilly.
-
-      If you are an application user, use these operations to manage
-      the applications that you use.
+      Use these operations to install or uninstall apps from the
+      Rebilly App Store to your Rebilly account, and to manage
+      application instances. An application user is a person or
+      organization that uses an app that is installed from the
+      Rebilly App Store. For more information, see
+      [Install or uninstall an app](https://www.rebilly.com/docs/dev-docs/install-an-app/).
 
 x-tagGroups: []
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -275,7 +275,7 @@ tags:
       this with the FramePay library, which helps you set a form
       into this API resource and create payment tokens. For more
       information, see the public key authentication scheme in the 
-      [Authentication section](./overview/#section/Authentication/).
+      [Authentication section](/tags#section/Authentication).
   - name: Products
     description: |-
       Use products to describe the goods and services that your

--- a/openapi/paths/api-keys.yaml
+++ b/openapi/paths/api-keys.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - API Keys
+    - API keys
   summary: Retrieve a list of API keys
   operationId: GetApiKeyCollection
   x-sdk-operation-name: getAll
@@ -43,7 +43,7 @@ post:
   x-products:
     - Users
   tags:
-    - API Keys
+    - API keys
   summary: Create an API key
   operationId: PostApiKey
   x-sdk-operation-name: create

--- a/openapi/paths/api-keys@{id}.yaml
+++ b/openapi/paths/api-keys@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - API Keys
+    - API keys
   summary: Retrieve API key
   operationId: GetApiKey
   x-sdk-operation-name: get
@@ -34,7 +34,7 @@ put:
   x-products:
     - Users
   tags:
-    - API Keys
+    - API keys
   summary: Create or update API key with predefined ID
   operationId: PutApiKey
   x-sdk-operation-name: update
@@ -77,7 +77,7 @@ delete:
   x-products:
     - Users
   tags:
-    - API Keys
+    - API keys
   summary: Delete API key
   operationId: DeleteApiKey
   x-sdk-operation-name: delete

--- a/openapi/paths/authentication-options.yaml
+++ b/openapi/paths/authentication-options.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Read current authentication options
   operationId: GetAuthenticationOption
   x-sdk-operation-name: getAuthOptions
@@ -33,7 +33,7 @@ put:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Change authentication options
   operationId: PutAuthenticationOption
   x-sdk-operation-name: updateAuthOptions

--- a/openapi/paths/authentication-tokens.yaml
+++ b/openapi/paths/authentication-tokens.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Retrieve a list of auth tokens
   operationId: GetAuthenticationTokenCollection
   x-sdk-operation-name: getAllAuthTokens
@@ -43,7 +43,7 @@ post:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Login a customer
   operationId: PostAuthenticationToken
   x-sdk-operation-name: login

--- a/openapi/paths/authentication-tokens@{token}.yaml
+++ b/openapi/paths/authentication-tokens@{token}.yaml
@@ -9,7 +9,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Verify an authentication token
   operationId: GetAuthenticationTokenVerification
   x-sdk-operation-name: verify
@@ -44,7 +44,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Logout a customer
   operationId: DeleteAuthenticationToken
   x-sdk-operation-name: logout

--- a/openapi/paths/authentication-tokens@{token}@exchange.yaml
+++ b/openapi/paths/authentication-tokens@{token}@exchange.yaml
@@ -9,7 +9,7 @@ post:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Exchange an authentication token
   operationId: PostAuthenticationTokenExchange
   x-sdk-operation-name: exchangeToken

--- a/openapi/paths/billing-portals.yaml
+++ b/openapi/paths/billing-portals.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Retrieve a list of billing portals
   operationId: GetBillingPortalCollection
   x-sdk-operation-name: getAll
@@ -38,7 +38,7 @@ post:
   x-products:
     - Users
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Create a billing portal
   operationId: PostBillingPortal
   x-sdk-operation-name: create

--- a/openapi/paths/billing-portals@{id}.yaml
+++ b/openapi/paths/billing-portals@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Retrieve a billing portal
   operationId: GetBillingPortal
   x-sdk-operation-name: get
@@ -27,7 +27,7 @@ put:
   x-products:
     - Users
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Create or update a billing portal
   operationId: PutBillingPortal
   x-sdk-operation-name: update
@@ -66,7 +66,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Delete a billing portal
   operationId: DeleteBillingPortal
   x-sdk-operation-name: delete

--- a/openapi/paths/broadcast-messages.yaml
+++ b/openapi/paths/broadcast-messages.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Broadcast Messages
+    - Broadcast messages
   summary: Retrieve a list of broadcast messages
   operationId: GetBroadcastMessageCollection
   x-sdk-operation-name: getAll
@@ -37,7 +37,7 @@ post:
   x-products:
     - Users
   tags:
-    - Broadcast Messages
+    - Broadcast messages
   summary: Create a broadcast message
   operationId: PostBroadcastMessage
   x-sdk-operation-name: create

--- a/openapi/paths/broadcast-messages@{id}.yaml
+++ b/openapi/paths/broadcast-messages@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Broadcast Messages
+    - Broadcast messages
   summary: Retrieve a broadcast message
   operationId: GetBroadcastMessage
   x-sdk-operation-name: get
@@ -27,7 +27,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Broadcast Messages
+    - Broadcast messages
   summary: Delete a broadcast message
   operationId: DeleteBroadcastMessage
   x-sdk-operation-name: delete
@@ -40,7 +40,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Broadcast Messages
+    - Broadcast messages
   summary: Update a broadcast message
   operationId: PatchBroadcastMessage
   x-sdk-operation-name: update

--- a/openapi/paths/checkout-forms.yaml
+++ b/openapi/paths/checkout-forms.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Browse a list of checkout forms
   operationId: GetCheckoutFormCollection
   x-sdk-operation-name: getAll
@@ -38,7 +38,7 @@ post:
   x-products:
     - Users
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Create a checkout form
   operationId: PostCheckoutForm
   x-sdk-operation-name: create

--- a/openapi/paths/checkout-forms@{id}.yaml
+++ b/openapi/paths/checkout-forms@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Retrieve a checkout form
   operationId: GetCheckoutForm
   x-sdk-operation-name: get
@@ -27,7 +27,7 @@ put:
   x-products:
     - Users
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Create or update a checkout form
   operationId: PutCheckoutForm
   x-sdk-operation-name: update
@@ -66,7 +66,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Delete a checkout form
   operationId: DeleteCheckoutForm
   x-sdk-operation-name: delete

--- a/openapi/paths/credential-hashes@aws-ses.yaml
+++ b/openapi/paths/credential-hashes@aws-ses.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Create an AWS SES credential
   operationId: PostAwsSesCredentialHash
   x-sdk-operation-name: createAWSSESCredential

--- a/openapi/paths/credential-hashes@aws-ses@{hash}.yaml
+++ b/openapi/paths/credential-hashes@aws-ses@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Retrieve an AWS SES credential
   operationId: GetAwsSesCredentialHash
   x-sdk-operation-name: getAWSSESCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Update an AWS SES credential
   operationId: PatchAwsSesCredentialHash
   x-sdk-operation-name: updateAWSSESCredential

--- a/openapi/paths/credential-hashes@emails.yaml
+++ b/openapi/paths/credential-hashes@emails.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Create an email credential
   operationId: PostEmailCredentialHash
   x-sdk-operation-name: createEmailCredential

--- a/openapi/paths/credential-hashes@emails@{hash}.yaml
+++ b/openapi/paths/credential-hashes@emails@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Retrieve an email credential
   operationId: GetEmailCredentialHash
   x-sdk-operation-name: getEmailCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Update an email credential
   operationId: PatchEmailCredentialHash
   x-sdk-operation-name: patchEmailCredential

--- a/openapi/paths/credential-hashes@mailgun.yaml
+++ b/openapi/paths/credential-hashes@mailgun.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Create a mailgun credential
   operationId: PostMailgunCredentialHash
   x-sdk-operation-name: createMailgunCredential

--- a/openapi/paths/credential-hashes@mailgun@{hash}.yaml
+++ b/openapi/paths/credential-hashes@mailgun@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Retrieve a mailgun credential
   operationId: GetMailgunCredentialHash
   x-sdk-operation-name: getMailgunCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Update a mailgun credential
   operationId: PatchMailgunCredentialHash
   x-sdk-operation-name: patchMailgunCredential

--- a/openapi/paths/credential-hashes@oauth2.yaml
+++ b/openapi/paths/credential-hashes@oauth2.yaml
@@ -8,7 +8,7 @@ get:
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Retrieve a list of OAuth2 credentials
   operationId: GetOauth2CredentialHashCollection
   x-sdk-operation-name: getAllOAuth2Credentials
@@ -38,7 +38,7 @@ post:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Create OAuth2 credential
   operationId: PostOauth2CredentialHash
   x-sdk-operation-name: createOAuth2Credential

--- a/openapi/paths/credential-hashes@oauth2@{hash}.yaml
+++ b/openapi/paths/credential-hashes@oauth2@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Retrieve an OAuth2 credential
   operationId: GetOauth2CredentialHash
   x-sdk-operation-name: getOAuth2Credential
@@ -27,7 +27,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Update an OAuth2 credential
   operationId: PatchOauth2CredentialHash
   x-sdk-operation-name: updateOAuth2Credential

--- a/openapi/paths/credential-hashes@oauth2@{hash}@items.yaml
+++ b/openapi/paths/credential-hashes@oauth2@{hash}@items.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: List root items available for credential
   operationId: GetOauth2CredentialHashItemCollection
   x-sdk-operation-name: getOAuth2CredentialItems

--- a/openapi/paths/credential-hashes@postmark.yaml
+++ b/openapi/paths/credential-hashes@postmark.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Create a Postmark credential
   operationId: PostPostmarkCredentialHash
   x-sdk-operation-name: createPostmarkCredential

--- a/openapi/paths/credential-hashes@postmark@{hash}.yaml
+++ b/openapi/paths/credential-hashes@postmark@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Retrieve a Postmark credential
   operationId: GetPostmarkCredentialHash
   x-sdk-operation-name: getPostmarkCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Update a Postmark credential
   operationId: PatchPostmarkCredentialHash
   x-sdk-operation-name: patchPostmarkCredential

--- a/openapi/paths/credential-hashes@sendgrid.yaml
+++ b/openapi/paths/credential-hashes@sendgrid.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Create a SendGrid credential
   operationId: PostSendGridCredentialHash
   x-sdk-operation-name: createSendGridCredential

--- a/openapi/paths/credential-hashes@sendgrid@{hash}.yaml
+++ b/openapi/paths/credential-hashes@sendgrid@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Retrieve a SendGrid credential
   operationId: GetSendGridCredentialHash
   x-sdk-operation-name: getSendGridCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Credentials
+    - Email credentials
   summary: Update a SendGrid credential
   operationId: PatchSendGridCredentialHash
   x-sdk-operation-name: patchSendGridCredential

--- a/openapi/paths/credential-hashes@webhooks.yaml
+++ b/openapi/paths/credential-hashes@webhooks.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Create a webhook credential
   operationId: PostWebhookCredentialHash
   x-sdk-operation-name: createWebhookCredential

--- a/openapi/paths/credential-hashes@webhooks@{hash}.yaml
+++ b/openapi/paths/credential-hashes@webhooks@{hash}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Retrieve a webhook credential
   operationId: GetWebhookCredentialHash
   x-sdk-operation-name: getWebhookCredential
@@ -31,7 +31,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Webhook Credentials
+    - Webhook credentials
   summary: Update a webhook credential
   operationId: PatchWebhookCredentialHash
   x-sdk-operation-name: patchWebhookCredential

--- a/openapi/paths/credentials.yaml
+++ b/openapi/paths/credentials.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Retrieve a list of credentials
   operationId: GetCredentialCollection
   x-sdk-operation-name: getAllCredentials
@@ -42,7 +42,7 @@ post:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Create a credential
   operationId: PostCredential
   x-sdk-operation-name: createCredential

--- a/openapi/paths/credentials@{id}.yaml
+++ b/openapi/paths/credentials@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Retrieve a credential
   operationId: GetCredential
   x-sdk-operation-name: getCredential
@@ -34,7 +34,7 @@ put:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Create or update a credential with predefined ID
   operationId: PutCredential
   x-sdk-operation-name: updateCredential
@@ -82,7 +82,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Delete a credential
   operationId: DeleteCredential
   x-sdk-operation-name: deleteCredential

--- a/openapi/paths/credit-memos@{id}@timeline.yaml
+++ b/openapi/paths/credit-memos@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Credit memos Timeline
+    - Credit memos timeline
   summary: Retrieve a list of credit memo timeline messages
   operationId: GetCreditMemoTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -40,7 +40,7 @@ post:
   x-products:
     - Core
   tags:
-    - Credit memos Timeline
+    - Credit memos timeline
   summary: Create a credit memo timeline message
   operationId: PostCreditMemoTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/credit-memos@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/credit-memos@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Core
   tags:
-    - Credit memos Timeline
+    - Credit memos timeline
   summary: Retrieve a credit memo timeline message
   operationId: GetCreditMemoTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -34,7 +34,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Credit memos Timeline
+    - Credit memos timeline
   summary: Delete a credit memo timeline message
   operationId: DeleteCreditMemoTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/custom-fields@{resource}.yaml
+++ b/openapi/paths/custom-fields@{resource}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Custom Fields
+    - Custom fields
   summary: Retrieve Custom Fields
   operationId: GetCustomFieldCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/custom-fields@{resource}@{name}.yaml
+++ b/openapi/paths/custom-fields@{resource}@{name}.yaml
@@ -12,7 +12,7 @@ get:
   x-products:
     - Core
   tags:
-    - Custom Fields
+    - Custom fields
   summary: Retrieve a Custom Field
   operationId: GetCustomField
   x-sdk-operation-name: get
@@ -42,7 +42,7 @@ put:
   x-products:
     - Core
   tags:
-    - Custom Fields
+    - Custom fields
   summary: Create or alter a Custom Field
   operationId: PutCustomField
   x-sdk-operation-name: create

--- a/openapi/paths/customer-timeline-custom-events.yaml
+++ b/openapi/paths/customer-timeline-custom-events.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Retrieve a list of customer timeline custom event types
   operationId: GetCustomerTimelineCustomEventTypeCollection
   x-sdk-operation-name: getAll
@@ -38,7 +38,7 @@ post:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Create Customer Timeline custom event type
   operationId: PostCustomerTimelineCustomEventType
   x-sdk-operation-name: create

--- a/openapi/paths/customer-timeline-custom-events@{id}.yaml
+++ b/openapi/paths/customer-timeline-custom-events@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Retrieve customer timeline custom event type
   operationId: GetCustomerTimelineCustomEventType
   x-sdk-operation-name: get

--- a/openapi/paths/customers@{id}@timeline.yaml
+++ b/openapi/paths/customers@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Retrieve a list of customer timeline messages
   operationId: GetCustomerTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -44,7 +44,7 @@ post:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Create a customer Timeline comment or custom defined event
   operationId: PostCustomerTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/customers@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/customers@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Retrieve a customer Timeline message
   operationId: GetCustomerTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -37,7 +37,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Customers Timeline
+    - Customers timeline
   summary: Delete a Customer Timeline message
   operationId: DeleteCustomerTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/data-exports.yaml
+++ b/openapi/paths/data-exports.yaml
@@ -15,7 +15,7 @@ post:
   x-products:
     - Reports
   tags:
-    - Data Exports
+    - Data exports
   summary: Request a data export of selected resource
   operationId: PostDataExport
   x-sdk-operation-name: queue
@@ -49,7 +49,7 @@ get:
   x-products:
     - Reports
   tags:
-    - Data Exports
+    - Data exports
   summary: Retrieve a list of data export requests
   operationId: GetDataExportCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/data-exports@{id}.yaml
+++ b/openapi/paths/data-exports@{id}.yaml
@@ -17,7 +17,7 @@ get:
   x-products:
     - Reports
   tags:
-    - Data Exports
+    - Data exports
   summary: Retrieve a data export request
   operationId: GetDataExport
   x-sdk-operation-name: get
@@ -53,7 +53,7 @@ put:
   x-products:
     - Reports
   tags:
-    - Data Exports
+    - Data exports
   summary: Modify a data export
   operationId: PutDataExport
   x-sdk-operation-name: update
@@ -89,7 +89,7 @@ delete:
   x-products:
     - Reports
   tags:
-    - Data Exports
+    - Data exports
   summary: Delete a data export
   operationId: DeleteDataExport
   x-sdk-operation-name: delete

--- a/openapi/paths/digital-wallets@onboarding@apple-pay.yaml
+++ b/openapi/paths/digital-wallets@onboarding@apple-pay.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Register a domain for Apple Pay
   operationId: PostDigitalWalletOnboardingApplePay
   x-sdk-operation-name: create

--- a/openapi/paths/digital-wallets@validation.yaml
+++ b/openapi/paths/digital-wallets@validation.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Core
   tags:
-    - Payment Tokens
+    - Payment tokens
   summary: Validate a digital wallet session
   operationId: PostDigitalWalletValidation
   x-sdk-operation-name: validate

--- a/openapi/paths/email-delivery-setting-verifications@{token}.yaml
+++ b/openapi/paths/email-delivery-setting-verifications@{token}.yaml
@@ -4,7 +4,7 @@ put:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Verify an email delivery setting
   operationId: PutEmailDeliverySettingsVerification
   x-sdk-operation-name: verify

--- a/openapi/paths/email-delivery-settings.yaml
+++ b/openapi/paths/email-delivery-settings.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Retrieve a list of email delivery settings
   operationId: GetEmailDeliverySettingCollection
   x-sdk-operation-name: getAll
@@ -37,7 +37,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Create an email delivery setting
   operationId: PostEmailDeliverySetting
   x-sdk-operation-name: create

--- a/openapi/paths/email-delivery-settings@{id}.yaml
+++ b/openapi/paths/email-delivery-settings@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Retrieve an email delivery setting
   operationId: GetEmailDeliverySetting
   x-sdk-operation-name: get
@@ -30,7 +30,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Delete an email delivery setting
   operationId: DeleteEmailDeliverySetting
   x-sdk-operation-name: delete
@@ -45,7 +45,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Update an email delivery setting
   operationId: PatchEmailDeliverySettings
   x-sdk-operation-name: update

--- a/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
+++ b/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Delivery Settings
+    - Email delivery settings
   summary: Resend email delivery setting verification email
   operationId: PostResendEmailDeliverySettingVerification
   x-sdk-operation-name: resendVerification

--- a/openapi/paths/email-messages.yaml
+++ b/openapi/paths/email-messages.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Messages
+    - Email messages
   summary: Retrieve a list of email messages
   operationId: GetEmailMessageCollection
   x-sdk-operation-name: getAll
@@ -38,7 +38,7 @@ post:
   x-products:
     - Users
   tags:
-    - Email Messages
+    - Email messages
   summary: Create an email message
   operationId: PostEmailMessage
   x-sdk-operation-name: create

--- a/openapi/paths/email-messages@{id}.yaml
+++ b/openapi/paths/email-messages@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Messages
+    - Email messages
   summary: Retrieve an email message
   operationId: GetEmailMessage
   x-sdk-operation-name: get
@@ -27,7 +27,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Email Messages
+    - Email messages
   summary: Delete an email message
   operationId: DeleteEmailMessage
   x-sdk-operation-name: delete
@@ -42,7 +42,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Email Messages
+    - Email messages
   summary: Send an email message
   operationId: PatchEmailMessage
   x-sdk-operation-name: send

--- a/openapi/paths/email-notifications.yaml
+++ b/openapi/paths/email-notifications.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Notifications
+    - Email notifications
   summary: Retrieve a list of email notification events
   operationId: GetEmailNotificationCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/events@{eventType}@timeline.yaml
+++ b/openapi/paths/events@{eventType}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Rules Timeline
+    - Rules timeline
   summary: Retrieve a list of Rules Engine timeline messages
   operationId: GetRulesEngineTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -40,7 +40,7 @@ post:
   x-products:
     - Users
   tags:
-    - Rules Timeline
+    - Rules timeline
   summary: Create Rules Engine Timeline comment
   operationId: PostRulesEngineTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
+++ b/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Users
   tags:
-    - Rules Timeline
+    - Rules timeline
   summary: Retrieve Rules Engine Timeline message
   operationId: GetRulesEngineTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -33,7 +33,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Rules Timeline
+    - Rules timeline
   summary: Delete Rules Engine Timeline message
   operationId: DeleteRulesEngineTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/gateway-accounts.yaml
+++ b/openapi/paths/gateway-accounts.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve a list of gateway accounts
   operationId: GetGatewayAccountCollection
   x-sdk-operation-name: getAll
@@ -46,7 +46,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Create a Gateway Account
   operationId: PostGatewayAccount
   x-sdk-operation-name: create

--- a/openapi/paths/gateway-accounts@{id}.yaml
+++ b/openapi/paths/gateway-accounts@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve a Gateway Account
   operationId: GetGatewayAccount
   x-sdk-operation-name: get
@@ -34,7 +34,7 @@ put:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Create or update a Gateway Account with predefined ID
   operationId: PutGatewayAccount
   x-sdk-operation-name: update
@@ -77,7 +77,7 @@ patch:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Update a Gateway Account with predefined ID
   operationId: PatchGatewayAccount
   x-sdk-operation-name: update
@@ -108,7 +108,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Delete a Gateway Account
   operationId: DeleteGatewayAccount
   x-sdk-operation-name: delete

--- a/openapi/paths/gateway-accounts@{id}@check-credentials.yaml
+++ b/openapi/paths/gateway-accounts@{id}@check-credentials.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Check gateway account credentials
   operationId: PostGatewayAccountCheckCredentials
   x-sdk-operation-name: checkCredentials

--- a/openapi/paths/gateway-accounts@{id}@close.yaml
+++ b/openapi/paths/gateway-accounts@{id}@close.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Close a Gateway Account
   operationId: PostGatewayAccountClosure
   x-sdk-operation-name: close

--- a/openapi/paths/gateway-accounts@{id}@disable.yaml
+++ b/openapi/paths/gateway-accounts@{id}@disable.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Disable a Gateway Account
   operationId: PostGatewayAccountDisablement
   x-sdk-operation-name: disable

--- a/openapi/paths/gateway-accounts@{id}@downtime-schedules.yaml
+++ b/openapi/paths/gateway-accounts@{id}@downtime-schedules.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: List gateway account downtime schedules
   operationId: GetGatewayAccountDowntimeScheduleCollection
   x-sdk-operation-name: getAllDowntimeSchedules
@@ -44,7 +44,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Create a Gateway Account downtime schedule
   operationId: PostGatewayAccountDowntimeSchedule
   x-sdk-operation-name: createDowntimeSchedule

--- a/openapi/paths/gateway-accounts@{id}@downtime-schedules@{downtimeId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@downtime-schedules@{downtimeId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve a Gateway Downtime schedule
   operationId: GetGatewayAccountDowntimeSchedule
   x-sdk-operation-name: getDowntimeSchedule
@@ -38,7 +38,7 @@ put:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Update a Gateway Account downtime schedule
   operationId: PutGatewayAccountDowntimeSchedule
   x-sdk-operation-name: updateDowntimeSchedule
@@ -72,7 +72,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Delete a Gateway Account downtime schedule
   operationId: DeleteGatewayAccountDowntimeSchedule
   x-sdk-operation-name: deleteDowntimeSchedule

--- a/openapi/paths/gateway-accounts@{id}@enable.yaml
+++ b/openapi/paths/gateway-accounts@{id}@enable.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Enable a Gateway Account
   operationId: PostGatewayAccountEnablement
   x-sdk-operation-name: enable

--- a/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
+++ b/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve financial settings
   operationId: GetGatewayAccountFinancialSettings
   x-sdk-operation-name: getFinancialSettings
@@ -30,7 +30,7 @@ put:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Set financial settings
   operationId: PutGatewayAccountFinancialSettings
   x-sdk-operation-name: setFinancialSettings

--- a/openapi/paths/gateway-accounts@{id}@limits.yaml
+++ b/openapi/paths/gateway-accounts@{id}@limits.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve a list of gateway account limits
   operationId: GetGatewayAccountLimitCollection
   x-sdk-operation-name: getAllVolumeLimits

--- a/openapi/paths/gateway-accounts@{id}@limits@{limitId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@limits@{limitId}.yaml
@@ -15,7 +15,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Retrieve a gateway account limit
   operationId: GetGatewayAccountLimit
   x-sdk-operation-name: getVolumeLimit
@@ -38,7 +38,7 @@ put:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Update a gateway account limit
   operationId: PutGatewayAccountLimit
   x-sdk-operation-name: updateVolumeLimit
@@ -79,7 +79,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Gateway Accounts
+    - Gateway accounts
   summary: Delete a gateway account limit
   operationId: DeleteGatewayAccountLimit
   x-sdk-operation-name: deleteVolumeLimit

--- a/openapi/paths/gateway-accounts@{id}@timeline.yaml
+++ b/openapi/paths/gateway-accounts@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts Timeline
+    - Gateway accounts timeline
   summary: Retrieve a list of gateway account timeline messages
   operationId: GetGatewayAccountTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -44,7 +44,7 @@ post:
   x-products:
     - Users
   tags:
-    - Gateway Accounts Timeline
+    - Gateway accounts timeline
   summary: Create a Gateway Account Timeline comment
   operationId: PostGatewayAccountTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/gateway-accounts@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/gateway-accounts@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Users
   tags:
-    - Gateway Accounts Timeline
+    - Gateway accounts timeline
   summary: Retrieve a Gateway Timeline message
   operationId: GetGatewayAccountTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -38,7 +38,7 @@ delete:
   x-products:
     - Users
   tags:
-    - Gateway Accounts Timeline
+    - Gateway accounts timeline
   summary: Delete a Gateway Timeline message
   operationId: DeleteGatewayAccountTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/invoices@{id}@timeline.yaml
+++ b/openapi/paths/invoices@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Invoices Timeline
+    - Invoices timeline
   summary: Retrieve a list of invoice timeline messages
   operationId: GetInvoiceTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -44,7 +44,7 @@ post:
   x-products:
     - Core
   tags:
-    - Invoices Timeline
+    - Invoices timeline
   summary: Create an invoice Timeline comment
   operationId: PostInvoiceTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/invoices@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/invoices@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Core
   tags:
-    - Invoices Timeline
+    - Invoices timeline
   summary: Retrieve an Invoice Timeline message
   operationId: GetInvoiceTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -37,7 +37,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Invoices Timeline
+    - Invoices timeline
   summary: Delete an Invoice Timeline message
   operationId: DeleteInvoiceTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/kyc-documents.yaml
+++ b/openapi/paths/kyc-documents.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a list of KYC documents
   operationId: GetKycDocumentCollection
   x-sdk-operation-name: getAll
@@ -41,7 +41,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Create a KYC Document
   operationId: PostKycDocument
   x-sdk-operation-name: create

--- a/openapi/paths/kyc-documents@{id}.yaml
+++ b/openapi/paths/kyc-documents@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a KYC Document
   operationId: GetKycDocument
   x-sdk-operation-name: get
@@ -30,7 +30,7 @@ put:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Create or update a KYC document with predefined ID
   operationId: PutKycDocument
   x-sdk-operation-name: update

--- a/openapi/paths/kyc-documents@{id}@acceptance.yaml
+++ b/openapi/paths/kyc-documents@{id}@acceptance.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Accept a KYC document
   operationId: PostKycDocumentAcceptance
   x-sdk-operation-name: accept

--- a/openapi/paths/kyc-documents@{id}@matches.yaml
+++ b/openapi/paths/kyc-documents@{id}@matches.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Update a KYC document's documentMatches
   operationId: PostKycDocumentMatches
   x-sdk-operation-name: matches

--- a/openapi/paths/kyc-documents@{id}@rejection.yaml
+++ b/openapi/paths/kyc-documents@{id}@rejection.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Reject a KYC document
   operationId: PostKycDocumentRejection
   x-sdk-operation-name: reject

--- a/openapi/paths/kyc-documents@{id}@review.yaml
+++ b/openapi/paths/kyc-documents@{id}@review.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Review a KYC document
   operationId: PostKycDocumentReview
   x-sdk-operation-name: review

--- a/openapi/paths/kyc-documents@{id}@start-review.yaml
+++ b/openapi/paths/kyc-documents@{id}@start-review.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Start review for a KYC document
   operationId: PostKycDocumentStartReview
   x-sdk-operation-name: startReview

--- a/openapi/paths/kyc-documents@{id}@stop-review.yaml
+++ b/openapi/paths/kyc-documents@{id}@stop-review.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Stop review for a KYC document
   operationId: PostKycDocumentStopReview
   x-sdk-operation-name: stopReview

--- a/openapi/paths/kyc-requests.yaml
+++ b/openapi/paths/kyc-requests.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Create a KYC Request
   operationId: PostKycRequest
   x-sdk-operation-name: create
@@ -70,7 +70,7 @@ get:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a list of KYC requests
   operationId: GetKycRequestCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/kyc-requests@{id}.yaml
+++ b/openapi/paths/kyc-requests@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a KYC request
   operationId: GetKycRequest
   x-sdk-operation-name: get
@@ -26,7 +26,7 @@ patch:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Update a KYC request
   operationId: PatchKycRequest
   x-sdk-operation-name: update
@@ -54,7 +54,7 @@ delete:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Delete the KYC request
   operationId: DeleteKycRequest
   x-sdk-operation-name: delete

--- a/openapi/paths/kyc-settings.yaml
+++ b/openapi/paths/kyc-settings.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Get KYC settings
   operationId: GetKycSettings
   x-sdk-operation-name: getKycSettings
@@ -25,7 +25,7 @@ put:
   x-products:
     - Core
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Update KYC settings
   operationId: PutKycSettings
   x-sdk-operation-name: updateKycSettings

--- a/openapi/paths/logout.yaml
+++ b/openapi/paths/logout.yaml
@@ -7,7 +7,7 @@ post:
   x-products:
     - Users
   tags:
-    - JWT Session
+    - JWT session
   summary: Destroys the user's current session
   operationId: PostLogoutRequest
   x-sdk-operation-name: logout

--- a/openapi/paths/password-tokens.yaml
+++ b/openapi/paths/password-tokens.yaml
@@ -3,7 +3,7 @@ get:
     - Full
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Retrieve a list of tokens
   operationId: GetPasswordTokenCollection
   x-sdk-operation-name: getAllResetPasswordTokens
@@ -41,7 +41,7 @@ post:
     - Full
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Create a Reset Password Token
   operationId: PostPasswordToken
   x-sdk-operation-name: createResetPasswordToken

--- a/openapi/paths/password-tokens@{id}.yaml
+++ b/openapi/paths/password-tokens@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Retrieve a Reset Password Token
   operationId: GetPasswordToken
   x-sdk-operation-name: getResetPasswordToken
@@ -31,7 +31,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Customer Authentication
+    - Customer authentication
   summary: Delete a Reset Password Token
   operationId: DeletePasswordToken
   x-sdk-operation-name: deleteResetPasswordToken

--- a/openapi/paths/payment-cards-bank-names.yaml
+++ b/openapi/paths/payment-cards-bank-names.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve a list of payment card issuing bank names
   operationId: GetPaymentCardBankNameCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/payment-instruments.yaml
+++ b/openapi/paths/payment-instruments.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve a list of payment instruments
   operationId: GetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
@@ -46,7 +46,7 @@ post:
   x-products:
     - Core
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Create a Payment Instrument
   operationId: PostPaymentInstrument
   x-sdk-operation-name: create

--- a/openapi/paths/payment-instruments@{id}.yaml
+++ b/openapi/paths/payment-instruments@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve a Payment Instrument
   operationId: GetPaymentInstrument
   x-sdk-operation-name: get
@@ -34,7 +34,7 @@ patch:
   x-products:
     - Core
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Update a Payment Instrument's values
   operationId: PatchPaymentInstrument
   x-sdk-operation-name: update

--- a/openapi/paths/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/payment-instruments@{id}@deactivation.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Core
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Deactivate a payment instrument
   operationId: PostPaymentInstrumentDeactivation
   x-sdk-operation-name: deactivate

--- a/openapi/paths/send-through-attribution@{eventType}.yaml
+++ b/openapi/paths/send-through-attribution@{eventType}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Users
   tags:
-    - Email Notifications
+    - Email notifications
   summary: List email notification attributions
   operationId: GetSendThroughAttributionCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/signin.yaml
+++ b/openapi/paths/signin.yaml
@@ -7,7 +7,7 @@ post:
   x-products:
     - Users
   tags:
-    - JWT Session
+    - JWT session
   summary: Create a session with email and password
   operationId: PostSigninRequest
   x-sdk-operation-name: signIn

--- a/openapi/paths/storefront/billing-portals@{slug}.yaml
+++ b/openapi/paths/storefront/billing-portals@{slug}.yaml
@@ -11,7 +11,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Billing Portals
+    - Billing portals
   summary: Retrieve a billing portal
   operationId: StorefrontGetBillingPortal
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/checkout-forms@{id}.yaml
+++ b/openapi/paths/storefront/checkout-forms@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Checkout Forms
+    - Checkout forms
   summary: Retrieve a checkout form
   operationId: StorefrontGetCheckoutForm
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a list of KYC documents
   operationId: StorefrontGetKycDocumentCollection
   x-sdk-operation-name: getAll
@@ -37,7 +37,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Create a KYC Document
   operationId: StorefrontPostKycDocument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/kyc-documents@{id}.yaml
+++ b/openapi/paths/storefront/kyc-documents@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a KYC Document
   operationId: StorefrontGetKycDocument
   x-sdk-operation-name: get
@@ -29,7 +29,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Update a KYC document
   operationId: StorefrontPatchKycDocument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/kyc-requests@{id}.yaml
+++ b/openapi/paths/storefront/kyc-requests@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC Documents
+    - KYC documents
   summary: Retrieve a KYC request
   operationId: StorefrontGetKycRequest
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve a list of Payment Instruments
   operationId: StorefrontGetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
@@ -40,7 +40,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Create a Payment Instrument
   operationId: StorefrontPostPaymentInstrument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/payment-instruments@{id}.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve a Payment Instrument
   operationId: StorefrontGetPaymentInstrument
   x-sdk-operation-name: get
@@ -39,7 +39,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Update a Payment Instrument's values
   operationId: StorefrontPatchPaymentInstrument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Deactivate a Payment Instrument
   operationId: StorefrontPostPaymentInstrumentDeactivation
   x-sdk-operation-name: deactivate

--- a/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Retrieve the payment instrument's setup transaction
   operationId: StorefrontGetPaymentInstrumentSetup
   x-sdk-operation-name: getSetupTransaction
@@ -31,7 +31,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment Instruments
+    - Payment instruments
   summary: Create the payment instrument's setup transaction
   operationId: StorefrontPostPaymentInstrumentSetup
   x-sdk-operation-name: setup

--- a/openapi/paths/subscriptions@{id}@timeline.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Orders Timeline
+    - Orders timeline
   summary: Retrieve a list of order timeline messages
   operationId: GetSubscriptionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -42,7 +42,7 @@ post:
   x-products:
     - Core
   tags:
-    - Orders Timeline
+    - Orders timeline
   summary: Create an order Timeline comment
   operationId: PostSubscriptionTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Core
   tags:
-    - Orders Timeline
+    - Orders timeline
   summary: Retrieve an Order Timeline message
   operationId: GetSubscriptionTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -38,7 +38,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Orders Timeline
+    - Orders timeline
   summary: Delete an Order Timeline message
   operationId: DeleteSubscriptionTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/paths/tokens.yaml
+++ b/openapi/paths/tokens.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Core
   tags:
-    - Payment Tokens
+    - Payment tokens
   summary: Create a payment token
   operationId: PostToken
   x-sdk-operation-name: create
@@ -54,7 +54,7 @@ get:
   x-products:
     - Core
   tags:
-    - Payment Tokens
+    - Payment tokens
   summary: Retrieve a list of tokens
   operationId: GetTokenCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/tokens@{token}.yaml
+++ b/openapi/paths/tokens@{token}.yaml
@@ -9,7 +9,7 @@ get:
   x-products:
     - Core
   tags:
-    - Payment Tokens
+    - Payment tokens
   summary: Retrieve a token
   operationId: GetToken
   x-sdk-operation-name: get

--- a/openapi/paths/transactions@{id}@timeline.yaml
+++ b/openapi/paths/transactions@{id}@timeline.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Transactions Timeline
+    - Transactions timeline
   summary: Retrieve a list of transaction timeline messages
   operationId: GetTransactionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
@@ -42,7 +42,7 @@ post:
   x-products:
     - Core
   tags:
-    - Transactions Timeline
+    - Transactions timeline
   summary: Create a transaction Timeline comment
   operationId: PostTransactionTimeline
   x-sdk-operation-name: createTimelineComment

--- a/openapi/paths/transactions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/transactions@{id}@timeline@{messageId}.yaml
@@ -10,7 +10,7 @@ get:
   x-products:
     - Core
   tags:
-    - Transactions Timeline
+    - Transactions timeline
   summary: Retrieve a transaction Timeline message
   operationId: GetTransactionTimeline
   x-sdk-operation-name: getTimelineMessage
@@ -38,7 +38,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Transactions Timeline
+    - Transactions timeline
   summary: Delete a Transaction Timeline message
   operationId: DeleteTransactionTimeline
   x-sdk-operation-name: deleteTimelineMessage

--- a/openapi/webhooks/gateway-account-downtime-ended.yaml
+++ b/openapi/webhooks/gateway-account-downtime-ended.yaml
@@ -3,7 +3,7 @@ operationId: gateway-account-downtime-ended
 x-products:
   - Users
 tags:
-  - Gateway Accounts
+  - Gateway accounts
 requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
 responses:

--- a/openapi/webhooks/gateway-account-downtime-started.yaml
+++ b/openapi/webhooks/gateway-account-downtime-started.yaml
@@ -3,7 +3,7 @@ operationId: gateway-account-downtime-started
 x-products:
   - Users
 tags:
-  - Gateway Accounts
+  - Gateway accounts
 requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
 responses:

--- a/openapi/webhooks/gateway-account-limit-reached.yaml
+++ b/openapi/webhooks/gateway-account-limit-reached.yaml
@@ -3,7 +3,7 @@ operationId: gateway-account-limit-reached
 x-products:
   - Users
 tags:
-  - Gateway Accounts
+  - Gateway accounts
 requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountAndGatewayAccountLimit.yaml
 responses:

--- a/openapi/webhooks/kyc-document-accepted.yaml
+++ b/openapi/webhooks/kyc-document-accepted.yaml
@@ -3,7 +3,7 @@ operationId: kyc-document-accepted
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-document-archived.yaml
+++ b/openapi/webhooks/kyc-document-archived.yaml
@@ -3,7 +3,7 @@ operationId: kyc-document-archived
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-document-modified.yaml
+++ b/openapi/webhooks/kyc-document-modified.yaml
@@ -3,7 +3,7 @@ operationId: kyc-document-modified
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-document-rejected.yaml
+++ b/openapi/webhooks/kyc-document-rejected.yaml
@@ -3,7 +3,7 @@ operationId: kyc-document-rejected
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-document-reviewed.yaml
+++ b/openapi/webhooks/kyc-document-reviewed.yaml
@@ -3,7 +3,7 @@ operationId: kyc-document-reviewed
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-request-attempted.yaml
+++ b/openapi/webhooks/kyc-request-attempted.yaml
@@ -3,7 +3,7 @@ operationId: kyc-request-attempted
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-request-failed.yaml
+++ b/openapi/webhooks/kyc-request-failed.yaml
@@ -3,7 +3,7 @@ operationId: kyc-request-failed
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-request-fulfilled.yaml
+++ b/openapi/webhooks/kyc-request-fulfilled.yaml
@@ -3,7 +3,7 @@ operationId: kyc-request-fulfilled
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:

--- a/openapi/webhooks/kyc-request-partially-fulfilled.yaml
+++ b/openapi/webhooks/kyc-request-partially-fulfilled.yaml
@@ -3,7 +3,7 @@ operationId: kyc-request-partially-fulfilled
 x-products:
   - Core
 tags:
-  - KYC Documents
+  - KYC documents
 requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:

--- a/openapi/webhooks/payment-card-created.yaml
+++ b/openapi/webhooks/payment-card-created.yaml
@@ -3,7 +3,7 @@ operationId: payment-card-created
 x-products:
   - Core
 tags:
-  - Payment Instruments
+  - Payment instruments
 requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:

--- a/openapi/webhooks/payment-card-expiration-reminder.yaml
+++ b/openapi/webhooks/payment-card-expiration-reminder.yaml
@@ -3,7 +3,7 @@ operationId: payment-card-expiration-reminder
 x-products:
   - Core
 tags:
-  - Payment Instruments
+  - Payment instruments
 requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:

--- a/openapi/webhooks/payment-card-expired.yaml
+++ b/openapi/webhooks/payment-card-expired.yaml
@@ -3,7 +3,7 @@ operationId: payment-card-expired
 x-products:
   - Core
 tags:
-  - Payment Instruments
+  - Payment instruments
 requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:

--- a/plugins/products-bundler/mapping/Combined.yaml
+++ b/plugins/products-bundler/mapping/Combined.yaml
@@ -49,7 +49,7 @@ x-tagGroups:
   - name: Security
     tags:
       - JWT session
-      - API Keys
+      - API keys
       - Reset password
   - name: Email
     tags:

--- a/plugins/products-bundler/mapping/Combined.yaml
+++ b/plugins/products-bundler/mapping/Combined.yaml
@@ -8,19 +8,19 @@ x-tagGroups:
   - name: Customers
     tags:
       - Customers
-      - Customer Authentication
+      - Customer authentication
       - Tags
       - Customers Timeline
   - name: Payment Instruments
     tags:
-      - Payment Instruments
-      - Payment Tokens
+      - Payment instruments
+      - Payment tokens
   - name: Payments
     tags:
       - Transactions
       - Disputes
       - Fees
-      - Transactions Timeline
+      - Transactions timeline
   - name: Orders & Invoices
     tags:
       - Orders
@@ -30,17 +30,17 @@ x-tagGroups:
       - Products
       - Coupons
       - Shipping rates
-      - Orders Timeline
-      - Invoices Timeline
-      - Credit memos Timeline
+      - Orders timeline
+      - Invoices timeline
+      - Credit memos timeline
   - name: Risk
     tags:
       - Blocklists
-      - KYC Documents
+      - KYC documents
       - AML
   - name: Misc
     tags:
-      - Custom Fields
+      - Custom fields
       - Files
       - Search
       - Reports
@@ -53,8 +53,8 @@ x-tagGroups:
       - Reset password
   - name: Email
     tags:
-      - Broadcast Messages
-      - Email Credentials
+      - Broadcast messages
+      - Email credentials
       - Email Delivery Settings
       - Email Messages
   - name: Rules
@@ -72,13 +72,13 @@ x-tagGroups:
       - Organization data exports
   - name: Webhooks
     tags:
-      - Webhook Credentials
+      - Webhook credentials
       - Webhooks
   - name: Other
     tags:
       - Balance transactions
-      - Gateway Accounts
-      - Payment Cards
+      - Gateway accounts
+      - Payment cards
       - Organizations
       - Segments
       - Status
@@ -89,22 +89,22 @@ x-tagGroups:
       - Experian credentials
       - TaxJar credentials
       - Metadata
-      - Gateway Accounts Timeline
+      - Gateway accounts timeline
   - name: Account management
     tags:
       - Account
       - Authentication
-      - Billing Portals
+      - Billing portals
       - Email verification
       - Password reset
-      - KYC Documents
+      - KYC documents
   - name: Payments
     tags:
-      - Payment Instruments
+      - Payment instruments
       - Transactions
   - name: Orders
     tags:
-      - Checkout Forms
+      - Checkout forms
       - Purchases
       - Orders
       - Invoices

--- a/plugins/products-bundler/mapping/Combined.yaml
+++ b/plugins/products-bundler/mapping/Combined.yaml
@@ -10,7 +10,7 @@ x-tagGroups:
       - Customers
       - Customer authentication
       - Tags
-      - Customers Timeline
+      - Customers timeline
   - name: Payment Instruments
     tags:
       - Payment instruments
@@ -45,24 +45,24 @@ x-tagGroups:
       - Search
       - Reports
       - Histograms
-      - Data Exports
+      - Data exports
   - name: Security
     tags:
-      - JWT Session
+      - JWT session
       - API Keys
       - Reset password
   - name: Email
     tags:
       - Broadcast messages
       - Email credentials
-      - Email Delivery Settings
-      - Email Messages
+      - Email delivery settings
+      - Email messages
   - name: Rules
     tags:
       - Rules
       - Lists
-      - Email Notifications
-      - Rules Timeline
+      - Email notifications
+      - Rules timeline
   - name: Users
     tags:
       - Profile

--- a/plugins/products-bundler/mapping/Core.yaml
+++ b/plugins/products-bundler/mapping/Core.yaml
@@ -4,19 +4,19 @@ x-tagGroups:
   - name: Customers
     tags:
       - Customers
-      - Customer Authentication
+      - Customer authentication
       - Tags
       - Customers Timeline
   - name: Payment Instruments
     tags:
-      - Payment Instruments
-      - Payment Tokens
+      - Payment instruments
+      - Payment tokens
   - name: Payments
     tags:
       - Transactions
       - Disputes
       - Fees
-      - Transactions Timeline
+      - Transactions timeline
   - name: Orders & Invoices
     tags:
       - Orders
@@ -26,17 +26,17 @@ x-tagGroups:
       - Products
       - Coupons
       - Shipping rates
-      - Orders Timeline
-      - Invoices Timeline
-      - Credit memos Timeline
+      - Orders timeline
+      - Invoices timeline
+      - Credit memos timeline
   - name: Risk
     tags:
       - Blocklists
-      - KYC Documents
+      - KYC documents
       - AML
   - name: Misc
     tags:
-      - Custom Fields
+      - Custom fields
       - Files
       - Search
   - name: Related docs

--- a/plugins/products-bundler/mapping/Core.yaml
+++ b/plugins/products-bundler/mapping/Core.yaml
@@ -6,7 +6,7 @@ x-tagGroups:
       - Customers
       - Customer authentication
       - Tags
-      - Customers Timeline
+      - Customers timeline
   - name: Payment Instruments
     tags:
       - Payment instruments

--- a/plugins/products-bundler/mapping/Reports.yaml
+++ b/plugins/products-bundler/mapping/Reports.yaml
@@ -54,6 +54,6 @@ x-tagGroups:
     tags:
       - Histograms
       - Reports
-      - Data Exports
+      - Data exports
       - Orders
       - Customers

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -24,13 +24,13 @@ x-tagGroups:
     tags:
       - Account
       - Authentication
-      - Billing Portals
+      - Billing portals
       - Email verification
       - Password reset
-      - KYC Documents
+      - KYC documents
   - name: Payments
     tags:
-      - Payment Instruments
+      - Payment instruments
       - Transactions
   - name: Orders
     tags:
@@ -39,7 +39,7 @@ x-tagGroups:
       - Purchases
       - Orders
       - Invoices
-      - Checkout Forms
+      - Checkout forms
   - name: System
     tags:
       - Websites

--- a/plugins/products-bundler/mapping/Users.yaml
+++ b/plugins/products-bundler/mapping/Users.yaml
@@ -74,21 +74,21 @@ info:
 x-tagGroups:
   - name: Security
     tags:
-      - JWT Session
+      - JWT session
       - API Keys
       - Reset password
   - name: Email
     tags:
       - Broadcast messages
       - Email credentials
-      - Email Delivery Settings
-      - Email Messages
+      - Email delivery settings
+      - Email messages
   - name: Rules
     tags:
       - Rules
       - Lists
-      - Email Notifications
-      - Rules Timeline
+      - Email notifications
+      - Rules timeline
   - name: Users
     tags:
       - Profile

--- a/plugins/products-bundler/mapping/Users.yaml
+++ b/plugins/products-bundler/mapping/Users.yaml
@@ -79,8 +79,8 @@ x-tagGroups:
       - Reset password
   - name: Email
     tags:
-      - Broadcast Messages
-      - Email Credentials
+      - Broadcast messages
+      - Email credentials
       - Email Delivery Settings
       - Email Messages
   - name: Rules
@@ -102,17 +102,17 @@ x-tagGroups:
       - Application users
   - name: Webhooks
     tags:
-      - Webhook Credentials
+      - Webhook credentials
       - Webhooks
   - name: Other
     tags:
       - Balance transactions
-      - Billing Portals
-      - Checkout Forms
-      - Gateway Accounts
-      - Gateway Accounts Timeline
-      - Payment Cards
-      - Payment Instruments
+      - Billing portals
+      - Checkout forms
+      - Gateway accounts
+      - Gateway accounts timeline
+      - Payment cards
+      - Payment instruments
       - Organizations
       - Segments
       - Status

--- a/plugins/products-bundler/mapping/Users.yaml
+++ b/plugins/products-bundler/mapping/Users.yaml
@@ -75,7 +75,7 @@ x-tagGroups:
   - name: Security
     tags:
       - JWT session
-      - API Keys
+      - API keys
       - Reset password
   - name: Email
     tags:


### PR DESCRIPTION
This pull request adds more detail to tag descriptions in `openapi/openapi.yaml.

This pull request also updates the capitalization of tag names. As a result, the related references in other files are also updated. This was completed in [9f767ed](https://github.com/Rebilly/api-definitions/pull/966/commits/9f767ed0f1480a4ad43d36a69e2be275e0d0384e) and [7aab864](https://github.com/Rebilly/api-definitions/pull/966/commits/7aab864a8e4b5d55747bd434d8ced460f7388787).

Also related to the change of tag name capitalization, there are 3 broken links in the docs repository. These are caused by references from the website repository that point to API tags that have been changed to lowercase. I corrected those links in another pull request, but this one needs to be merged first.

