### PR TITLE
Fix product casing on AML review path

### DIFF
--- a/openapi/paths/aml-checks@{id}@review.yaml
+++ b/openapi/paths/aml-checks@{id}@review.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
   x-products:
-    - core
+    - Core
   tags:
     - AML
   summary: Review an AML check


### PR DESCRIPTION
## Summary
Fix `x-products` casing from `core` to `Core`. Wasn't assigned correctly because of this.

## Links
#1149

## Checklist

- [x] Writing style
- [x] API design standards
