### PR TITLE
Update summary descriptions

### DIFF
--- a/openapi/paths/api-keys.yaml
+++ b/openapi/paths/api-keys.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - API keys
-  summary: Retrieve a list of API keys
+  summary: Retrieve API keys
   operationId: GetApiKeyCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/api-keys@{id}.yaml
+++ b/openapi/paths/api-keys@{id}.yaml
@@ -35,7 +35,7 @@ put:
     - Users
   tags:
     - API keys
-  summary: Create or update API key with specified ID
+  summary: Upsert an API key
   operationId: PutApiKey
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/application-instances@{applicationId}.yaml
+++ b/openapi/paths/application-instances@{applicationId}.yaml
@@ -42,7 +42,7 @@ put:
     - Users
   tags:
     - Application users
-  summary: Create or update an application instance
+  summary: Upsert an application instance
   operationId: PutApplicationInstance
   x-sdk-operation-name: upsert
   description: |-

--- a/openapi/paths/applications.yaml
+++ b/openapi/paths/applications.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Application users
-  summary: Retrieve a list of applications
+  summary: Retrieve applications
   operationId: GetApplicationCollection
   x-sdk-operation-name: getAll
   description: |-

--- a/openapi/paths/attachments.yaml
+++ b/openapi/paths/attachments.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Files
-  summary: Retrieve a list of attachments
+  summary: Retrieve attachments
   operationId: GetAttachmentCollection
   x-sdk-operation-name: getAllAttachments
   description: |-

--- a/openapi/paths/authentication-tokens.yaml
+++ b/openapi/paths/authentication-tokens.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Customer authentication
-  summary: Retrieve auth tokens
+  summary: Retrieve authentication tokens
   operationId: GetAuthenticationTokenCollection
   x-sdk-operation-name: getAllAuthTokens
   description: |-

--- a/openapi/paths/authentication-tokens.yaml
+++ b/openapi/paths/authentication-tokens.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Customer authentication
-  summary: Retrieve a list of auth tokens
+  summary: Retrieve auth tokens
   operationId: GetAuthenticationTokenCollection
   x-sdk-operation-name: getAllAuthTokens
   description: |-

--- a/openapi/paths/balance-transactions.yaml
+++ b/openapi/paths/balance-transactions.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Users
   tags: ["Balance transactions"]
-  summary: Retrieve a list of balance transactions
+  summary: Retrieve balance transactions
   description: |
     Retrieve a list of balance transactions.
 

--- a/openapi/paths/billing-portals.yaml
+++ b/openapi/paths/billing-portals.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Billing portals
-  summary: Retrieve a list of billing portals
+  summary: Retrieve billing portals
   operationId: GetBillingPortalCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/billing-portals@{id}.yaml
+++ b/openapi/paths/billing-portals@{id}.yaml
@@ -28,7 +28,7 @@ put:
     - Users
   tags:
     - Billing portals
-  summary: Create or update a billing portal
+  summary: Upsert a billing portal
   operationId: PutBillingPortal
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/blocklists.yaml
+++ b/openapi/paths/blocklists.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Blocklists
-  summary: Retrieve a list of blocklists
+  summary: Retrieve blocklists
   operationId: GetBlocklistCollection
   x-sdk-operation-name: getAll
   description: |-

--- a/openapi/paths/broadcast-messages.yaml
+++ b/openapi/paths/broadcast-messages.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Broadcast messages
-  summary: Retrieve a list of broadcast messages
+  summary: Retrieve broadcast messages
   operationId: GetBroadcastMessageCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/checkout-forms@{id}.yaml
+++ b/openapi/paths/checkout-forms@{id}.yaml
@@ -28,7 +28,7 @@ put:
     - Users
   tags:
     - Checkout forms
-  summary: Create or update a checkout form
+  summary: Upsert a checkout form
   operationId: PutCheckoutForm
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/coupons-redemptions.yaml
+++ b/openapi/paths/coupons-redemptions.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Coupons
-  summary: Retrieve a list of coupon redemptions
+  summary: Retrieve coupon redemptions
   operationId: GetCouponRedemptionCollection
   x-sdk-operation-name: getAllRedemptions
   description: Retrieves a list of coupon redemptions.

--- a/openapi/paths/coupons.yaml
+++ b/openapi/paths/coupons.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Coupons
-  summary: Retrieve a list of coupons
+  summary: Retrieve coupons
   operationId: GetCouponCollection
   x-sdk-operation-name: getAll
   description: Retrieves a list of coupons.

--- a/openapi/paths/coupons@{id}.yaml
+++ b/openapi/paths/coupons@{id}.yaml
@@ -35,7 +35,7 @@ put:
     - Core
   tags:
     - Coupons
-  summary: Create or update a coupon
+  summary: Upsert a coupon
   operationId: PutCoupon
   x-sdk-operation-name: update
   description: |-

--- a/openapi/paths/credential-hashes@experian.yaml
+++ b/openapi/paths/credential-hashes@experian.yaml
@@ -9,7 +9,7 @@ get:
     - $ref: ../components/parameters/collectionQuery.yaml
   tags:
     - Experian credentials
-  summary: Retrieve a list of Experian credentials
+  summary: Retrieve Experian credentials
   operationId: GetExperianCredentialHashCollection
   x-sdk-operation-name: getAllExperianCredentials
   description: |

--- a/openapi/paths/credential-hashes@oauth2.yaml
+++ b/openapi/paths/credential-hashes@oauth2.yaml
@@ -9,7 +9,7 @@ get:
     - $ref: ../components/parameters/collectionQuery.yaml
   tags:
     - Webhook credentials
-  summary: Retrieve a list of OAuth2 credentials
+  summary: Retrieve OAuth2 credentials
   operationId: GetOauth2CredentialHashCollection
   x-sdk-operation-name: getAllOAuth2Credentials
   description: |

--- a/openapi/paths/credential-hashes@plaid.yaml
+++ b/openapi/paths/credential-hashes@plaid.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Plaid credentials
-  summary: Retrieve a list of Plaid credentials
+  summary: Retrieve Plaid credentials
   operationId: GetPlaidCredentialCollection
   x-sdk-operation-name: getAllPlaidCredentials
   parameters:

--- a/openapi/paths/credential-hashes@taxjar.yaml
+++ b/openapi/paths/credential-hashes@taxjar.yaml
@@ -9,7 +9,7 @@ get:
     - $ref: ../components/parameters/collectionQuery.yaml
   tags:
     - TaxJar credentials
-  summary: Retrieve a list of TaxJar credentials
+  summary: Retrieve TaxJar credentials
   operationId: GetTaxJarCredentialHashCollection
   x-sdk-operation-name: getAllTaxJarCredentials
   description: |

--- a/openapi/paths/credentials.yaml
+++ b/openapi/paths/credentials.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Customer authentication
-  summary: Retrieve a list of credentials
+  summary: Retrieve credentials
   operationId: GetCredentialCollection
   x-sdk-operation-name: getAllCredentials
   description: |-
@@ -51,7 +51,7 @@ post:
   operationId: PostCredential
   x-sdk-operation-name: createCredential
   description: |-
-    Creates an authentication credential.
+    Creates an authentication credential
   requestBody:
     content:
       application/json:

--- a/openapi/paths/credentials.yaml
+++ b/openapi/paths/credentials.yaml
@@ -51,7 +51,7 @@ post:
   operationId: PostCredential
   x-sdk-operation-name: createCredential
   description: |-
-    Creates an authentication credential
+    Creates an authentication credential.
   requestBody:
     content:
       application/json:

--- a/openapi/paths/credentials@{id}.yaml
+++ b/openapi/paths/credentials@{id}.yaml
@@ -39,7 +39,7 @@ put:
     - Core
   tags:
     - Customer authentication
-  summary: Create or update a credential
+  summary: Upsert a credential
   operationId: PutCredential
   x-sdk-operation-name: updateCredential
   description: |-

--- a/openapi/paths/credit-memos.yaml
+++ b/openapi/paths/credit-memos.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Credit memos
-  summary: Retrieve a list of credit memos
+  summary: Retrieve credit memos
   operationId: GetCreditMemoCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/credit-memos@{id}.yaml
+++ b/openapi/paths/credit-memos@{id}.yaml
@@ -34,7 +34,7 @@ put:
     - Core
   tags:
     - Credit memos
-  summary: Create or update a credit memo with specified ID
+  summary: Upsert a credit memo
   operationId: PutCreditMemo
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/credit-memos@{id}@timeline.yaml
+++ b/openapi/paths/credit-memos@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Credit memos timeline
-  summary: Retrieve a list of credit memo timeline messages
+  summary: Retrieve credit memo timeline messages
   operationId: GetCreditMemoTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/custom-domains.yaml
+++ b/openapi/paths/custom-domains.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Custom domains
-  summary: Retrieve a list of custom domains
+  summary: Retrieve custom domains
   operationId: GetCustomDomainCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/customer-timeline-custom-events.yaml
+++ b/openapi/paths/customer-timeline-custom-events.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Customers timeline
-  summary: Retrieve a list of customer timeline custom event types
+  summary: Retrieve customer timeline custom event types
   operationId: GetCustomerTimelineCustomEventTypeCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/customers.yaml
+++ b/openapi/paths/customers.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Customers
-  summary: Retrieve a list of customers
+  summary: Retrieve customers
   operationId: GetCustomerCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/customers@{id}.yaml
+++ b/openapi/paths/customers@{id}.yaml
@@ -46,7 +46,7 @@ put:
     - Core
   tags:
     - Customers
-  summary: Create or update a customer with specified ID
+  summary: Upsert a customer
   operationId: PutCustomer
   x-sdk-operation-name: update
   description: >

--- a/openapi/paths/customers@{id}@edd-timeline.yaml
+++ b/openapi/paths/customers@{id}@edd-timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Customers
-  summary: Retrieve a list of EDD timeline messages
+  summary: Retrieve EDD timeline messages
   operationId: GetEddTimelineCollection
   x-sdk-operation-name: getEddTimelineCollection
   description: |

--- a/openapi/paths/customers@{id}@timeline.yaml
+++ b/openapi/paths/customers@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Customers timeline
-  summary: Retrieve a list of customer timeline messages
+  summary: Retrieve customer timeline messages
   operationId: GetCustomerTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/data-exports.yaml
+++ b/openapi/paths/data-exports.yaml
@@ -54,7 +54,7 @@ get:
     - Reports
   tags:
     - Data exports
-  summary: Retrieve a list of data export requests
+  summary: Retrieve data export requests
   operationId: GetDataExportCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/disputes.yaml
+++ b/openapi/paths/disputes.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Disputes
-  summary: Retrieve a list of disputes
+  summary: Retrieve disputes
   operationId: GetDisputeCollection
   x-sdk-operation-name: getAll
   description: |-

--- a/openapi/paths/disputes@{id}.yaml
+++ b/openapi/paths/disputes@{id}.yaml
@@ -35,7 +35,7 @@ put:
     - Core
   tags:
     - Disputes
-  summary: Create or update a dispute
+  summary: Upsert a dispute
   operationId: PutDispute
   x-sdk-operation-name: update
   description: |-

--- a/openapi/paths/email-delivery-settings.yaml
+++ b/openapi/paths/email-delivery-settings.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Email delivery settings
-  summary: Retrieve a list of email delivery settings
+  summary: Retrieve email delivery settings
   operationId: GetEmailDeliverySettingCollection
   x-sdk-operation-name: getAll
   parameters:

--- a/openapi/paths/email-messages.yaml
+++ b/openapi/paths/email-messages.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Email messages
-  summary: Retrieve a list of email messages
+  summary: Retrieve email messages
   operationId: GetEmailMessageCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/email-notifications.yaml
+++ b/openapi/paths/email-notifications.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Email notifications
-  summary: Retrieve a list of email notification events
+  summary: Retrieve email notification events
   operationId: GetEmailNotificationCollection
   x-sdk-operation-name: getAll
   parameters:

--- a/openapi/paths/events.yaml
+++ b/openapi/paths/events.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Rules
-  summary: Retrieve a list of existing events
+  summary: Retrieve existing events
   operationId: GetEventCollection
   x-sdk-operation-name: getAll
   responses:

--- a/openapi/paths/events@{eventType}@rules.yaml
+++ b/openapi/paths/events@{eventType}@rules.yaml
@@ -5,7 +5,7 @@ get:
     - Users
   tags:
     - Rules
-  summary: Retrieve a list of rules for event
+  summary: Retrieve rules for event
   operationId: GetEventRuleCollection
   x-sdk-operation-name: getRules
   responses:

--- a/openapi/paths/events@{eventType}@timeline.yaml
+++ b/openapi/paths/events@{eventType}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Users
   tags:
     - Rules timeline
-  summary: Retrieve a list of Rules Engine timeline messages
+  summary: Retrieve rules engine timeline messages
   operationId: GetRulesEngineTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/fees.yaml
+++ b/openapi/paths/fees.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags: [Fees]
-  summary: Retrieve a list of Fees entries
+  summary: Retrieve fees entries
   description: |
     Retrieve a list of Fees entries.
 

--- a/openapi/paths/fees@{id}.yaml
+++ b/openapi/paths/fees@{id}.yaml
@@ -35,7 +35,7 @@ put:
   x-products:
     - Core
   tags: [Fees]
-  summary: Create or update a fee entry
+  summary: Upsert a fee entry
   description: |
     Create or update (upsert) a fee entry.
 

--- a/openapi/paths/files.yaml
+++ b/openapi/paths/files.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Files
-  summary: Retrieve a list of files
+  summary: Retrieve files
   operationId: GetFileCollection
   x-sdk-operation-name: getAll
   description: |-

--- a/openapi/paths/gateway-accounts.yaml
+++ b/openapi/paths/gateway-accounts.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Gateway accounts
-  summary: Retrieve a list of gateway accounts
+  summary: Retrieve gateway accounts
   operationId: GetGatewayAccountCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/gateway-accounts@{id}.yaml
+++ b/openapi/paths/gateway-accounts@{id}.yaml
@@ -35,7 +35,7 @@ put:
     - Users
   tags:
     - Gateway accounts
-  summary: Create or update a Gateway Account with specified ID
+  summary: Upsert a gateway account
   operationId: PutGatewayAccount
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/gateway-accounts@{id}@limits.yaml
+++ b/openapi/paths/gateway-accounts@{id}@limits.yaml
@@ -5,7 +5,7 @@ get:
     - Users
   tags:
     - Gateway accounts
-  summary: Retrieve a list of gateway account limits
+  summary: Retrieve gateway account limits
   operationId: GetGatewayAccountLimitCollection
   x-sdk-operation-name: getAllVolumeLimits
   description: |

--- a/openapi/paths/gateway-accounts@{id}@timeline.yaml
+++ b/openapi/paths/gateway-accounts@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Users
   tags:
     - Gateway accounts timeline
-  summary: Retrieve a list of gateway account timeline messages
+  summary: Retrieve gateway account timeline messages
   operationId: GetGatewayAccountTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/integrations.yaml
+++ b/openapi/paths/integrations.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Integrations
-  summary: Retrieve a list of integrations
+  summary: Retrieve integrations
   operationId: GetIntegrationCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/invoices.yaml
+++ b/openapi/paths/invoices.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Invoices
-  summary: Retrieve a list of invoices
+  summary: Retrieve invoices
   operationId: GetInvoiceCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/invoices@{id}.yaml
+++ b/openapi/paths/invoices@{id}.yaml
@@ -49,7 +49,7 @@ put:
     - Core
   tags:
     - Invoices
-  summary: Create or update an invoice with specified ID
+  summary: Upsert an invoice
   operationId: PutInvoice
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/invoices@{id}@timeline.yaml
+++ b/openapi/paths/invoices@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Invoices timeline
-  summary: Retrieve a list of invoice timeline messages
+  summary: Retrieve invoice timeline messages
   operationId: GetInvoiceTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/kyc-documents.yaml
+++ b/openapi/paths/kyc-documents.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - KYC documents
-  summary: Retrieve a list of KYC documents
+  summary: Retrieve KYC documents
   operationId: GetKycDocumentCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/kyc-documents@{id}.yaml
+++ b/openapi/paths/kyc-documents@{id}.yaml
@@ -31,7 +31,7 @@ put:
     - Core
   tags:
     - KYC documents
-  summary: Create or update a KYC document with specified ID
+  summary: Upsert a KYC document
   operationId: PutKycDocument
   x-sdk-operation-name: update
   description: Create or update (upsert) a KYC document with specified identifier string.

--- a/openapi/paths/kyc-requests.yaml
+++ b/openapi/paths/kyc-requests.yaml
@@ -71,7 +71,7 @@ get:
     - Core
   tags:
     - KYC documents
-  summary: Retrieve a list of KYC requests
+  summary: Retrieve KYC requests
   operationId: GetKycRequestCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/lists@{id}.yaml
+++ b/openapi/paths/lists@{id}.yaml
@@ -32,7 +32,7 @@ put:
     - Users
   tags:
     - Lists
-  summary: Create or update a list with specified ID
+  summary: Upsert a list
   operationId: PutList
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/memberships.yaml
+++ b/openapi/paths/memberships.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Memberships
-  summary: Retrieve a list of memberships
+  summary: Retrieve memberships
   operationId: GetMembershipCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/memberships@{organizationId}@{userId}.yaml
+++ b/openapi/paths/memberships@{organizationId}@{userId}.yaml
@@ -39,7 +39,7 @@ put:
     - Users
   tags:
     - Memberships
-  summary: Create or update membership
+  summary: Upsert membership
   operationId: PutMembership
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/organization-exports.yaml
+++ b/openapi/paths/organization-exports.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Organization data exports
-  summary: Retrieve a list of organization data exports
+  summary: Retrieve organization data exports
   operationId: GetOrganizationExportCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/organizations.yaml
+++ b/openapi/paths/organizations.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Organizations
-  summary: Retrieve a list of organizations
+  summary: Retrieve organizations
   operationId: GetOrganizationCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/password-tokens.yaml
+++ b/openapi/paths/password-tokens.yaml
@@ -4,7 +4,7 @@ get:
     - Core
   tags:
     - Customer authentication
-  summary: Retrieve a list of tokens
+  summary: Retrieve tokens
   operationId: GetPasswordTokenCollection
   x-sdk-operation-name: getAllResetPasswordTokens
   description: |-

--- a/openapi/paths/payment-cards-bank-names.yaml
+++ b/openapi/paths/payment-cards-bank-names.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Payment instruments
-  summary: Retrieve a list of payment card issuing bank names
+  summary: Retrieve payment card issuing bank names
   operationId: GetPaymentCardBankNameCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/payment-instruments.yaml
+++ b/openapi/paths/payment-instruments.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Payment instruments
-  summary: Retrieve a list of payment instruments
+  summary: Retrieve payment instruments
   operationId: GetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/plans.yaml
+++ b/openapi/paths/plans.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Plans
-  summary: Retrieve a list of plans
+  summary: Retrieve plans
   operationId: GetPlanCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/plans@{id}.yaml
+++ b/openapi/paths/plans@{id}.yaml
@@ -43,7 +43,7 @@ put:
     - Core
   tags:
     - Plans
-  summary: Create or update a Plan with specified ID
+  summary: Upsert a plan
   operationId: PutPlan
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/products.yaml
+++ b/openapi/paths/products.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Products
-  summary: Retrieve a list of products
+  summary: Retrieve products
   operationId: GetProductCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/products@{id}.yaml
+++ b/openapi/paths/products@{id}.yaml
@@ -40,7 +40,7 @@ put:
     - Core
   tags:
     - Products
-  summary: Create or update a product with specified ID
+  summary: Upsert a product
   operationId: PutProduct
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/roles.yaml
+++ b/openapi/paths/roles.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Roles
-  summary: Retrieve a list of roles
+  summary: Retrieve roles
   operationId: GetRoleCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/shipping-rates.yaml
+++ b/openapi/paths/shipping-rates.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Shipping rates
-  summary: Retrieve a list of shipping rates
+  summary: Retrieve shipping rates
   operationId: GetShippingRateCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/storefront/invoices.yaml
+++ b/openapi/paths/storefront/invoices.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - Invoices
-  summary: Retrieve a list of invoices
+  summary: Retrieve invoices
   operationId: StorefrontGetInvoiceCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - KYC documents
-  summary: Retrieve a list of KYC documents
+  summary: Retrieve KYC documents
   operationId: StorefrontGetKycDocumentCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/storefront/orders.yaml
+++ b/openapi/paths/storefront/orders.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - Orders
-  summary: Retrieve a list of orders
+  summary: Retrieve orders
   operationId: StorefrontGetOrderCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - Payment instruments
-  summary: Retrieve a list of Payment Instruments
+  summary: Retrieve payment instruments
   operationId: StorefrontGetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/storefront/products.yaml
+++ b/openapi/paths/storefront/products.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - Products
-  summary: Retrieve a list of products
+  summary: Retrieve products
   operationId: StorefrontGetProductCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/storefront/transactions.yaml
+++ b/openapi/paths/storefront/transactions.yaml
@@ -3,7 +3,7 @@ get:
     - Storefront
   tags:
     - Transactions
-  summary: Retrieve a list of transactions
+  summary: Retrieve transactions
   operationId: StorefrontGetTransactionCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/subscription-cancellations.yaml
+++ b/openapi/paths/subscription-cancellations.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Orders
-  summary: Retrieve a list of cancellations
+  summary: Retrieve cancellations
   operationId: GetSubscriptionCancellationCollection
   x-sdk-operation-name: getAll
   description: Retrieve a list of cancellations for all subscriptions.

--- a/openapi/paths/subscription-pauses.yaml
+++ b/openapi/paths/subscription-pauses.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Orders
-  summary: Retrieve a list of subscription pauses
+  summary: Retrieve subscription pauses
   operationId: GetSubscriptionPauseCollection
   x-sdk-operation-name: getAll
   description: Retrieve a list of pauses for all subscriptions.

--- a/openapi/paths/subscription-reactivations.yaml
+++ b/openapi/paths/subscription-reactivations.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Orders
-  summary: Retrieve a list of reactivations
+  summary: Retrieve reactivations
   operationId: GetSubscriptionReactivationCollection
   x-sdk-operation-name: getAll
   description: Retrieve a list of reactivations for all subscriptions.

--- a/openapi/paths/subscriptions.yaml
+++ b/openapi/paths/subscriptions.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Orders
-  summary: Retrieve a list of orders
+  summary: Retrieve orders
   operationId: GetSubscriptionCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/subscriptions@{id}.yaml
+++ b/openapi/paths/subscriptions@{id}.yaml
@@ -45,7 +45,7 @@ put:
     - Core
   tags:
     - Orders
-  summary: Create or update an order with specified ID
+  summary: Upsert an order
   operationId: PutSubscription
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/subscriptions@{id}@timeline.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Orders timeline
-  summary: Retrieve a list of order timeline messages
+  summary: Retrieve order timeline messages
   operationId: GetSubscriptionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -3,7 +3,7 @@ get:
     - Core
   tags:
     - Tags
-  summary: Retrieve a list of tags
+  summary: Retrieve tags
   operationId: GetTagCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/tokens.yaml
+++ b/openapi/paths/tokens.yaml
@@ -55,7 +55,7 @@ get:
     - Core
   tags:
     - Payment tokens
-  summary: Retrieve a list of tokens
+  summary: Retrieve tokens
   operationId: GetTokenCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/tracking@api.yaml
+++ b/openapi/paths/tracking@api.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Tracking
-  summary: Retrieve a list of tracking API logs
+  summary: Retrieve tracking API logs
   operationId: GetTrackingApiCollection
   x-sdk-operation-name: getAllApiLogs
   parameters:

--- a/openapi/paths/tracking@webhooks.yaml
+++ b/openapi/paths/tracking@webhooks.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Tracking
-  summary: Retrieve a list of tracking webhook notifications
+  summary: Retrieve tracking webhook notifications
   operationId: GetTrackingWebhookCollection
   x-sdk-operation-name: getAllWebhookTrackingLogs
   parameters:

--- a/openapi/paths/transactions.yaml
+++ b/openapi/paths/transactions.yaml
@@ -68,7 +68,7 @@ get:
     - Core
   tags:
     - Transactions
-  summary: Retrieve a list of transactions
+  summary: Retrieve transactions
   operationId: GetTransactionCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/transactions@{id}@timeline.yaml
+++ b/openapi/paths/transactions@{id}@timeline.yaml
@@ -5,7 +5,7 @@ get:
     - Core
   tags:
     - Transactions timeline
-  summary: Retrieve a list of transaction timeline messages
+  summary: Retrieve transaction timeline messages
   operationId: GetTransactionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
   description: |

--- a/openapi/paths/users@{id}.yaml
+++ b/openapi/paths/users@{id}.yaml
@@ -35,7 +35,7 @@ put:
     - Users
   tags:
     - Users
-  summary: Create or update user with specified ID
+  summary: Upsert a user
   operationId: PutUser
   x-sdk-operation-name: update
   description: |

--- a/openapi/paths/webhooks.yaml
+++ b/openapi/paths/webhooks.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Webhooks
-  summary: Retrieve a list of webhooks
+  summary: Retrieve webhooks
   operationId: GetWebhookCollection
   x-sdk-operation-name: getAll
   description: |

--- a/openapi/paths/webhooks@{id}.yaml
+++ b/openapi/paths/webhooks@{id}.yaml
@@ -36,7 +36,7 @@ put:
     - Users
   tags:
     - Webhooks
-  summary: Create or update a webhook with specified ID
+  summary: Upsert a webhook
   operationId: PutWebhook
   x-sdk-operation-name: update
   security:

--- a/openapi/paths/websites.yaml
+++ b/openapi/paths/websites.yaml
@@ -3,7 +3,7 @@ get:
     - Users
   tags:
     - Websites
-  summary: Retrieve a list of websites
+  summary: Retrieve websites
   operationId: GetWebsiteCollection
   x-sdk-operation-name: getAll
   security:

--- a/openapi/paths/websites@{id}.yaml
+++ b/openapi/paths/websites@{id}.yaml
@@ -39,7 +39,7 @@ put:
     - Users
   tags:
     - Websites
-  summary: Create or update a website with specified ID
+  summary: Upsert a website
   operationId: PutWebsite
   x-sdk-operation-name: update
   description: |


### PR DESCRIPTION
## Summary

This pull request makes two updates to all summary fields to help make them more concise. Many of our summary descriptions are currently two lines long in the left navigation. This pull request helps shorten them.

### Changes

- `Create and update...` -> `Upsert...`: Reduces the description length and helps the reader to quickly differentiate between create and upsert operations. The term 'upsert' is described as 'create or update' in all operation descriptions.
- `Retrieve a list of...` -> `Retrieve...`: Shortens the summary for operations that retrieve a collect of items. The term 'a list of' is not needed here. The reader can differentiate between retrieving a single entity or many, as follows: 
    - Retrieve a customer -> gets one customer
    - Retrieve customers -> gets more than one customer, all customers, or a collection of customers

### [Preview](https://preview.redoc.ly/openapi-api/summary-update/)

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
