### PR TITLE
Add period to postal code

### DIFF
--- a/openapi/components/schemas/Contact/ContactObject.yaml
+++ b/openapi/components/schemas/Contact/ContactObject.yaml
@@ -61,7 +61,7 @@ properties:
   postalCode:
     description: Contact's postal code.
     type: string
-    pattern: '^[\w\s\-]+$'
+    pattern: '^[\w\s\-\.]+$'
     maxLength: 10
     nullable: true
     example: WC2N 5NF


### PR DESCRIPTION
## Summary

This pull request updates the `postalCode` parameter to permit the use of `.` in postal codes.

## Links

N/A

## Checklist

- [x] Writing style
- [x] API design standards
