### PR TITLE
fix: fix eventType lists to show appropriate events

### DIFF
--- a/openapi/components/requestBodies/Webhooks/ApplicationInstanceDisabled.yaml
+++ b/openapi/components/requestBodies/Webhooks/ApplicationInstanceDisabled.yaml
@@ -9,15 +9,12 @@ content:
           allOf:
             - $ref: ../../schemas/ResourceId.yaml
         eventType:
+          type: string
+          description: Webhook event type.
           enum:
             - application-instance-disabled
-          example: application-instance-disabled
-          allOf:
-            - $ref: ../../schemas/GlobalWebhookEventType.yaml
         _embedded:
-          description: |-
-            Embedded objects that are requested by the `expand`
-            query parameter.
+          description: Embedded objects.
           type: object
           properties:
             application:

--- a/openapi/components/requestBodies/Webhooks/ApplicationInstanceEnabled.yaml
+++ b/openapi/components/requestBodies/Webhooks/ApplicationInstanceEnabled.yaml
@@ -9,15 +9,12 @@ content:
           allOf:
             - $ref: ../../schemas/ResourceId.yaml
         eventType:
+          type: string
+          description: Webhook event type.
           enum:
             - application-instance-enabled
-          example: application-instance-enabled
-          allOf:
-            - $ref: ../../schemas/GlobalWebhookEventType.yaml
         _embedded:
-          description: |-
-            Embedded objects that are requested by the `expand`
-            query parameter.
+          description: Embedded objects.
           type: object
           properties:
             application:

--- a/openapi/components/requestBodies/Webhooks/BalanceTransactionSettled.yaml
+++ b/openapi/components/requestBodies/Webhooks/BalanceTransactionSettled.yaml
@@ -9,14 +9,13 @@ content:
           description: ID of the transaction.
           type: string
         eventType:
-          example: balance-transaction-settled
-          allOf:
-            - $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - balance-transaction-settled
         _embedded:
           type: object
-          description: |-
-            Available embedded objects that are requested by the expand
-            query parameter.
+          description: Embedded objects.
           properties:
             balanceTransaction:
               $ref: ../../schemas/BalanceTransactions/BalanceTransaction.yaml

--- a/openapi/components/requestBodies/Webhooks/CustomerWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/CustomerWebhook.yaml
@@ -5,7 +5,16 @@ content:
         customerId:
           $ref: ../../schemas/CustomerId.yaml
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - aml-list-possibly-matched
+            - customer-created
+            - customer-merged
+            - customer-one-time-password-requested
+            - customer-redirected-offsite
+            - customer-returned
+            - customer-updated
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
@@ -6,7 +6,11 @@ content:
           description: Dispute identifier string.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - dispute-created
+            - dispute-modified
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/ExperianCheckPerformed.yaml
+++ b/openapi/components/requestBodies/Webhooks/ExperianCheckPerformed.yaml
@@ -4,8 +4,6 @@ content:
       properties:
         customerId:
           $ref: ../../schemas/CustomerId.yaml
-          description: The ID of the checked customer.
-          type: string
         outcome:
           description: The check decision where `1` - record matches, `0` - no matches found, `-1` - record mismatches.
           type: integer
@@ -27,10 +25,13 @@ content:
           type: string
           example: 'Authentication Error: Bad Username or Password'
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - experian-check-performed
         _embedded:
           type: object
-          description: Customer object.
+          description: Embedded object.
           properties:
             customer:
               $ref: ../../schemas/Customer.yaml

--- a/openapi/components/requestBodies/Webhooks/GatewayAccountAndGatewayAccountLimit.yaml
+++ b/openapi/components/requestBodies/Webhooks/GatewayAccountAndGatewayAccountLimit.yaml
@@ -6,7 +6,10 @@ content:
           description: The gateway account ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - gateway-account-limit-reached
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/GatewayAccountWebhook.yaml
@@ -6,7 +6,14 @@ content:
           description: The gateway account ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - gateway-account-downtime-ended
+            - gateway-account-downtime-started
+            # TODO: do these exist:
+            # - gateway-account-onboarding-completed
+            # - gateway-account-onboarding-failed
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/InvoiceAndTransaction.yaml
+++ b/openapi/components/requestBodies/Webhooks/InvoiceAndTransaction.yaml
@@ -9,7 +9,11 @@ content:
           description: ID of the invoice.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - renewal-invoice-payment-canceled
+            - renewal-invoice-payment-declined
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/InvoiceRevenueRecognized.yaml
+++ b/openapi/components/requestBodies/Webhooks/InvoiceRevenueRecognized.yaml
@@ -19,6 +19,7 @@ content:
           $ref: ../../schemas/CurrencyCode.yaml
         eventType:
           type: string
+          description: Webhook event type.
           enum:
             - invoice-revenue-recognized
         _embedded:

--- a/openapi/components/requestBodies/Webhooks/InvoiceTaxCalculationFailed.yaml
+++ b/openapi/components/requestBodies/Webhooks/InvoiceTaxCalculationFailed.yaml
@@ -9,7 +9,10 @@ content:
           description: Error message explaining tax calculation failure.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - invoice-tax-calculation-failed
         _embedded:
           type: object
           description: Invoice object.

--- a/openapi/components/requestBodies/Webhooks/InvoiceWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/InvoiceWebhook.yaml
@@ -6,7 +6,22 @@ content:
           description: The invoice ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - invoice-abandoned
+            - invoice-created
+            - invoice-issued
+            - invoice-modified
+            - invoice-paid
+            - invoice-partially-paid
+            - invoice-partially-refunded
+            - invoice-past-due
+            - invoice-past-due-reminder
+            - invoice-refunded
+            - invoice-reissued
+            - invoice-tax-calculation-failed
+            - invoice-voided
         _embedded:
           type: object
           description: |-

--- a/openapi/components/requestBodies/Webhooks/KycDocumentWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/KycDocumentWebhook.yaml
@@ -11,7 +11,15 @@ content:
           description: The file ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - kyc-document-accepted
+            - kyc-document-created
+            - kyc-document-modified
+            - kyc-document-rejected
+            - kyc-document-reviewed
+            - kyc-document-archived
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/MergedCustomer.yaml
+++ b/openapi/components/requestBodies/Webhooks/MergedCustomer.yaml
@@ -6,7 +6,10 @@ content:
           description: ID of the customer that contains the merged data.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - customer-merged
         duplicatedCustomer:
           $ref: ../../schemas/Customer.yaml
         _embedded:

--- a/openapi/components/requestBodies/Webhooks/PaymentCardWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/PaymentCardWebhook.yaml
@@ -6,7 +6,12 @@ content:
           description: The payment card ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - payment-card-created
+            - payment-card-expiration-reminder
+            - payment-card-expired
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/RenewalInvoiceIssued.yaml
+++ b/openapi/components/requestBodies/Webhooks/RenewalInvoiceIssued.yaml
@@ -9,7 +9,10 @@ content:
           description: The invoice ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - renewal-invoice-issued
         _embedded:
           type: object
           properties:
@@ -25,4 +28,4 @@ content:
             anyOf:
               - $ref: ../../schemas/Links/SubscriptionLink.yaml
               - $ref: ../../schemas/Links/InvoiceLink.yaml
-description: Invoice and Order webhook request body resource.
+description: Renewal invoice issued webhook request body resource.

--- a/openapi/components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
+++ b/openapi/components/requestBodies/Webhooks/SubscriptionAndSubscriptionPause.yaml
@@ -10,7 +10,7 @@ content:
           type: string
         eventType:
           type: string
-          description: Rebilly webhooks event type.
+          description: Webhook event type.
           enum:
             - subscription-pause-created
             - subscription-pause-modified

--- a/openapi/components/requestBodies/Webhooks/SubscriptionWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/SubscriptionWebhook.yaml
@@ -6,7 +6,22 @@ content:
           description: The order ID.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - order-completed
+            - subscription-activated
+            - subscription-canceled
+            - subscription-downgraded
+            - subscription-modified
+            - subscription-reactivated
+            - subscription-renewal-reminder
+            - subscription-renewed
+            - subscription-trial-converted
+            - subscription-trial-end-changed
+            - subscription-trial-end-reminder
+            - subscription-trial-ended
+            - subscription-upgraded
         _embedded:
           type: object
           properties:

--- a/openapi/components/requestBodies/Webhooks/TransactionWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/TransactionWebhook.yaml
@@ -6,7 +6,20 @@ content:
           description: ID of the transaction.
           type: string
         eventType:
-          $ref: ../../schemas/GlobalWebhookEventType.yaml
+          type: string
+          description: Webhook event type.
+          enum:
+            - gateway-account-requested
+            - nsf-response-received
+            - offsite-payment-completed
+            - risk-score-changed
+            - transaction-amount-discrepancy-found
+            - transaction-declined
+            - transaction-discrepancy-found
+            - transaction-process-requested
+            - transaction-processed
+            - transaction-timeout-resolved
+            - waiting-gateway-transaction-completed
         _embedded:
           type: object
           properties:

--- a/openapi/components/schemas/GlobalWebhookEventType.yaml
+++ b/openapi/components/schemas/GlobalWebhookEventType.yaml
@@ -3,8 +3,6 @@ description: Webhook event type.
 enum:
   - aml-list-possibly-matched
   - application-instance-disabled
-  - application-instance-disabled
-  - application-instance-enabled
   - application-instance-enabled
   - balance-transaction-settled
   - credit-memo-applied

--- a/openapi/webhooks/renewal-invoice-issued.yaml
+++ b/openapi/webhooks/renewal-invoice-issued.yaml
@@ -5,7 +5,7 @@ x-products:
 tags:
   - Orders
 requestBody:
-  $ref: ../components/requestBodies/Webhooks/InvoiceAndSubscription.yaml
+  $ref: ../components/requestBodies/Webhooks/RenewalInvoiceIssued.yaml
 responses:
   '2xx':
     description: Returns any 2xx status to indicate that the data was received.


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
The eventType is improperly defined in most webhooks. This fixes the issue to show the relevant event types.

## Links
<!-- add any related links to other PRs or docs -->
n/a

## Checklist

- [x] Writing style
- [x] API design standards
