### PR TITLE
Update to style to remove word from examples

### DIFF
--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -214,7 +214,7 @@ Response example:
 ```yaml
 responses:
   '200':
-    description: Revenue audit report successfully retrieved.
+    description: Revenue audit report retrieved.
 ```
 
 Response example:
@@ -222,7 +222,7 @@ Response example:
 ```yaml
 responses:
   '200':
-    description: Report successfully retrieved.
+    description: Report retrieved.
 ```
 
 ### Objects, parameters, and properties descriptions examples


### PR DESCRIPTION
## Summary

This pull request updates the writing guide to remove 'successfully' from responses examples. This word does not add to the meaning on these messages.

## Links

N/A

## Checklist

- [x] Writing style
- [x] API design standards
