### PR TITLE
Update CreditMemo taxAmount as read-only

### DIFF
--- a/openapi/components/schemas/CreditMemos/CommonCreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemos/CommonCreditMemo.yaml
@@ -170,7 +170,8 @@ properties:
     default: 0.00
     x-type: Money
   taxAmount:
-    description: Tax amount of an invoice to credit.
+    description: Sum of items tax amount of an invoice to credit.
+    readOnly: true
     type: number
     format: double
     default: 0.00


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

[Preview](https://preview.redoc.ly/rebilly-core/update-tax-amount-as-read-only/tag/Credit-memos/operation/GetCreditMemoCollection)

- [x] Update CreditMemo taxAmount as read-only

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
