### PR TITLE
Add experimental badge for experimental APIs

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -540,25 +540,6 @@ tags:
     description: |-
       Use organization data exports to export your organization data which you may want to do as a business continuity practice.
       These may also be used to to export data if you decide to migrate to a different payments solution.
-  - name: Rebilly API
-    description: |-
-      Rebilly API is a collection of the most commonly used endpoints and operations.
-      For more information, see the [Rebilly API](https://api-reference.rebilly.com).
-  - name: Reports API
-    description: |-
-      Reports API is a collection of report related endpoints and operations.
-      This API is currently experimental.
-      For more information, see the [Reports API](https://reports-api-docs.rebilly.com).
-  - name: Storefront API
-    description: |-
-      Storefront API is a collection of customer related endpoints and operations.
-      This API is currently experimental.
-      For more information, see the [Storefront API](https://storefront-api-docs.rebilly.com/).
-  - name: Users API
-    description: |-
-      Users API is a collection of user and Rebilly UI related endpoints and operations.
-      A user represents a person who can log in to Rebilly, and take actions based on their granted permissions, and role.
-      For more information, see the [Rebilly User API](https://user-api-docs.rebilly.com).
   - name: Account
     description: |-
       Use these operations to manage Rebilly accounts.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -540,6 +540,25 @@ tags:
     description: |-
       Use organization data exports to export your organization data which you may want to do as a business continuity practice.
       These may also be used to to export data if you decide to migrate to a different payments solution.
+  - name: Rebilly API
+    description: |-
+      Rebilly API is a collection of the most commonly used endpoints and operations.
+      For more information, see the [Rebilly API](https://api-reference.rebilly.com).
+  - name: Reports API
+    description: |-
+      Reports API is a collection of report related endpoints and operations.
+      This API is currently experimental.
+      For more information, see the [Reports API](https://reports-api-docs.rebilly.com).
+  - name: Storefront API
+    description: |-
+      Storefront API is a collection of customer related endpoints and operations.
+      This API is currently experimental.
+      For more information, see the [Storefront API](https://storefront-api-docs.rebilly.com/).
+  - name: Users API
+    description: |-
+      Users API is a collection of user and Rebilly UI related endpoints and operations.
+      A user represents a person who can log in to Rebilly, and take actions based on their granted permissions, and role.
+      For more information, see the [Rebilly User API](https://user-api-docs.rebilly.com).
   - name: Account
     description: |-
       Use these operations to manage Rebilly accounts.

--- a/openapi/paths/balance-transactions.yaml
+++ b/openapi/paths/balance-transactions.yaml
@@ -1,4 +1,5 @@
 get:
+  x-badge: Experimental
   x-products:
     - Users
   tags: ["Balance transactions"]

--- a/openapi/paths/balance-transactions@{id}.yaml
+++ b/openapi/paths/balance-transactions@{id}.yaml
@@ -1,6 +1,7 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
+  x-badge: Experimental
   x-products:
     - Users
   tags: ["Balance transactions"]

--- a/openapi/paths/customers@{customerId}@summary-metrics.yaml
+++ b/openapi/paths/customers@{customerId}@summary-metrics.yaml
@@ -25,6 +25,7 @@ parameters:
     schema:
       type: string
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/fees.yaml
+++ b/openapi/paths/fees.yaml
@@ -1,4 +1,5 @@
 get:
+  x-badge: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -33,6 +34,7 @@ get:
     '403':
       $ref: ../components/responses/Forbidden.yaml
 post:
+  x-badge: Experimental
   x-products:
     - Core
   tags: [Fees]

--- a/openapi/paths/fees@{id}.yaml
+++ b/openapi/paths/fees@{id}.yaml
@@ -1,6 +1,7 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
+  x-badge: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -32,6 +33,7 @@ get:
     '404':
       $ref: ../components/responses/NotFound.yaml
 put:
+  x-badge: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -92,6 +94,7 @@ put:
     '422':
       $ref: ../components/responses/ValidationError.yaml
 patch:
+  x-badge: Experimental
   x-products:
     - Core
   tags: [Fees]

--- a/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
+++ b/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
@@ -1,6 +1,7 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
+  x-badge: Experimental
   x-products:
     - Users
   tags:
@@ -27,6 +28,7 @@ get:
       $ref: ../components/responses/NotFound.yaml
 
 put:
+  x-badge: Experimental
   x-products:
     - Users
   tags:

--- a/openapi/paths/histograms@transactions.yaml
+++ b/openapi/paths/histograms@transactions.yaml
@@ -18,6 +18,7 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@api-log-summary.yaml
+++ b/openapi/paths/reports@api-log-summary.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@cumulative-subscriptions.yaml
+++ b/openapi/paths/reports@cumulative-subscriptions.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@dashboard.yaml
+++ b/openapi/paths/reports@dashboard.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@dcc-markup.yaml
+++ b/openapi/paths/reports@dcc-markup.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@disputes.yaml
+++ b/openapi/paths/reports@disputes.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@events-triggered.yaml
+++ b/openapi/paths/reports@events-triggered.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
+++ b/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
@@ -19,6 +19,7 @@ parameters:
     schema:
       $ref: ../components/schemas/EventType.yaml
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@future-renewals.yaml
+++ b/openapi/paths/reports@future-renewals.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@journal.yaml
+++ b/openapi/paths/reports@journal.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-acceptance-summary.yaml
+++ b/openapi/paths/reports@kyc-acceptance-summary.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-rejection-summary.yaml
+++ b/openapi/paths/reports@kyc-rejection-summary.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-request-summary.yaml
+++ b/openapi/paths/reports@kyc-request-summary.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:
@@ -19,8 +20,7 @@ get:
   summary: Retrieve a KYC requests report
   operationId: GetKycRequestSummaryReport
   x-sdk-operation-name: getKycRequestSummary
-  description: |
-    Retrieve a KYC request report by type and by rejection reasons.
+  description: Retrieve a KYC request report by type and by rejection reasons.
   parameters:
     - name: periodStart
       in: query

--- a/openapi/paths/reports@monthly-recurring-revenue.yaml
+++ b/openapi/paths/reports@monthly-recurring-revenue.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:
@@ -19,8 +20,7 @@ get:
   summary: Retrieve a monthly recurring revenue report
   operationId: GetMonthlyRecurringRevenueReport
   x-sdk-operation-name: getMonthlyRecurringRevenue
-  description: |
-    Retrieve a monthly recurring revenue report.
+  description: Retrieve a monthly recurring revenue report.
   parameters:
     - name: currency
       in: query

--- a/openapi/paths/reports@renewal-sales.yaml
+++ b/openapi/paths/reports@renewal-sales.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:
@@ -19,8 +20,7 @@ get:
   summary: Retrieve a renewal sales report
   operationId: GetRenewalSaleReport
   x-sdk-operation-name: getRenewalSales
-  description: |
-    Retrieve a renewal sales report.
+  description: Retrieve a renewal sales report.
   parameters:
     - name: periodStart
       in: query

--- a/openapi/paths/reports@retention-percentage.yaml
+++ b/openapi/paths/reports@retention-percentage.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@retention-value.yaml
+++ b/openapi/paths/reports@retention-value.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@revenue-audit.yaml
+++ b/openapi/paths/reports@revenue-audit.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@revenue-waterfall.yaml
+++ b/openapi/paths/reports@revenue-waterfall.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:
@@ -19,8 +20,7 @@ get:
   summary: Retrieve a revenue waterfall report
   operationId: GetRevenueWaterfallReport
   x-sdk-operation-name: getRevenueWaterfall
-  description: |
-    Retrieve a revenue waterfall report.
+  description: Retrieve a revenue waterfall report.
   parameters:
     - name: currency
       in: query

--- a/openapi/paths/reports@subscription-cancellation.yaml
+++ b/openapi/paths/reports@subscription-cancellation.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@subscription-renewal.yaml
+++ b/openapi/paths/reports@subscription-renewal.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@time-series-transaction.yaml
+++ b/openapi/paths/reports@time-series-transaction.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@transactions-time-dispute.yaml
+++ b/openapi/paths/reports@transactions-time-dispute.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@transactions.yaml
+++ b/openapi/paths/reports@transactions.yaml
@@ -12,6 +12,7 @@ servers:
         default: unknown
         description: Your organization ID.
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/storefront/preview-purchase.yaml
+++ b/openapi/paths/storefront/preview-purchase.yaml
@@ -1,4 +1,5 @@
 post:
+  x-badge: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
+++ b/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
@@ -19,6 +19,7 @@ parameters:
     schema:
       type: string
 get:
+  x-badge: Experimental
   x-products:
     - Reports
   tags:
@@ -26,8 +27,7 @@ get:
   summary: Retrieve subscription order summary metrics
   operationId: GetSubscriptionSummaryMetricReport
   x-sdk-operation-name: getSubscriptionSummaryMetrics
-  description: |
-    Retrieve subscription order summary metrics.
+  description: Retrieve subscription order summary metrics.
   responses:
     '200':
       description: Metrics retrieved.

--- a/web/index.html
+++ b/web/index.html
@@ -29,11 +29,18 @@
     {{redocHead}}
   </head>
   <body>
-    <!-- <script>
+    <script>
       window.REFERENCE_DOCS_OPTIONS = {
-        BeforeOperationSummary: (operation) => ({ html: `<i>ID: ${operation.operationId}</i>` }),
-      }
-    </script> -->
+        hooks: {
+          BeforeOperationSummary: ({ operation }) =>
+            operation.operationDefinition["x-badge"]
+              ? {
+                  html: `<span style="background: #505A6F;border-radius: 5px;margin-left: 2px;padding: 2px 10px;font-size: 28px;color: white; vertical-align: middle;">${operation.operationDefinition["x-badge"]}</span> `,
+                }
+              : null,
+        },
+      };
+    </script>
     {{redocBody}}
   </body>
 </html>


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

Adds an experimental badge for the experimental APIs.

It uses x-badge defined on the operation level.

```yaml
get:
  x-badge: Experimental
```

Also, ~~removes outdated and unused tags~~.

## Links
<!-- add any related links to other PRs or docs -->
Inspired by this: https://redocly.com/docs/developer-portal/guides/reference-docs-hooks/#example-5-add-the-beta-badge-to-operations

This is intended to work with the API reference docs, and updates to the developer portal are going to follow.

## Checklist

- [x] Writing style
- [x] API design standards
