### PR TITLE
Fix typo across multiple files

### DIFF
--- a/openapi/webhooks/application-instance-disabled.yaml
+++ b/openapi/webhooks/application-instance-disabled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/ApplicationInstanceDisabled.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/application-instance-enabled.yaml
+++ b/openapi/webhooks/application-instance-enabled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/ApplicationInstanceEnabled.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/balance-transaction-settled.yaml
+++ b/openapi/webhooks/balance-transaction-settled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceRevenueRecognized.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/credit-memo-applied.yaml
+++ b/openapi/webhooks/credit-memo-applied.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CreditMemoWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/credit-memo-created.yaml
+++ b/openapi/webhooks/credit-memo-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CreditMemoWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/credit-memo-modified.yaml
+++ b/openapi/webhooks/credit-memo-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CreditMemoWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/credit-memo-partially-applied.yaml
+++ b/openapi/webhooks/credit-memo-partially-applied.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CreditMemoWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/credit-memo-voided.yaml
+++ b/openapi/webhooks/credit-memo-voided.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CreditMemoWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-created.yaml
+++ b/openapi/webhooks/customer-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CustomerWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-merged.yaml
+++ b/openapi/webhooks/customer-merged.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/MergedCustomer.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-one-time-password-requested.yaml
+++ b/openapi/webhooks/customer-one-time-password-requested.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CustomerWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-redirected-offsite.yaml
+++ b/openapi/webhooks/customer-redirected-offsite.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CustomerRedirect.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-returned.yaml
+++ b/openapi/webhooks/customer-returned.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CustomerRedirect.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/customer-updated.yaml
+++ b/openapi/webhooks/customer-updated.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/CustomerWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/dispute-created.yaml
+++ b/openapi/webhooks/dispute-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/DisputeWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/dispute-modified.yaml
+++ b/openapi/webhooks/dispute-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/DisputeWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/experian-check-performed.yaml
+++ b/openapi/webhooks/experian-check-performed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/ExperianCheckPerformed.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/gateway-account-downtime-ended.yaml
+++ b/openapi/webhooks/gateway-account-downtime-ended.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/gateway-account-downtime-started.yaml
+++ b/openapi/webhooks/gateway-account-downtime-started.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
 responses:
   '2XX':
-    description: Return any 2XX status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/gateway-account-limit-reached.yaml
+++ b/openapi/webhooks/gateway-account-limit-reached.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/GatewayAccountAndGatewayAccountLimit.yaml
 responses:
   '2XX':
-    description: Return any 2XX status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/gateway-account-requested.yaml
+++ b/openapi/webhooks/gateway-account-requested.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-abandoned.yaml
+++ b/openapi/webhooks/invoice-abandoned.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-created.yaml
+++ b/openapi/webhooks/invoice-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-issued.yaml
+++ b/openapi/webhooks/invoice-issued.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-modified.yaml
+++ b/openapi/webhooks/invoice-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-paid.yaml
+++ b/openapi/webhooks/invoice-paid.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-partially-paid.yaml
+++ b/openapi/webhooks/invoice-partially-paid.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-partially-refunded.yaml
+++ b/openapi/webhooks/invoice-partially-refunded.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-past-due-reminder.yaml
+++ b/openapi/webhooks/invoice-past-due-reminder.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-past-due.yaml
+++ b/openapi/webhooks/invoice-past-due.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-refunded.yaml
+++ b/openapi/webhooks/invoice-refunded.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-reissued.yaml
+++ b/openapi/webhooks/invoice-reissued.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-revenue-recognized.yaml
+++ b/openapi/webhooks/invoice-revenue-recognized.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceRevenueRecognized.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-tax-calculation-failed.yaml
+++ b/openapi/webhooks/invoice-tax-calculation-failed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceTaxCalculationFailed.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/invoice-voided.yaml
+++ b/openapi/webhooks/invoice-voided.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-document-accepted.yaml
+++ b/openapi/webhooks/kyc-document-accepted.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-document-archived.yaml
+++ b/openapi/webhooks/kyc-document-archived.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-document-modified.yaml
+++ b/openapi/webhooks/kyc-document-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-document-rejected.yaml
+++ b/openapi/webhooks/kyc-document-rejected.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-document-reviewed.yaml
+++ b/openapi/webhooks/kyc-document-reviewed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycDocumentWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-request-attempted.yaml
+++ b/openapi/webhooks/kyc-request-attempted.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-request-failed.yaml
+++ b/openapi/webhooks/kyc-request-failed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-request-fulfilled.yaml
+++ b/openapi/webhooks/kyc-request-fulfilled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/kyc-request-partially-fulfilled.yaml
+++ b/openapi/webhooks/kyc-request-partially-fulfilled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/KycRequestWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/nsf-response-received.yaml
+++ b/openapi/webhooks/nsf-response-received.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/offsite-payment-completed.yaml
+++ b/openapi/webhooks/offsite-payment-completed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/order-completed.yaml
+++ b/openapi/webhooks/order-completed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/payment-card-created.yaml
+++ b/openapi/webhooks/payment-card-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/payment-card-expiration-reminder.yaml
+++ b/openapi/webhooks/payment-card-expiration-reminder.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/payment-card-expired.yaml
+++ b/openapi/webhooks/payment-card-expired.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/PaymentCardWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/renewal-invoice-issued.yaml
+++ b/openapi/webhooks/renewal-invoice-issued.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceAndSubscription.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/renewal-invoice-payment-canceled.yaml
+++ b/openapi/webhooks/renewal-invoice-payment-canceled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceAndTransaction.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/renewal-invoice-payment-declined.yaml
+++ b/openapi/webhooks/renewal-invoice-payment-declined.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/InvoiceAndTransaction.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/risk-score-changed.yaml
+++ b/openapi/webhooks/risk-score-changed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-activated.yaml
+++ b/openapi/webhooks/subscription-activated.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-canceled.yaml
+++ b/openapi/webhooks/subscription-canceled.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-downgraded.yaml
+++ b/openapi/webhooks/subscription-downgraded.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-modified.yaml
+++ b/openapi/webhooks/subscription-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-pause-created.yaml
+++ b/openapi/webhooks/subscription-pause-created.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-pause-modified.yaml
+++ b/openapi/webhooks/subscription-pause-modified.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-pause-revoked.yaml
+++ b/openapi/webhooks/subscription-pause-revoked.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-paused.yaml
+++ b/openapi/webhooks/subscription-paused.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-reactivated.yaml
+++ b/openapi/webhooks/subscription-reactivated.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-renewal-reminder.yaml
+++ b/openapi/webhooks/subscription-renewal-reminder.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-renewed.yaml
+++ b/openapi/webhooks/subscription-renewed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-resumed.yaml
+++ b/openapi/webhooks/subscription-resumed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-trial-converted.yaml
+++ b/openapi/webhooks/subscription-trial-converted.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-trial-end-changed.yaml
+++ b/openapi/webhooks/subscription-trial-end-changed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-trial-end-reminder.yaml
+++ b/openapi/webhooks/subscription-trial-end-reminder.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-trial-ended.yaml
+++ b/openapi/webhooks/subscription-trial-ended.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/subscription-upgraded.yaml
+++ b/openapi/webhooks/subscription-upgraded.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-amount-discrepancy-found.yaml
+++ b/openapi/webhooks/transaction-amount-discrepancy-found.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-declined.yaml
+++ b/openapi/webhooks/transaction-declined.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-discrepancy-found.yaml
+++ b/openapi/webhooks/transaction-discrepancy-found.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-process-requested.yaml
+++ b/openapi/webhooks/transaction-process-requested.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-processed.yaml
+++ b/openapi/webhooks/transaction-processed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/transaction-timeout-resolved.yaml
+++ b/openapi/webhooks/transaction-timeout-resolved.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.

--- a/openapi/webhooks/waiting-gateway-transaction-completed.yaml
+++ b/openapi/webhooks/waiting-gateway-transaction-completed.yaml
@@ -8,4 +8,4 @@ requestBody:
   $ref: ../components/requestBodies/Webhooks/TransactionWebhook.yaml
 responses:
   '2xx':
-    description: Return any 2xx status to indicate that the data was received successfully.
+    description: Returns any 2xx status to indicate that the data was received successfully.


### PR DESCRIPTION
## Summary

This pull request updates a common typo ("Return any 2xx status" -> "Returns any 2xx status").

## Links

N/A

## Checklist

- [x] Writing style
- [x] API design standards
