### PR TITLE
Increase plan name and invoice item description size

### DIFF
--- a/openapi/components/schemas/Common/CommonPlan.yaml
+++ b/openapi/components/schemas/Common/CommonPlan.yaml
@@ -13,6 +13,7 @@ properties:
   name:
     description: Plan name, displayed on invoices and receipts.
     type: string
+    maxLength: 255
   description:
     type: string
     description: Plain-text description of the plan. This field accepts plain-text only.

--- a/openapi/components/schemas/Invoices/InvoiceItem.yaml
+++ b/openapi/components/schemas/Invoices/InvoiceItem.yaml
@@ -21,6 +21,7 @@ properties:
   description:
     description: Description of the invoice item.
     type: string
+    maxLength: 1000
   unitPrice:
     description: Unit price of the invoice item.
     type: number

--- a/openapi/components/schemas/Subscription/UpcomingInvoiceItem.yaml
+++ b/openapi/components/schemas/Subscription/UpcomingInvoiceItem.yaml
@@ -15,6 +15,7 @@ properties:
   description:
     description: Description of line item.
     type: string
+    maxLength: 1000
   unitPriceAmount:
     description: Unit price of the line item.
     type: number


### PR DESCRIPTION
## Summary

Increase Plan.name size to 255
Increase InvoiceItem.description size to 1000
Increase UpcomingInvoiceItem.description size to 1000

## Checklist

- [x] Writing style
- [x] API design standards
