### PR TITLE
docs: add response description rule and fix gaps

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -183,13 +183,13 @@ rules:
       property: description
     assertions:
       pattern: /(\.|\.\n)$/
-  # assert/response-description:
-  #   subject:
-  #     type: Response
-  #     property: description
-  #   assertions:
-  #     # pattern: /^((?!was|will).)*$/m
-  #     notPattern: /(was|will)/i
+  assert/response-description:
+    subject:
+      type: Response
+      property: description
+    assertions:
+      pattern: /(\.)$/
+      notPattern: /(was|will)/i
   assert/operation-description:
     subject:
       type: Operation

--- a/openapi/components/responses/Found.yaml
+++ b/openapi/components/responses/Found.yaml
@@ -1,4 +1,4 @@
-description: Resource was moved.
+description: Resource moved.
 headers:
   Location:
     schema:

--- a/openapi/paths/subscription-cancellations.yaml
+++ b/openapi/paths/subscription-cancellations.yaml
@@ -50,7 +50,7 @@ post:
     $ref: ../components/requestBodies/SubscriptionCancellation.yaml
   responses:
     '201':
-      description: Cancellation created, the order is or will be deactivated.
+      description: Cancellation created.
       headers:
         Location:
           $ref: ../components/headers/Location.yaml

--- a/openapi/paths/subscription-cancellations@{id}.yaml
+++ b/openapi/paths/subscription-cancellations@{id}.yaml
@@ -40,13 +40,13 @@ put:
     $ref: ../components/requestBodies/SubscriptionCancellation.yaml
   responses:
     '200':
-      description: Cancellation updated, the order is or will be deactivated.
+      description: Cancellation updated.
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Subscription/SubscriptionCancellation.yaml
     '201':
-      description: Cancellation created, the order is or will be deactivated.
+      description: Cancellation created.
       headers:
         Location:
           $ref: ../components/headers/Location.yaml

--- a/openapi/paths/subscription-pauses.yaml
+++ b/openapi/paths/subscription-pauses.yaml
@@ -50,8 +50,7 @@ post:
     required: true
   responses:
     '201':
-      description: >
-        Pause created, the subscription will be paused at the specified time.
+      description: Pause created.
       headers:
         Location:
           $ref: ../components/headers/Location.yaml

--- a/openapi/paths/subscription-pauses@{id}.yaml
+++ b/openapi/paths/subscription-pauses@{id}.yaml
@@ -38,13 +38,13 @@ put:
           $ref: ../components/schemas/Subscription/SubscriptionPause.yaml
   responses:
     '200':
-      description: Pause updated, the subscription is or will be paused.
+      description: Pause updated.
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Subscription/SubscriptionPause.yaml
     '201':
-      description: Pause created, the subscription is or will be paused.
+      description: Pause created.
       headers:
         Location:
           $ref: ../components/headers/Location.yaml

--- a/openapi/paths/subscription-reactivations.yaml
+++ b/openapi/paths/subscription-reactivations.yaml
@@ -54,11 +54,10 @@ post:
     required: true
   responses:
     '201':
-      description: >
-        Reactivation created, the order is active and won't be.
-        deactivated.
-
-        If there was a cancellation with status "confirmed", it is revoked.
+      description: |-
+        Reactivation created.
+        The order is active and won't be deactivated.
+        If there is a cancellation with status "confirmed", it is revoked.
       headers:
         Location:
           $ref: ../components/headers/Location.yaml


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
- Add lint rule to identify response descriptions that contain will or was.
- Fix gaps.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
