### PR TITLE
Fix minor issues related to sdk generation

### DIFF
--- a/openapi/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
+++ b/openapi/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
@@ -1,9 +1,9 @@
 type: object
 discriminator:
   propertyName: mode
-  x-enum-mapping:
-    - $ref: ./TokenModes/password.yaml
-    - $ref: ./TokenModes/passwordless.yaml
+  mapping:
+    password: ./TokenModes/password.yaml
+    passwordless: ./TokenModes/passwordless.yaml
 properties:
   mode:
     description: |-
@@ -12,4 +12,5 @@ properties:
       token, requires a secret API key to log in. To obtain an API key, see 
       [Manage API keys](https://www.rebilly.com/docs/dev-docs/api-keys/#manage-api-keys).
     default: password
+    type: string
 x-abstract-parent: CommonAuthenticationToken

--- a/openapi/components/schemas/Plans/FlexiblePlan.yaml
+++ b/openapi/components/schemas/Plans/FlexiblePlan.yaml
@@ -3,7 +3,6 @@ allOf:
   - $ref: ../Common/CommonPlan.yaml
 properties:
   id:
-    readOnly: false
     description: ID of a plan you wish to modify.
     allOf:
       - $ref: ../ResourceId.yaml

--- a/openapi/paths/files@{id}@download.yaml
+++ b/openapi/paths/files@{id}@download.yaml
@@ -26,11 +26,12 @@ get:
             type: string
           example: image/png
       content:
-        application/json:
+        application/json, application/pdf, image/jpg, image/png, image/gif, audio/mpeg:
           schema:
             type: string
             readOnly: true
             format: binary
+
     '302':
       $ref: ../components/responses/Found.yaml
     '401':


### PR DESCRIPTION
Addressing comments on https://github.com/Rebilly/api-definitions/pull/962

- simplify `AuthenticationToken` discriminator mapping.
- remove `readOnly: false` from `FlexiblePlan`.
- Add more MIME types in download  file specification. Used the MIME types listed in [here](https://api-reference.rebilly.com/tag/Files/operation/PostFile/)