### PR TITLE
Add PayPal Partner account credential fields

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
@@ -5,6 +5,23 @@ allOf:
     required:
       - settings
     properties:
+      credentials:
+        type: object
+        description: PayPal credentials object. The credentials object may be provided in order to specify the PayPal Partner account under which the gateway account is onboarded.
+        properties:
+          partnerId:
+            type: string
+            description: ID of the PayPal Partner account.
+          partnerClientId:
+            type: string
+            description: ID of the PayPal Partner account API client.
+          partnerSecret:
+            type: string
+            description: Secret key for the PayPal Partner account API client.
+            format: password
+          partnerBnCode:
+            type: string
+            description: BN Code for the PayPal Partner account. Used to track the source of API requests.
       settings:
         type: object
         description: PayPal settings object.

--- a/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
@@ -7,7 +7,7 @@ allOf:
     properties:
       credentials:
         type: object
-        description: PayPal credentials object. The credentials object may be provided in order to specify the PayPal Partner account under which the gateway account is onboarded.
+        description: PayPal credentials object. This object specifies the PayPal Partner account from which a gateway account is registered.
         properties:
           partnerId:
             type: string

--- a/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PayPal.yaml
@@ -21,7 +21,7 @@ allOf:
             format: password
           partnerBnCode:
             type: string
-            description: BN Code for the PayPal Partner account. Used to track the source of API requests.
+            description: BN Code for the PayPal Partner account. This unique code tracks the source of API requests.
       settings:
         type: object
         description: PayPal settings object.


### PR DESCRIPTION
## Summary
Adds a credentials object to PayPal gateway accounts. The fields in this object allow PayPal gateway accounts to be onboarded under third-party PayPal partner accounts.

## Checklist

- [X] Writing style
- [X] API design standards
