### PR TITLE
Rename AmlEntry operations to AmlHit

### DIFF
--- a/openapi/components/schemas/AML.yaml
+++ b/openapi/components/schemas/AML.yaml
@@ -19,7 +19,7 @@ properties:
     description: Describes which list the result is from.
   sourceType:
     readOnly: true
-    description: Describes the categories of the invidual or entity.
+    description: Describes the categories of the individual or entity.
     type: array
     example:
       - sanctions

--- a/openapi/paths/aml.yaml
+++ b/openapi/paths/aml.yaml
@@ -4,7 +4,7 @@ get:
   tags:
     - AML
   summary: Search an individual's details against AML lists
-  operationId: GetAmlEntry
+  operationId: GetAmlHit
   x-sdk-operation-name: getAll
   description: |-
     Searches a individual's details against multiple

--- a/openapi/paths/customers@{id}@aml.yaml
+++ b/openapi/paths/customers@{id}@aml.yaml
@@ -6,7 +6,7 @@ get:
   tags:
     - AML
   summary: Search by customer ID against AML lists
-  operationId: GetCustomerAmlEntryCollection
+  operationId: GetCustomerAmlHitCollection
   x-sdk-operation-name: getAml
   description: |-
     Searches a customer's information, by Rebilly customer ID, against


### PR DESCRIPTION
## Summary
Rename AmlEntry operations to AmlHit for consistent and clear terminology.

## Checklist

- [x] Writing style
- [x] API design standards
