### PR TITLE
Add SOE as AML source type

### DIFF
--- a/openapi/components/schemas/AML.yaml
+++ b/openapi/components/schemas/AML.yaml
@@ -31,6 +31,7 @@ properties:
         - sanctions
         - adverse-media
         - enforcements
+        - state-owned-enterprise
   gender:
     type: string
     readOnly: true


### PR DESCRIPTION
## Summary
Add SOE (State Owned Enterprise) as an AML source type. It is usually listed as a relationship to another entry, but doesn't necessarily have sanctions/enforcements etc of its own (although it can, and would be marked as another entry in this array if so.)

## Links
N/A

## Checklist

- [x] Writing style
- [x] API design standards
