### PR TITLE
Fix metrics parameter of operation GetDashboardReport

### DIFF
--- a/openapi/paths/reports@dashboard.yaml
+++ b/openapi/paths/reports@dashboard.yaml
@@ -40,7 +40,6 @@ get:
       description: Comma-separated list of metrics.
       schema:
         type: string
-        format: date-time
     - name: segments
       in: query
       description: Dashboard report segments as a JSON array.


### PR DESCRIPTION
## Summary

Remove date-time format from metrics parameter of operation GetDashboardReport.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
