### PR TITLE
Fix cashier request description to fit  docs

### DIFF
--- a/openapi/paths/cashier-requests.yaml
+++ b/openapi/paths/cashier-requests.yaml
@@ -3,11 +3,11 @@ post:
     - Core
   tags:
     - Cashier
-  summary: Create a cashier request
+  summary: Create a cashier deposit request
   operationId: PostCashierRequest
   x-sdk-operation-name: create
   description: |-
-    Creates a cashier request.
+    Creates a cashier deposit request.
     To complete the deposit, the customer is redirected to the `cashier` link.
     After the deposit, the customer is redirected to the `redirectUrl`.
     Corresponding transaction webhooks are sent to webhooks subscribers.
@@ -39,7 +39,7 @@ get:
     - Core
   tags:
     - Cashier
-  summary: Retrieve cashier requests
+  summary: Retrieve cashier deposit requests
   operationId: GetCashierRequestCollection
   x-sdk-operation-name: getAll
   description: Retrieves a list of cashier requests.
@@ -50,7 +50,7 @@ get:
     - $ref: ../components/parameters/collectionSort.yaml
   responses:
     '200':
-      description: List of cashier requests retrieved.
+      description: List of cashier deposit requests retrieved.
       headers:
         Pagination-Total:
           $ref: ../components/headers/Pagination-Total.yaml

--- a/openapi/paths/cashier-requests@{id}.yaml
+++ b/openapi/paths/cashier-requests@{id}.yaml
@@ -5,10 +5,10 @@ get:
     - Core
   tags:
     - Cashier
-  summary: Retrieve a cashier request
+  summary: Retrieve a cashier deposit request
   operationId: GetCashierRequest
   x-sdk-operation-name: get
-  description: Retrieves a cashier request with a specified ID.
+  description: Retrieves a cashier deposit request with a specified ID.
   parameters:
     - $ref: ../components/parameters/collectionExpand.yaml
   responses:

--- a/openapi/paths/storefront/cashier-requests@{id}.yaml
+++ b/openapi/paths/storefront/cashier-requests@{id}.yaml
@@ -5,17 +5,17 @@ get:
     - Storefront
   tags:
     - Cashier
-  summary: Retrieve a cashier request
+  summary: Retrieve a cashier deposit request
   operationId: StorefrontGetCashierRequest
   x-sdk-operation-name: get
   security:
     - CustomerJWT: []
-  description: Retrieves a cashier request with a specified ID.
+  description: Retrieves a cashier deposit request with a specified ID.
   parameters:
     - $ref: ../../components/parameters/collectionExpand.yaml
   responses:
     '200':
-      description: Cashier request retrieved.
+      description: Cashier deposit request retrieved.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary
In the docs related to Cashier request, the proper term to define entity is `Cashier deposit request`. 

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
