### PR TITLE
Timestamp when instead of at which

### DIFF
--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -243,14 +243,14 @@ Coupon created time:
 
 ```yaml
   createdTime:
-    description: Date and time at which the coupon is created.
+    description: Date and time when the coupon is created.
 ```
 
 Coupon expired time:
 
 ```yaml
   expiredTime:
-    description: Date and time at which the coupon expires.
+    description: Date and time when the coupon expires.
 ```
 
 ### Boolean fields


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

"Date and time when" seems more natural than "Date and time at which".

Thoughts?

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [ ] Writing style
- [ ] API design standards
