### PR TITLE
Add guidance on line breaks and capitalization

### DIFF
--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -81,6 +81,23 @@ Features:
 - Use the MRR report in revenue recognition to view predictable recurring revenue. ✅
 - To view predictable recurring revenue, use the MRR report in revenue recognition. ✅
 
+## Capitalization
+
+Use sentence-style capitalization for all descriptions. Capitalize the first letter of the first word and use lowercase thereafter.
+
+### Exceptions
+
+[Proper nouns](https://www.gingersoftware.com/content/grammar-rules/nouns/proper-noun/), including brand, product, and service names, must always be capitalized.
+
+### Examples
+
+- Installs the application.
+- Tests your system.
+- Checks system settings.
+- Retrieves HD movies, TV shows, and more.
+- 1 GB of cloud storage.
+- Available for Microsoft partners.
+
 ## Tags
 
 We use tags to group related operations. When searching operations, the reader may look at the tag description for the context. It is important that we add detail to these descriptions and link to related content if required.

--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -11,7 +11,6 @@ This topic provides guidance on how to write API documentation descriptions.
 - Avoid [passive voice](https://developers.google.com/tech-writing/one/active-voice).
 - Avoid using ("should", "could", "can").
 - To add multi-lined descriptions, after a `description:`, add one space, then insert `|-`. This escapes the YAML formatting and enables the use of Markdown.
-- Use [semantic line breaks](https://sembr.org/).
 
 ## Avoid knowledge bias
 

--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -98,6 +98,28 @@ Use sentence-style capitalization for all descriptions. Capitalize the first let
 - 1 GB of cloud storage.
 - Available for Microsoft partners.
 
+## Line breaks
+
+Use [semantic line breaks](https://sembr.org/). This standard specifies that you must add a line break after each substantial unit of thought. A written unit of thought ends with punctuation. Only add a new line after a period, or a comma.
+
+### Examples
+
+```yaml
+   description: |-
+     Total number of allowed document upload attempts.
+     Use `0` to allow unlimited upload attempts.
+```
+
+```yaml
+  description: |-
+    Property weights that are used for the KYC document verification process.
+
+    All KYC documents start the verification process with a score of 100.
+    If a check fails, the score is reduced by the corresponding weight.
+    For example, if the `firstName` check weight is set to `5`, and the check fails,
+    the KYC document score becomes `95`.
+```
+
 ## Tags
 
 We use tags to group related operations. When searching operations, the reader may look at the tag description for the context. It is important that we add detail to these descriptions and link to related content if required.

--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -11,6 +11,7 @@ This topic provides guidance on how to write API documentation descriptions.
 - Avoid [passive voice](https://developers.google.com/tech-writing/one/active-voice).
 - Avoid using ("should", "could", "can").
 - To add multi-lined descriptions, after a `description:`, add one space, then insert `|-`. This escapes the YAML formatting and enables the use of Markdown.
+- Use [semantic line breaks](https://sembr.org/).
 
 ## Avoid knowledge bias
 


### PR DESCRIPTION
## Summary

Adds guidance to use semantic line breaks and sentence-style capitalization in API descriptions. 

## Links

N/A

## Checklist

- [x] Writing style
- [x] API design standards
