### PR TITLE
Add PayPal client ID to RTP response

### DIFF
--- a/openapi/components/schemas/ReadyToPay/Features/PayPalBillingAgreementFeature.yaml
+++ b/openapi/components/schemas/ReadyToPay/Features/PayPalBillingAgreementFeature.yaml
@@ -3,6 +3,7 @@ title: Billing agreement
 required:
   - name
   - paypalMerchantId
+  - paypalClientId
   - billingAgreementToken
   - expirationTime
 properties:
@@ -11,6 +12,9 @@ properties:
   paypalMerchantId:
     type: string
     description: PayPal merchant ID.
+  paypalClientId:
+    type: string
+    description: PayPal client ID.
   billingAgreementToken:
     type: string
     description: PayPal billing agreement token.


### PR DESCRIPTION
## Summary
Adds the PayPal client ID to the Ready to Pay response for the PayPal payment method.

## Checklist

- [X] Writing style
- [X] API design standards
