### PR TITLE
Separate plans bodies by types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ node_modules
 
 # OpenAPI output bundles folder
 dist
-
-# IDE files
-/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 
 # OpenAPI output bundles folder
 dist
+
+# IDE files
+/.idea/

--- a/openapi/components/requestBodies/Plan.yaml
+++ b/openapi/components/requestBodies/Plan.yaml
@@ -1,6 +1,9 @@
 content:
   application/json:
     schema:
-      $ref: ../schemas/Plans/Plan.yaml
+      oneOf:
+        - $ref: ../schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
+        - $ref: ../schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
+        - $ref: ../schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
 description: Plan resource.
 required: true

--- a/openapi/components/schemas/Common/CommonPlan.yaml
+++ b/openapi/components/schemas/Common/CommonPlan.yaml
@@ -13,6 +13,14 @@ properties:
   name:
     description: The plan name, displayed on invoices and receipts.
     type: string
+  description:
+    type: string
+    description: Plain-text description of the plan. This field accepts plain-text only.
+  richDescription:
+    type: string
+    description: >-
+      Rich-text description of the plan. This field accepts rich text formatting,
+      such as: bold, underline, italic, and hyperlinks.
   productId:
     description: The related product ID.
     allOf:
@@ -34,38 +42,6 @@ properties:
     type: string
   pricing:
     $ref: ../Plans/PlanPriceFormula.yaml
-  recurringInterval:
-    description: The service interval. For a one-time item, use `null`.
-    allOf:
-      - $ref: ../Plans/PlanPeriod.yaml
-      - type: object
-        properties:
-          limit:
-            description: |
-              The number of invoices this subscription order will generate
-              (if 1, it will not generate any beyond the initial order creation).
-              For example, set this property to `12`, when the `periodUnit` is month and the
-              `periodDuration` is 1, for a 1 year contract billed monthly.
-            type: integer
-          billingTiming:
-            $ref: ../Plans/PlanBillingTiming.yaml
-  trial:
-    type: object
-    description: The trial. Set `null` if no trial.
-    required:
-      - price
-      - period
-    properties:
-      price:
-        description: The price of the trial. For a free trial, use `0`.
-        type: number
-        format: double
-      period:
-        $ref: ../Plans/PlanPeriod.yaml
-  isTrialOnly:
-    type: boolean
-    description: Whether a plan has a trial without recurring instructions.
-    readOnly: true
   setup:
     type: object
     description: The setup. Set `null` if no setup.
@@ -78,6 +54,9 @@ properties:
         format: double
   customFields:
     $ref: ../ResourceCustomFields.yaml
+  isActive:
+    type: boolean
+    description: Specifies whether a plan is active.
   revision:
     type: integer
     readOnly: true
@@ -90,3 +69,14 @@ properties:
       - $ref: ../ServerTimestamp.yaml
   updatedTime:
     $ref: ../UpdatedTime.yaml
+  isTrialOnly:
+    type: boolean
+    description: Whether a plan has a trial without recurring instructions.
+    readOnly: true
+  _links:
+    type: array
+    description: The links related to resource.
+    readOnly: true
+    minItems: 1
+    items:
+      $ref: ../Links/SelfLink.yaml

--- a/openapi/components/schemas/Plans/FlexiblePlan.yaml
+++ b/openapi/components/schemas/Plans/FlexiblePlan.yaml
@@ -1,43 +1,9 @@
 type: object
 allOf:
-  - $ref: ../Common/CommonPlan.yaml
+  - $ref: ./Plan.yaml
 properties:
   id:
     readOnly: false
     description: ID of a plan you wish to modify.
     allOf:
       - $ref: ../ResourceId.yaml
-  isActive:
-    type: boolean
-    description: Specifies whether a plan is active.
-  invoiceTimeShift:
-    description: |-
-        Use invoice time shift to adjust the invoice issue and due date 
-        when billing must occur before the service period changes. 
-        For example, rent must be paid in advance, so the invoice must 
-        be in advance of the billing date. For more information, see 
-        [Service period anchor, and billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
-    nullable: true
-    allOf:
-      - $ref: ../Invoices/InvoiceTimeShift.yaml
-  description:
-    type: string
-    description: Plain-text description of the plan. This field accepts plain-text only.
-  richDescription:
-    type: string
-    description: >-
-         Rich-text description of the plan. This field accepts rich text formatting, 
-         such as: bold, underline, italic, and hyperlinks.
-  _links:
-    type: array
-    description: Related resource links.
-    readOnly: true
-    minItems: 1
-    items:
-      $ref: ../Links/SelfLink.yaml
-required:
-  - id
-  - name
-  - currency
-  - productId
-  - pricing

--- a/openapi/components/schemas/Plans/Plan.yaml
+++ b/openapi/components/schemas/Plans/Plan.yaml
@@ -1,14 +1,4 @@
-allOf:
-  - $ref: ../Common/CommonPlan.yaml
-  - properties:
-      invoiceTimeShift:
-        description: You can shift issue time and due time of invoices for this plan.
-        allOf:
-          - $ref: ../Invoices/InvoiceTimeShift.yaml
-      _links:
-        type: array
-        description: The links related to resource.
-        readOnly: true
-        minItems: 1
-        items:
-          $ref: ../Links/SelfLink.yaml
+oneOf:
+  - $ref: ./PlanTypes/OneTimeSalePlan.yaml
+  - $ref: ./PlanTypes/SubscriptionOrderPlan.yaml
+  - $ref: ./PlanTypes/TrialOnlyPlan.yaml

--- a/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
@@ -1,0 +1,3 @@
+type: object
+allOf:
+  - $ref: ../../Common/CommonPlan.yaml

--- a/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
@@ -1,3 +1,4 @@
 type: object
+additionalProperties: false
 allOf:
   - $ref: ../../Common/CommonPlan.yaml

--- a/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
@@ -1,4 +1,5 @@
 type: object
+additionalProperties: false
 required:
   - name
   - currency

--- a/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
@@ -1,0 +1,47 @@
+type: object
+required:
+  - name
+  - currency
+  - productId
+  - pricing
+  - recurringInterval
+allOf:
+  - $ref: ../../Common/CommonPlan.yaml
+properties:
+  recurringInterval:
+    description: The service interval. For a one-time item, use `null`.
+    allOf:
+      - $ref: ../PlanPeriod.yaml
+      - type: object
+        properties:
+          limit:
+            description: |
+              The number of invoices this subscription order will generate
+              (if 1, it will not generate any beyond the initial order creation).
+              For example, set this property to `12`, when the `periodUnit` is month and the
+              `periodDuration` is 1, for a 1 year contract billed monthly.
+            type: integer
+          billingTiming:
+            $ref: ../PlanBillingTiming.yaml
+  trial:
+    type: object
+    description: The trial configuration. Set `null` if no trial.
+    required:
+      - price
+      - period
+    properties:
+      price:
+        description: The price of the trial. For a free trial, use `0`.
+        type: number
+        format: double
+      period:
+        $ref: ../PlanPeriod.yaml
+  invoiceTimeShift:
+    description: |-
+      Use invoice time shift to adjust the invoice issue and due date
+      when billing must occur before the service period changes.
+      For example, rent must be paid in advance, so the invoice must
+      be in advance of the billing date. For more information, see
+      [Service period anchor, and billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
+    allOf:
+      - $ref: ../../Invoices/InvoiceTimeShift.yaml

--- a/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
@@ -1,0 +1,32 @@
+type: object
+required:
+  - name
+  - currency
+  - productId
+  - pricing
+  - trial
+allOf:
+  - $ref: ../../Common/CommonPlan.yaml
+properties:
+  trial:
+    type: object
+    description: The trial configuration.
+    required:
+      - price
+      - period
+    properties:
+      price:
+        description: The price of the trial. For a free trial, use `0`.
+        type: number
+        format: double
+      period:
+        $ref: ../PlanPeriod.yaml
+  invoiceTimeShift:
+    description: |-
+      Use invoice time shift to adjust the invoice issue and due date
+      when billing must occur before the service period changes.
+      For example, rent must be paid in advance, so the invoice must
+      be in advance of the billing date. For more information, see
+      [Service period anchor, and billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
+    allOf:
+      - $ref: ../../Invoices/InvoiceTimeShift.yaml

--- a/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
@@ -1,4 +1,5 @@
 type: object
+additionalProperties: false
 required:
   - name
   - currency


### PR DESCRIPTION
This PR includes plan types bodies separation to make related requests payloads more clear.
This PR **DOES NOT** include descriptions improvements for now, all the descriptions were copied as is to be improved once the concept is approved.

![image](https://user-images.githubusercontent.com/4003786/187390862-f7f07177-e026-41cd-bc76-ed9aad09026b.png)

![image](https://user-images.githubusercontent.com/4003786/187391016-b9099859-b9fd-4d69-a16c-fa8000f20fa0.png)
