### PR TITLE
chore: add strip to block scalars

### DIFF
--- a/openapi/components/schemas/Transactions/TransactionRedirectUrl.yaml
+++ b/openapi/components/schemas/Transactions/TransactionRedirectUrl.yaml
@@ -1,4 +1,4 @@
-description: |
+description: |-
   URL to redirect the end-user when an offsite transaction is completed.
   The 2 placeholders are available to use in this URI: `{id}` and `{result}`.
   Defaults to the website's configured URL.

--- a/openapi/paths/api-keys.yaml
+++ b/openapi/paths/api-keys.yaml
@@ -6,8 +6,7 @@ get:
   summary: Retrieve API keys
   operationId: GetApiKeyCollection
   x-sdk-operation-name: getAll
-  description: |
-    Retrieve a list of API keys.
+  description: Retrieve a list of API keys.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
@@ -47,7 +46,7 @@ post:
   summary: Create an API key
   operationId: PostApiKey
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create an API key.
   requestBody:
     $ref: ../components/requestBodies/ApiKey.yaml

--- a/openapi/paths/api-keys@{id}.yaml
+++ b/openapi/paths/api-keys@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve API key
   operationId: GetApiKey
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve API key with specified identifier string.
   responses:
     '200':
@@ -38,7 +38,7 @@ put:
   summary: Upsert an API key
   operationId: PutApiKey
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) API key with specified identifier string.
   responses:
     '200':
@@ -81,7 +81,7 @@ delete:
   summary: Delete API key
   operationId: DeleteApiKey
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete API key with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/attachments@{id}.yaml
+++ b/openapi/paths/attachments@{id}.yaml
@@ -38,7 +38,7 @@ put:
   summary: Update an attachment
   operationId: PutAttachment
   x-sdk-operation-name: updateAttachment
-  description: |
+  description: |-
     Updates an attachment with a specified ID.
   requestBody:
     $ref: ../components/requestBodies/Attachment.yaml

--- a/openapi/paths/custom-domains.yaml
+++ b/openapi/paths/custom-domains.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve custom domains
   operationId: GetCustomDomainCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of custom domains.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -42,7 +42,7 @@ post:
   summary: Create a custom domain
   operationId: PostCustomDomain
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a custom domain.
   responses:
     '201':

--- a/openapi/paths/custom-domains@{domain}.yaml
+++ b/openapi/paths/custom-domains@{domain}.yaml
@@ -15,7 +15,7 @@ get:
   summary: Retrieve a custom domain
   operationId: GetCustomDomain
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a custom domain with specified identifier string.
   responses:
     '200':
@@ -38,7 +38,7 @@ delete:
   summary: Delete a custom domain
   operationId: DeleteCustomDomain
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a custom domain with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/files@{id}.yaml
+++ b/openapi/paths/files@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a file record
   operationId: GetFile
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieves a file with a specified ID.
   responses:
     '200':

--- a/openapi/paths/files@{id}@download.yaml
+++ b/openapi/paths/files@{id}@download.yaml
@@ -9,7 +9,7 @@ get:
   summary: Download a file
   operationId: GetFileDownload
   x-sdk-operation-name: download
-  description: |
+  description: |-
     Downloads a file with a specified ID.
   responses:
     '200':

--- a/openapi/paths/payment-cards-bank-names.yaml
+++ b/openapi/paths/payment-cards-bank-names.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve payment card issuing bank names
   operationId: GetPaymentCardBankNameCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of payment card issuing bank names.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml

--- a/openapi/paths/payment-instruments.yaml
+++ b/openapi/paths/payment-instruments.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve payment instruments
   operationId: GetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of payment instruments.
   parameters:
     - $ref: ../components/parameters/collectionFilter.yaml
@@ -50,7 +50,7 @@ post:
   summary: Create a Payment Instrument
   operationId: PostPaymentInstrument
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a payment instrument.
     If such payment card, bank account or alternative payment instrument already exists
     then it is updated instead.

--- a/openapi/paths/payment-instruments@{id}.yaml
+++ b/openapi/paths/payment-instruments@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a Payment Instrument
   operationId: GetPaymentInstrument
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a payment instrument by ID.
   responses:
     '200':

--- a/openapi/paths/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/payment-instruments@{id}@deactivation.yaml
@@ -8,7 +8,7 @@ post:
   summary: Deactivate a payment instrument
   operationId: PostPaymentInstrumentDeactivation
   x-sdk-operation-name: deactivate
-  description: |
+  description: |-
     Deactivate a payment instrument.
   responses:
     '201':

--- a/openapi/paths/payment-methods.yaml
+++ b/openapi/paths/payment-methods.yaml
@@ -11,7 +11,7 @@ get:
   summary: Retrieve payment methods metadata
   operationId: GetPaymentMethodCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve payment methods metadata.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml

--- a/openapi/paths/payment-methods@{apiName}.yaml
+++ b/openapi/paths/payment-methods@{apiName}.yaml
@@ -18,7 +18,7 @@ get:
   summary: Retrieve a specified payment method metadata
   operationId: GetPaymentMethod
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a specified payment method metadata.
   security: []
   responses:

--- a/openapi/paths/payouts.yaml
+++ b/openapi/paths/payouts.yaml
@@ -6,7 +6,7 @@ post:
   summary: Create a credit transaction
   operationId: PostPayout
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a transaction of type `credit`.
   requestBody:
     $ref: ../components/requestBodies/PayoutRequest.yaml

--- a/openapi/paths/permissions-emulation.yaml
+++ b/openapi/paths/permissions-emulation.yaml
@@ -6,7 +6,7 @@ post:
   summary: Start permissions emulation
   operationId: PostPermissionsEmulation
   x-sdk-operation-name: startPermissionsEmulation
-  description: |
+  description: |-
     Start permissions emulation.
 
     Emulation during emulation is not supported. If request sent during an ongoing emulation then 403 is sent in response.

--- a/openapi/paths/plans.yaml
+++ b/openapi/paths/plans.yaml
@@ -10,7 +10,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a list of plans.
   parameters:
     - $ref: ../components/parameters/collectionFilter.yaml
@@ -57,7 +57,7 @@ post:
   summary: Create a plan
   operationId: PostPlan
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a plan.
   requestBody:
     $ref: ../components/requestBodies/Plan.yaml

--- a/openapi/paths/plans@{id}.yaml
+++ b/openapi/paths/plans@{id}.yaml
@@ -12,7 +12,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a plan with specified identifier string.
   responses:
     '200':
@@ -46,7 +46,7 @@ put:
   summary: Upsert a plan
   operationId: PutPlan
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) a Plan with specified identifier string.
   requestBody:
     $ref: ../components/requestBodies/Plan.yaml
@@ -93,7 +93,7 @@ delete:
   summary: Delete a Plan
   operationId: DeletePlan
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a Plan with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/previews@webhooks.yaml
+++ b/openapi/paths/previews@webhooks.yaml
@@ -6,7 +6,7 @@ post:
   summary: Trigger a test webhook
   operationId: PostPreviewWebhook
   x-sdk-operation-name: webhook
-  description: |
+  description: |-
     Trigger a test webhook.
   requestBody:
     $ref: ../components/requestBodies/GlobalWebhook.yaml

--- a/openapi/paths/products.yaml
+++ b/openapi/paths/products.yaml
@@ -10,7 +10,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a list of products.
   parameters:
     - $ref: ../components/parameters/collectionFilter.yaml
@@ -54,7 +54,7 @@ post:
   summary: Create a Product
   operationId: PostProduct
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a Product.
   requestBody:
     $ref: ../components/requestBodies/Product.yaml

--- a/openapi/paths/products@{id}.yaml
+++ b/openapi/paths/products@{id}.yaml
@@ -12,7 +12,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a product with specified identifier string.
   responses:
     '200':
@@ -43,7 +43,7 @@ put:
   summary: Upsert a product
   operationId: PutProduct
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) a product with specified identifier string.
   requestBody:
     $ref: ../components/requestBodies/Product.yaml
@@ -85,7 +85,7 @@ delete:
   summary: Delete a product
   operationId: DeleteProduct
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a product with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/profile.yaml
+++ b/openapi/paths/profile.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve user's profile
   operationId: GetProfile
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve user's profile.
   responses:
     '200':
@@ -33,7 +33,7 @@ put:
   summary: Update user's profile
   operationId: PutProfile
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Update user's profile.
   requestBody:
     content:

--- a/openapi/paths/profile@mfa.yaml
+++ b/openapi/paths/profile@mfa.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve user MFA status
   operationId: GetProfileMfa
   x-sdk-operation-name: getMfa
-  description: |
+  description: |-
     Retrieve user MFA status.
   responses:
     '200':
@@ -33,7 +33,7 @@ post:
   summary: Update user MFA
   operationId: PostProfileMfa
   x-sdk-operation-name: updateMfa
-  description: |
+  description: |-
     Update user MFA. Link with rel `enrollment` must be followed to verify existing or enroll new MFA.
   responses:
     '201':
@@ -63,7 +63,7 @@ delete:
   summary: Delete user MFA
   operationId: DeleteProfileMfa
   x-sdk-operation-name: deleteMfa
-  description: |
+  description: |-
     Delete user MFA. To succed `lastAuthTime` must be no more than 10 minutes before this call.
   responses:
     '204':

--- a/openapi/paths/profile@totp-reset.yaml
+++ b/openapi/paths/profile@totp-reset.yaml
@@ -6,7 +6,7 @@ post:
   summary: Reset (renew) totpSecret
   operationId: PostProfileTotpReset
   x-sdk-operation-name: resetTotp
-  description: |
+  description: |-
     Reset (renew) totpSecret.
   deprecated: true
   responses:

--- a/openapi/paths/reports@events-triggered.yaml
+++ b/openapi/paths/reports@events-triggered.yaml
@@ -20,7 +20,7 @@ get:
   summary: Retrieve a events triggered summary report
   operationId: GetTriggeredEventReport
   x-sdk-operation-name: getEventsTriggeredSummary
-  description: |
+  description: |-
     Retrieve a events triggered summary report.
   parameters:
     - name: periodStart

--- a/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
+++ b/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
@@ -27,7 +27,7 @@ get:
   summary: Retrieve a rules matched summary report
   operationId: GetTriggeredEventRuleReport
   x-sdk-operation-name: getTriggeredEventRuleReport
-  description: |
+  description: |-
     Retrieve a rules matched summary report by events triggered.
   parameters:
     - name: periodStart

--- a/openapi/paths/reports@journal.yaml
+++ b/openapi/paths/reports@journal.yaml
@@ -20,7 +20,7 @@ get:
   summary: Retrieve a journal report
   operationId: GetJournalReport
   x-sdk-operation-name: getJournal
-  description: |
+  description: |-
     Retrieve a journal report which reflects a per-account revenue.
     It is a more-granular step of a revenue waterfall report.
   parameters:

--- a/openapi/paths/reports@kyc-rejection-summary.yaml
+++ b/openapi/paths/reports@kyc-rejection-summary.yaml
@@ -20,7 +20,7 @@ get:
   summary: Retrieve a KYC rejections report
   operationId: GetKycRejectionSummaryReport
   x-sdk-operation-name: getKycRejectionSummary
-  description: |
+  description: |-
     Retrieve a KYC rejection report by type and by rejection reasons.
   parameters:
     - name: periodStart

--- a/openapi/paths/reports@retention-percentage.yaml
+++ b/openapi/paths/reports@retention-percentage.yaml
@@ -20,7 +20,7 @@ get:
   summary: Retrieve a retention percentage report
   operationId: GetRetentionPercentageReport
   x-sdk-operation-name: getRetentionPercentage
-  description: |
+  description: |-
     Retrieve a retention percentage report.
   parameters:
     - name: aggregationField

--- a/openapi/paths/reports@revenue-audit.yaml
+++ b/openapi/paths/reports@revenue-audit.yaml
@@ -20,7 +20,7 @@ get:
   summary: Retrieve a revenue audit report
   operationId: GetRevenueAuditReport
   x-sdk-operation-name: getRevenueAudit
-  description: |
+  description: |-
     Retrieve a revenue audit report which contains detailed journal entries.
     A revenue audit report is a combination of a granular
     [revenue waterfall](https://www.rebilly.com/docs/data-tables/revenue-recognition/#revenue-waterfall)

--- a/openapi/paths/roles.yaml
+++ b/openapi/paths/roles.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve roles
   operationId: GetRoleCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of roles.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml

--- a/openapi/paths/roles@{id}.yaml
+++ b/openapi/paths/roles@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a role
   operationId: GetRole
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a role with specified identifier string.
   parameters:
     - $ref: ../components/parameters/collectionExpand.yaml
@@ -33,7 +33,7 @@ put:
   summary: Create a role with specified ID
   operationId: PutRole
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create a role with specified identifier string.
   responses:
     '200':
@@ -72,7 +72,7 @@ delete:
   summary: Delete a role
   operationId: DeleteRole
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a role with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/shipping-rates.yaml
+++ b/openapi/paths/shipping-rates.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve shipping rates
   operationId: GetShippingRateCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of shipping rates.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -46,7 +46,7 @@ post:
   summary: Create a shipping rate
   operationId: PostShippingRate
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a shipping rate.
   requestBody:
     content:

--- a/openapi/paths/shipping-rates@{id}.yaml
+++ b/openapi/paths/shipping-rates@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a shipping rate
   operationId: GetShippingRate
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a shipping rate with specified identifier string.
   responses:
     '200':
@@ -35,7 +35,7 @@ put:
   summary: Create a shipping rate with specified ID
   operationId: PutShippingRate
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create a shipping rate with specified identifier string.
   responses:
     '200':
@@ -78,7 +78,7 @@ delete:
   summary: Delete a shipping rate
   operationId: DeleteShippingRate
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a shipping rate with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/signup.yaml
+++ b/openapi/paths/signup.yaml
@@ -11,7 +11,7 @@ post:
   summary: Register and create new profile
   operationId: PostSignupRequest
   x-sdk-operation-name: signUp
-  description: |
+  description: |-
     Creates a new user and sends an email confirmation.
   requestBody:
     content:

--- a/openapi/paths/status.yaml
+++ b/openapi/paths/status.yaml
@@ -11,7 +11,7 @@ get:
   summary: Retrieve API current status
   operationId: GetStatus
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve API current status.
   security: []
   responses:

--- a/openapi/paths/storefront/account.yaml
+++ b/openapi/paths/storefront/account.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve account.
   parameters:
     - $ref: ../../components/parameters/collectionExpand.yaml
@@ -33,7 +33,7 @@ patch:
   x-sdk-operation-name: update
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Register account.
   requestBody:
     content:

--- a/openapi/paths/storefront/billing-portals@{slug}.yaml
+++ b/openapi/paths/storefront/billing-portals@{slug}.yaml
@@ -15,7 +15,7 @@ get:
   summary: Retrieve a billing portal
   operationId: StorefrontGetBillingPortal
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a billing portal with a specified slug.
   responses:
     '200':

--- a/openapi/paths/storefront/invoices.yaml
+++ b/openapi/paths/storefront/invoices.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAll
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a list of invoices.
   parameters:
     - $ref: ../../components/parameters/collectionFilter.yaml

--- a/openapi/paths/storefront/invoices@{id}.yaml
+++ b/openapi/paths/storefront/invoices@{id}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a invoice with specified ID.
   parameters:
     - $ref: ../../components/parameters/collectionExpand.yaml

--- a/openapi/paths/storefront/logout.yaml
+++ b/openapi/paths/storefront/logout.yaml
@@ -8,7 +8,7 @@ post:
   x-sdk-operation-name: logout
   security:
       - CustomerJWT: []
-  description: |
+  description: |-
     Destroys the user's current session.
   responses:
     204:

--- a/openapi/paths/storefront/orders.yaml
+++ b/openapi/paths/storefront/orders.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAll
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a list of orders.
   parameters:
     - $ref: ../../components/parameters/collectionFilter.yaml

--- a/openapi/paths/storefront/orders@{id}.yaml
+++ b/openapi/paths/storefront/orders@{id}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve an order with specified identifier string.
   responses:
     200:
@@ -35,7 +35,7 @@ patch:
   x-sdk-operation-name: update
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Update an order with specified ID.
   requestBody:
     $ref: ../../components/requestBodies/storefront/PatchOrder.yaml

--- a/openapi/paths/storefront/orders@{id}@cancellation.yaml
+++ b/openapi/paths/storefront/orders@{id}@cancellation.yaml
@@ -10,7 +10,7 @@ post:
   x-sdk-operation-name: cancel
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Cancel an order.
   requestBody:
     $ref: ../../components/requestBodies/storefront/PostOrderCancellation.yaml

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAll
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a list of payment instruments.
   parameters:
     - $ref: ../../components/parameters/collectionFilter.yaml
@@ -47,7 +47,7 @@ post:
   security:
     - CustomerJWT: []
     - PublishableApiKey: []
-  description: |
+  description: |-
     Create a payment instrument.
 
     The only way to create a payment instrument is using a payment instrument

--- a/openapi/paths/storefront/payment-instruments@{id}.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a payment instrument by ID.
   parameters:
     - $ref: ../../components/parameters/collectionLimit.yaml
@@ -45,7 +45,7 @@ patch:
   x-sdk-operation-name: update
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Update any of the payment instrument's values.
 
     Use Framepay payment token to update desired values.

--- a/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
@@ -10,7 +10,7 @@ post:
   x-sdk-operation-name: deactivate
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Deactivate a payment instrument.
   responses:
     201:

--- a/openapi/paths/storefront/plans.yaml
+++ b/openapi/paths/storefront/plans.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve a list of plans
   operationId: StorefrontGetPlanCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of plans.
   parameters:
     - $ref: ../../components/parameters/collectionFilter.yaml

--- a/openapi/paths/storefront/plans@{id}.yaml
+++ b/openapi/paths/storefront/plans@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a plan
   operationId: StorefrontGetPlan
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a plan with specified ID.
   parameters:
     - $ref: ../../components/parameters/collectionExpand.yaml

--- a/openapi/paths/storefront/products.yaml
+++ b/openapi/paths/storefront/products.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve products
   operationId: StorefrontGetProductCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of products.
   parameters:
     - $ref: ../../components/parameters/collectionFilter.yaml

--- a/openapi/paths/storefront/products@{id}.yaml
+++ b/openapi/paths/storefront/products@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a product
   operationId: StorefrontGetProduct
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a product with specified ID.
   responses:
     200:

--- a/openapi/paths/storefront/purchase.yaml
+++ b/openapi/paths/storefront/purchase.yaml
@@ -6,7 +6,7 @@ post:
   summary: Make a purchase
   operationId: StorefrontPostPurchase
   x-sdk-operation-name: purchase
-  description: |
+  description: |-
     Purchase can be accomplished both with and without Authentication.
     Purchase via pre-created Payment Instrument is only available with Authentication.
     Use purchase preview before making an actual purchase.

--- a/openapi/paths/storefront/register.yaml
+++ b/openapi/paths/storefront/register.yaml
@@ -8,7 +8,7 @@ post:
   x-sdk-operation-name: register
   security:
     - PublishableApiKey: []
-  description: |
+  description: |-
     Register account.
   requestBody:
     $ref: ../../components/requestBodies/storefront/PostRegister.yaml

--- a/openapi/paths/storefront/transactions.yaml
+++ b/openapi/paths/storefront/transactions.yaml
@@ -8,7 +8,7 @@ get:
   x-sdk-operation-name: getAll
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a list of transactions.
   parameters:
     - $ref: ../../components/parameters/collectionLimit.yaml

--- a/openapi/paths/storefront/transactions@{id}.yaml
+++ b/openapi/paths/storefront/transactions@{id}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a transaction with specified ID.
   responses:
     200:

--- a/openapi/paths/storefront/websites@{id}.yaml
+++ b/openapi/paths/storefront/websites@{id}.yaml
@@ -10,7 +10,7 @@ get:
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: |
+  description: |-
     Retrieve a website. Use it to find the website name, logo, or more.
   responses:
     200:

--- a/openapi/paths/subscriptions.yaml
+++ b/openapi/paths/subscriptions.yaml
@@ -10,7 +10,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a list of orders.
   parameters:
     - $ref: ../components/parameters/collectionFilter.yaml
@@ -58,7 +58,7 @@ post:
   summary: Create an order
   operationId: PostSubscription
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create an order. Consider using the [Create or update an order with specified ID](../PutSubscription) operation.
     operation to complete this task.
   parameters:

--- a/openapi/paths/subscriptions@{id}.yaml
+++ b/openapi/paths/subscriptions@{id}.yaml
@@ -14,7 +14,7 @@ get:
     - ApplicationJWT: []
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
-  description: |
+  description: |-
     Retrieve an order with specified identifier string.
   responses:
     '200':
@@ -48,7 +48,7 @@ put:
   summary: Upsert an order
   operationId: PutSubscription
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) an order with specified identifier string.
   parameters:
     - $ref: ../components/parameters/subscriptionExpand.yaml
@@ -97,7 +97,7 @@ delete:
   summary: Delete a pending order
   operationId: DeleteSubscription
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a pending order with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/subscriptions@{id}@timeline.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve order timeline messages
   operationId: GetSubscriptionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
-  description: |
+  description: |-
     Retrieve a list of order timeline messages.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -46,7 +46,7 @@ post:
   summary: Create an order Timeline comment
   operationId: PostSubscriptionTimeline
   x-sdk-operation-name: createTimelineComment
-  description: |
+  description: |-
     Create an order Timeline comment.
   requestBody:
     content:

--- a/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/subscriptions@{id}@timeline@{messageId}.yaml
@@ -14,7 +14,7 @@ get:
   summary: Retrieve an Order Timeline message
   operationId: GetSubscriptionTimeline
   x-sdk-operation-name: getTimelineMessage
-  description: |
+  description: |-
     Retrieve a order message with specified identifier string.
   responses:
     '200':
@@ -42,7 +42,7 @@ delete:
   summary: Delete an Order Timeline message
   operationId: DeleteSubscriptionTimeline
   x-sdk-operation-name: deleteTimelineMessage
-  description: |
+  description: |-
     Delete an Order Timeline message with specified identifier string.
   responses:
     '204':

--- a/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
+++ b/openapi/paths/subscriptions@{id}@upcoming-invoices@{invoiceId}@issue.yaml
@@ -14,7 +14,7 @@ post:
   summary: Issue an upcoming invoice for early pay
   operationId: PostUpcomingInvoiceIssuance
   x-sdk-operation-name: issueUpcomingInvoice
-  description: |
+  description: |-
     Issue an upcoming invoice with specified identifier string for early pay.
   requestBody:
     content:

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve tags
   operationId: GetTagCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of tags.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -47,7 +47,7 @@ post:
   summary: Create a tag
   operationId: PostTag
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a tag.
   requestBody:
     $ref: ../components/requestBodies/Tag.yaml

--- a/openapi/paths/tags@{tag}.yaml
+++ b/openapi/paths/tags@{tag}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve a tag
   operationId: GetTag
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a tag.
   responses:
     '200':
@@ -31,7 +31,7 @@ patch:
   summary: Update a tag
   operationId: PatchTag
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Update a tag.
   requestBody:
     $ref: ../components/requestBodies/UpdateTag.yaml
@@ -60,7 +60,7 @@ delete:
   summary: Delete a tag
   operationId: DeleteTag
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a tag.
     It's an asynchronous operation.
   responses:

--- a/openapi/paths/tags@{tag}@customers.yaml
+++ b/openapi/paths/tags@{tag}@customers.yaml
@@ -46,7 +46,7 @@ delete:
   summary: Untag a list of customers
   operationId: DeleteTagCustomerCollection
   x-sdk-operation-name: untagCustomers
-  description: |
+  description: |-
     Untag a list of customers.
     If the customer from the list is already untagged it is ignored.
     It's an asynchronous operation.

--- a/openapi/paths/tags@{tag}@customers@{customerId}.yaml
+++ b/openapi/paths/tags@{tag}@customers@{customerId}.yaml
@@ -9,7 +9,7 @@ post:
   summary: Tag a customer
   operationId: PostTagCustomer
   x-sdk-operation-name: tagCustomer
-  description: |
+  description: |-
     Tag a customer.
   responses:
     '204':
@@ -28,7 +28,7 @@ delete:
   summary: Untag a customer
   operationId: DeleteTagCustomer
   x-sdk-operation-name: untagCustomer
-  description: |
+  description: |-
     Untag a customer.
   responses:
     '204':

--- a/openapi/paths/tags@{tag}@kyc-documents.yaml
+++ b/openapi/paths/tags@{tag}@kyc-documents.yaml
@@ -8,7 +8,7 @@ post:
   summary: Tag a list of kyc documents
   operationId: PostTagKycDocumentCollection
   x-sdk-operation-name: tagKycDocuments
-  description: |
+  description: |-
     Tag a list of kyc documents.
     If the kyc document from the list is already tagged it is ignored.
     It's an asynchronous operation.

--- a/openapi/paths/tags@{tag}@kyc-documents@{kycDocumentId}.yaml
+++ b/openapi/paths/tags@{tag}@kyc-documents@{kycDocumentId}.yaml
@@ -9,7 +9,7 @@ post:
   summary: Tag a kyc document
   operationId: PostTagKycDocument
   x-sdk-operation-name: tagKycDocument
-  description: |
+  description: |-
     Tag a kyc document.
   responses:
     '204':
@@ -28,7 +28,7 @@ delete:
   summary: Untag a kyc document
   operationId: DeleteTagKycDocument
   x-sdk-operation-name: untagKycDocument
-  description: |
+  description: |-
     Untag a kyc document.
   responses:
     '204':

--- a/openapi/paths/tokens@{token}.yaml
+++ b/openapi/paths/tokens@{token}.yaml
@@ -13,7 +13,7 @@ get:
   summary: Retrieve a token
   operationId: GetToken
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve a token with specified identifier string.
   security:
     - PublishableApiKey: []

--- a/openapi/paths/transactions@{id}.yaml
+++ b/openapi/paths/transactions@{id}.yaml
@@ -12,7 +12,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a Transaction with specified identifier string.
   parameters:
     - $ref: ../components/parameters/collectionExpand.yaml
@@ -44,7 +44,7 @@ patch:
   summary: Update a transaction
   operationId: PatchTransaction
   x-sdk-operation-name: patch
-  description: |
+  description: |-
     Update a transaction's custom fields.
   requestBody:
     $ref: ../components/requestBodies/PatchTransactionRequest.yaml

--- a/openapi/paths/transactions@{id}@timeline.yaml
+++ b/openapi/paths/transactions@{id}@timeline.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve transaction timeline messages
   operationId: GetTransactionTimelineCollection
   x-sdk-operation-name: getAllTimelineMessages
-  description: |
+  description: |-
     Retrieve a list of transaction timeline messages.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -46,7 +46,7 @@ post:
   summary: Create a transaction Timeline comment
   operationId: PostTransactionTimeline
   x-sdk-operation-name: createTimelineComment
-  description: |
+  description: |-
     Create a transaction Timeline comment.
   requestBody:
     content:

--- a/openapi/paths/usages.yaml
+++ b/openapi/paths/usages.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve usage records
   operationId: GetUsageCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieves a list of usage records.
   parameters:
     - $ref: ../components/parameters/collectionFilter.yaml
@@ -42,7 +42,7 @@ post:
   summary: Create a usage record
   operationId: PostUsage
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Creates a usage report.
   requestBody:
     required: true

--- a/openapi/paths/usages@{id}.yaml
+++ b/openapi/paths/usages@{id}.yaml
@@ -11,7 +11,7 @@ get:
   security:
     - SecretApiKey: []
     - JWT: []
-  description: |
+  description: |-
     Retrieves a usage record.
   responses:
     '200':
@@ -34,7 +34,7 @@ put:
   summary: Upsert a usage record
   operationId: PutUsage
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Creates or updates a usage record with a specified ID.
   requestBody:
     required: true
@@ -74,7 +74,7 @@ delete:
   summary: Delete a usage record
   operationId: DeleteUsage
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Deletes a usage record.
   responses:
     '204':

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve a list of users
   operationId: GetUserCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of users.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -49,7 +49,7 @@ post:
   summary: Create an user
   operationId: PostUser
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create an user.
   requestBody:
     $ref: ../components/requestBodies/User.yaml

--- a/openapi/paths/users@{id}.yaml
+++ b/openapi/paths/users@{id}.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve user
   operationId: GetUser
   x-sdk-operation-name: get
-  description: |
+  description: |-
     Retrieve user with specified identifier string.
   responses:
     '200':
@@ -38,7 +38,7 @@ put:
   summary: Upsert a user
   operationId: PutUser
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) user with specified identifier string.
   requestBody:
     $ref: ../components/requestBodies/User.yaml

--- a/openapi/paths/users@{id}@mfa.yaml
+++ b/openapi/paths/users@{id}@mfa.yaml
@@ -8,7 +8,7 @@ get:
   summary: Retrieve user MFA status
   operationId: GetUserMfa
   x-sdk-operation-name: getMfa
-  description: |
+  description: |-
     Retrieve user MFA status.
   responses:
     '200':

--- a/openapi/paths/users@{id}@totp-reset.yaml
+++ b/openapi/paths/users@{id}@totp-reset.yaml
@@ -8,7 +8,7 @@ post:
   summary: Reset (renew) totpSecret
   operationId: PostUserTotpReset
   x-sdk-operation-name: resetTotp
-  description: |
+  description: |-
     Reset (renew) totpSecret.
   responses:
     '201':

--- a/openapi/paths/webhooks.yaml
+++ b/openapi/paths/webhooks.yaml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve webhooks
   operationId: GetWebhookCollection
   x-sdk-operation-name: getAll
-  description: |
+  description: |-
     Retrieve a list of webhooks.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -48,7 +48,7 @@ post:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Create a webhook.
   requestBody:
     $ref: ../components/requestBodies/GlobalWebhook.yaml

--- a/openapi/paths/webhooks@{id}.yaml
+++ b/openapi/paths/webhooks@{id}.yaml
@@ -12,7 +12,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a webhook with specified identifier string.
   responses:
     '200':
@@ -43,7 +43,7 @@ put:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Create or update (upsert) a webhook with specified identifier string.
   requestBody:
     $ref: ../components/requestBodies/GlobalWebhook.yaml

--- a/openapi/paths/websites.yaml
+++ b/openapi/paths/websites.yaml
@@ -10,7 +10,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a list of websites.
   parameters:
     - $ref: ../components/parameters/collectionLimit.yaml
@@ -53,7 +53,7 @@ post:
   summary: Create a website
   operationId: PostWebsite
   x-sdk-operation-name: create
-  description: |
+  description: |-
     Create a website.
   requestBody:
     $ref: ../components/requestBodies/Website.yaml

--- a/openapi/paths/websites@{id}.yaml
+++ b/openapi/paths/websites@{id}.yaml
@@ -12,7 +12,7 @@ get:
     - SecretApiKey: []
     - JWT: []
     - ApplicationJWT: []
-  description: |
+  description: |-
     Retrieve a website with specified identifier string.
   responses:
     '200':
@@ -42,7 +42,7 @@ put:
   summary: Upsert a website
   operationId: PutWebsite
   x-sdk-operation-name: update
-  description: |
+  description: |-
     Create or update (upsert) a website with specified identifier string.
   requestBody:
     $ref: ../components/requestBodies/Website.yaml
@@ -85,7 +85,7 @@ delete:
   summary: Delete a website
   operationId: DeleteWebsite
   x-sdk-operation-name: delete
-  description: |
+  description: |-
     Delete a website with specified identifier string.
   responses:
     '204':

--- a/plugins/products-bundler/mapping/Reports.yaml
+++ b/plugins/products-bundler/mapping/Reports.yaml
@@ -1,7 +1,7 @@
 info:
   version: '0.1'
   title: Rebilly Experimental Reports API
-  description: |
+  description: |-
     # Introduction
 
     This API is experimental and likely to change.  We would appreciate

--- a/plugins/products-bundler/mapping/Storefront.yaml
+++ b/plugins/products-bundler/mapping/Storefront.yaml
@@ -1,7 +1,7 @@
 info:
   version: '0.1'
   title: Rebilly Storefront API
-  description: |
+  description: |-
     # Warning
 
     The Rebilly Storefront API is experimental and subject to change.

--- a/plugins/products-bundler/mapping/Users.yaml
+++ b/plugins/products-bundler/mapping/Users.yaml
@@ -1,6 +1,6 @@
 info:
   title: Rebilly User API
-  description: |
+  description: |-
     # Introduction
     This document covers APIs mostly intended for consumption by Rebilly's
     Frontend GUI [app](https://app.rebilly.com).  However, any client is welcome


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

This change was made using find/replace.

Change from:
```
description: |
```
To:
```
description: |-
```

Note that there are many one-line descriptions which should not have any block scalar. However, that's is not part of this PR. This PR removes the trailing line break from the strings.

## Checklist

- [x] Writing style
- [x] API design standards
