### PR TITLE
Clarify what happens if allocation amount exceeds limit

### DIFF
--- a/openapi/components/schemas/CreditMemos/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemos/CreditMemo.yaml
@@ -38,8 +38,7 @@ properties:
             amount:
               description: |-
                 Amount of credit that is allocated from the credit memo to the transaction.
-                This value cannot exceed the unused amount of the credit memo or the transaction amount.
-                If the `amount` value is not supplied, the lesser of the following two values is used:
+                If the `amount` value is not supplied or exceeds the unused amount of the credit memo or the transaction amount, the lesser of the following two values is used:
                 - The unused amount of the credit memo.
                 - The transaction amount.
               type: number


### PR DESCRIPTION
## Summary
Add clarification that the amount is adjusted if it exceeds either the credit memo unused amount or the transaction amount.
