### PR TITLE
docs: improve server variable organizationId description

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -27,20 +27,18 @@ servers:
       organizationId:
         default: unknown
         description: |-
-          Your organization ID. The organization ID describes your
-          organization in Rebilly. For information on how to obtain
-          your organization ID, see
-          [Obtain your organization ID and website ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
+          Your organization ID.
+          An organization is an entity that represents your company.
+          For more information, see [Obtain your organization ID](https://www.rebilly.com/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
   - url: 'https://api.rebilly.com/organizations/{organizationId}'
     description: Live server
     variables:
       organizationId:
         default: unknown
         description: |-
-          Your organization ID. The organization ID describes your
-          organization in Rebilly. For information on how to obtain
-          your organization ID, see
-          [Obtain your organization ID and website ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
+          Your organization ID.
+          An organization is an entity that represents your company.
+          For more information, see [Obtain your organization ID](https://www.rebilly.com/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 
 components:
   securitySchemes:


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

The current description is inaccurate and has some redundancy. This proposal complies with the WRITING_STYLE.md.

Redundancy:
- First two sentences say the same thing differently.
- Third sentence says the same thing twice (For more information on how to do X, see how to do X.)

Inaccuracy:
- The second sentence says the ID "describes" but ID's are a unique string that represent some object or entity.

As a note, I still think this is inaccurate with the usage of the word **your** in the description. If you are building an app or integrating for a 3rd party, it is not your ID, it's the ID of the organization that is using the app or integration.

## Links
<!-- add any related links to other PRs or docs -->
- https://github.com/Rebilly/api-definitions/blob/main/WRITING-STYLE.md#example-which-avoids-knowledge-bias
- Also, you can't access this [Redocly bug link where I report bad Markdown rendering of server variables](https://github.com/Redocly/reference-docs/issues/984) but I put it here so I can have easy access if I need to follow up with them in the future on it.

## Checklist

- [x] Writing style
- [x] API design standards
