### PR TITLE
Update links

### DIFF
--- a/openapi/components/parameters/collectionExpand.yaml
+++ b/openapi/components/parameters/collectionExpand.yaml
@@ -5,6 +5,6 @@ description: |-
   property of the response. This field accepts a comma-separated list of objects.
 
   For more information, see
-  [Expand to include embedded objects](https://api-reference.rebilly.com/#section/Expand-to-include-embedded-objects).
+  [Expand to include embedded objects](https://all-rebilly.redoc.ly/#section/Expand-to-include-embedded-objects).
 schema:
   type: string

--- a/openapi/components/parameters/collectionFilter.yaml
+++ b/openapi/components/parameters/collectionFilter.yaml
@@ -5,6 +5,6 @@ description: |-
   a special format. Use `,` for multiple allowed values.  Use `;` for multiple fields.
 
   For more information, see
-  [Using filter with collections](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
+  [Using filter with collections](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
 schema:
   type: string

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -287,7 +287,7 @@ properties:
       If a transaction exceeds this value, the gateway account is not used.
 
       For more information see,
-      [Using filters](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
+      [Using filters](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
     type: string
     example: amount:1..100;bin:411111,444433
   timeout:

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -60,7 +60,7 @@ properties:
       Use `;` for multiple fields.
 
       For more information,
-      see [Using filters](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
+      see [Using filters](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
     type: string
   createdTime:
     $ref: CreatedTime.yaml

--- a/openapi/components/schemas/PaymentInstruments/ValueObjects/VaultedInstrument.yaml
+++ b/openapi/components/schemas/PaymentInstruments/ValueObjects/VaultedInstrument.yaml
@@ -7,7 +7,7 @@ properties:
   method:
     description: |-
       Payment method supported vault.
-      For more information, see [Payment instrument](https://api-reference.rebilly.com/tag/Payment-Instruments).
+      For more information, see [Payment instrument](https://all-rebilly.redoc.ly/tag/Payment-instruments).
     type: string
     enum:
       - payment-card

--- a/openapi/components/schemas/ReadyToPay/ReadyToPayMethodFilters.yaml
+++ b/openapi/components/schemas/ReadyToPay/ReadyToPayMethodFilters.yaml
@@ -2,6 +2,6 @@ type: array
 description: |-
   For the method to be applicable, one or more of the following filters must match.
   If no filters are sent, no restrictions are applied.
-  For more information, see [Using filters](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
+  For more information, see [Using filters](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
 items:
   type: string

--- a/openapi/components/schemas/ResourceCustomFields.yaml
+++ b/openapi/components/schemas/ResourceCustomFields.yaml
@@ -1,6 +1,6 @@
 description: |-
   Use custom fields to extend a resource scheme to include custom data that is not provided as a common field.
-  For more information, see [Custom fields](https://api-reference.rebilly.com/tag/Custom-fields).
+  For more information, see [Custom fields](https://all-rebilly.redoc.ly/tag/Custom-fields).
 type: object
 default: {}
 example: {"foo": "bar"}

--- a/openapi/components/schemas/Rules/Bind.yaml
+++ b/openapi/components/schemas/Rules/Bind.yaml
@@ -27,7 +27,7 @@ properties:
       This field requires a special format. Use `,` for multiple allowed values.
       Use `;` for multiple fields.
 
-      For more information, see [Using filter with collections](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
+      For more information, see [Using filter with collections](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
     type: string
   actions:
     description: Actions that execute when an event occurs.

--- a/openapi/components/schemas/ShippingTypes/RebillyShipping.yaml
+++ b/openapi/components/schemas/ShippingTypes/RebillyShipping.yaml
@@ -12,4 +12,4 @@ allOf:
       amount:
         type: integer
         readOnly: true
-        description: Shipping amount which is calculated from [Shipping rates](https://api-reference.rebilly.com/tag/Shipping-rates).
+        description: Shipping amount which is calculated from [Shipping rates](https://all-rebilly.redoc.ly/tag/Shipping-rates).

--- a/openapi/description.md
+++ b/openapi/description.md
@@ -29,7 +29,7 @@ Rebilly offers four forms of authentication: secret key, publishable key, JSON W
 To create or manage API keys, select one of the following:
 
 - Use the Rebilly UI: In the left navigation bar, click **Automations**, **Integrations**, **Custom integrations**, then click **API keys**.
-- Use the Rebilly API: go to [API Keys](https://user-api-docs.rebilly.com/#tag/API-Keys).
+- Use the Rebilly API: go to [API Keys](https://all-rebilly.redoc.ly/#tag/API-Keys).
 
 For more information, see [API keys](https://www.rebilly.com/docs/concepts-and-features/concept/api-keys).
 
@@ -60,7 +60,7 @@ Rebilly also offers [FramePay](https://docs.rebilly.com/docs/developer-docs/fram
  a client-side iFrame-based solution to help
 create payment tokens while minimizing PCI DSS compliance burdens
 and maximizing the customization ability. [FramePay](https://docs.rebilly.com/docs/developer-docs/framepay/)
-is interacting with the [payment tokens creation operation](https://api-reference.rebilly.com/tag/Payment-Tokens#operation/PostToken).
+is interacting with the [payment tokens creation operation](https://all-rebilly.redoc.ly/tag/Payment-tokens/operation/PostToken/).
 
 ## Javascript SDK
 
@@ -102,7 +102,7 @@ Here is filter format description:
 - You can use gte (greater than or equals) filter like this: `?filter=amount:1..`, or lte (less than or equals) than filter like this: `?filter=amount:..10`.
   This also works for datetime-based fields.
 
-- You can create some [specified values lists](https://user-api-docs.rebilly.com/#tag/Lists) and use them in filter: `?filter=firstName:@yourListName`.
+- You can create some [specified values lists](https://all-rebilly.redoc.ly/#tag/Lists) and use them in filter: `?filter=firstName:@yourListName`.
   You can also exclude list values: `?filter=firstName:!@yourListName`.
 
 - Datetime-based fields accept values formatted using RFC 3339 like this: `?filter=createdTime:2021-02-14T13:30:00Z`. 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -45,7 +45,7 @@ components:
     JWT:
       description: |-
         JWT is a short lifetime token that can be assigned a specific expiration time.
-        To create a JWT session, see [JWT session resource](https://user-api-docs.rebilly.com/tag/JWT-Session#operation/PostSigninRequest).
+        To create a JWT session, see [JWT session resource](https://all-rebilly.redoc.ly/tag/JWT-session/operation/PostSigninRequest).
 
         Usage format: `Bearer <JWT>`.
       type: http
@@ -53,7 +53,7 @@ components:
       bearerFormat: JWT
     ApplicationJWT:
       description: |-
-        Applications in our App Store can create a JSON Web Token (JWT) by [fetching an user's instance](https://user-api-docs.rebilly.com/tag/Application-owners#operation/GetApplicationInstanceByOrganization).
+        Applications in our App Store can create a JSON Web Token (JWT) by [fetching an user's instance](https://all-rebilly.redoc.ly/tag/Application-owners#operation/GetApplicationInstanceByOrganization).
 
         Usage format: `Bearer <JWT>`.
       type: http
@@ -113,7 +113,7 @@ tags:
       For information on how to create and manage API keys, see [API keys](https://www.rebilly.com/docs/dev-docs/api-keys/).
 
       In addition to API keys, you may use JSON Web Tokens (JWT) to authenticate to the API.
-      For more information, see [JWT session](https://user-api-docs.rebilly.com/#tag/JWT-Session).
+      For more information, see [JWT session](https://all-rebilly.redoc.ly/#tag/JWT-Session).
   - name: Application owners
     description: |-
       Use these operations to register applications to the Rebilly Apps Store and manage application instances.

--- a/openapi/paths/ready-to-pay.yaml
+++ b/openapi/paths/ready-to-pay.yaml
@@ -17,7 +17,7 @@ post:
     To invert this behavior, place an all matching rule at the end of the `ready-to-pay-requested` event in the rules engine,
     and include an empty `paymentMethods` property for the `adjust-ready-to-pay` action.
 
-    For more information, see [Update event rules](https://user-api-docs.rebilly.com/tag/Rules#operation/PutEventRule) and [Gateway accounts](https://user-api-docs.rebilly.com/tag/Gateway-accounts).
+    For more information, see [Update event rules](https://all-rebilly.redoc.ly/tag/Rules#operation/PutEventRule) and [Gateway accounts](https://all-rebilly.redoc.ly/tag/Gateway-accounts).
   requestBody:
     content:
       application/json:

--- a/openapi/paths/reports@revenue-audit.yaml
+++ b/openapi/paths/reports@revenue-audit.yaml
@@ -31,7 +31,7 @@ get:
 
     A revenue audit report is a combination of a granular [revenue waterfall](https://www.rebilly.com/docs/data-tables/revenue-recognition/#revenue-waterfall) and a journal report,
     which describes revenue per account.
-    Use [`filter`](https://api-reference.rebilly.com/#section/Using-filter-with-collections) `limit` and `offset` parameters to restrict the output.
+    Use [`filter`](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections) `limit` and `offset` parameters to restrict the output.
   security:
     - SecretApiKey: []
     - JWT: []

--- a/openapi/paths/storefront/ready-to-pay.yaml
+++ b/openapi/paths/storefront/ready-to-pay.yaml
@@ -19,7 +19,7 @@ post:
     To invert this behavior, place an all matching rule at the end of the `ready-to-pay-requested` event in the rules engine,
     and include an empty `paymentMethods` property for the `adjust-ready-to-pay` action.
 
-    For more information, see [Update event rules](https://user-api-docs.rebilly.com/tag/Rules#operation/PutEventRule) and [Gateway accounts](https://user-api-docs.rebilly.com/tag/Gateway-Accounts).
+    For more information, see [Update event rules](https://all-rebilly.redoc.ly/tag/Rules#operation/PutEventRule) and [Gateway accounts](https://all-rebilly.redoc.ly/tag/Gateway-accounts).
 
     If this operation to pay is used with a transaction-scoped JSON Web Token (JWT), all fields are ignored except `riskMetadata`.
   requestBody:


### PR DESCRIPTION
## Summary

This pull request updates links to remove the use of `user-api-docs.rebilly.com` and `api-reference.rebilly.com` domains, and replaces them with `all-rebilly.redoc.ly`

## Links

N/A

## Checklist

- [x] Writing style
- [x] API design standards
