### PR TITLE
Add missing type

### DIFF
--- a/openapi/components/schemas/Transactions/TransactionRequest.yaml
+++ b/openapi/components/schemas/Transactions/TransactionRequest.yaml
@@ -1,6 +1,7 @@
 allOf:
   - required:
     - type
+  - type: object
   - properties:
       upsertCustomer:
         type: boolean


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
Without the type, the properties `type`, `limits` and `upsertCustomer` don't show up in the request body of the `POST /transactions` sample.

## Links
Closes #1011
