### PR TITLE
Resolve properties not showing in examples on redocly

### DIFF
--- a/openapi/components/schemas/Transactions/TransactionRequest.yaml
+++ b/openapi/components/schemas/Transactions/TransactionRequest.yaml
@@ -1,4 +1,5 @@
 allOf:
+  - $ref: ../Common/CommonTransactionRequest.yaml
   - required:
     - type
   - properties:
@@ -29,4 +30,3 @@ allOf:
           - setup
       limits:
         $ref: ../TransactionLimitAmount.yaml
-  - $ref: ../Common/CommonTransactionRequest.yaml


### PR DESCRIPTION
## Summary
With the $ref at the bottom, the properties `upsertCustomer`, `type` and `limit` are not shown in the `POST /transactions` example. Putting the $ref at the top fixes this.

## Links
[POST /transactions/ in the docs](https://api-reference.rebilly.com/tag/Transactions/operation/PostTransaction)