### PR TITLE
refactor: remove recursion for embedded descriptions

### DIFF
--- a/openapi/components/schemas/Attachment.yaml
+++ b/openapi/components/schemas/Attachment.yaml
@@ -60,10 +60,9 @@ properties:
             - self
             - file
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ./Embeds/FileEmbed.yaml
+    properties:
+      file:
+        type: object

--- a/openapi/components/schemas/BankAccounts/BankAccount.yaml
+++ b/openapi/components/schemas/BankAccounts/BankAccount.yaml
@@ -32,10 +32,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/Cashier/CashierRequest.yaml
+++ b/openapi/components/schemas/Cashier/CashierRequest.yaml
@@ -89,12 +89,13 @@ properties:
             - cashier
             - transaction
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 0
-    items:
-      anyOf:
-        - $ref: ../Embeds/CustomerEmbed.yaml
-        - $ref: ../Embeds/WebsiteEmbed.yaml
-        - $ref: ../Embeds/TransactionEmbed.yaml
+    properties:
+      customer:
+        type: object
+      website:
+        type: object
+      transaction:
+        type: object

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -133,10 +133,9 @@ properties:
             - leadSource
             - website
   _embedded:
-    type: array
-    description: Array of embedded objects that are requested using the `expand` query string parameter.
+    type: object
+    description: Embedded objects that are requested using the `expand` query string parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ./Embeds/LeadSourceEmbed.yaml
+    properties:
+      leadSource:
+        type: object

--- a/openapi/components/schemas/Dispute.yaml
+++ b/openapi/components/schemas/Dispute.yaml
@@ -277,10 +277,9 @@ properties:
             - self
             - transaction
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ./Embeds/TransactionEmbed.yaml
+    properties:
+      transaction:
+        type: object

--- a/openapi/components/schemas/Invoices/Invoice.yaml
+++ b/openapi/components/schemas/Invoices/Invoice.yaml
@@ -10,6 +10,7 @@ allOf:
       transactions:
         type: array
         description: Invoice transactions array.
+        maxItems: 10
         readOnly: true
         items:
           $ref: ../Transactions/Transaction.yaml
@@ -115,14 +116,17 @@ allOf:
                 - recalculateInvoice
                 - subscription
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
-            - $ref: ../Embeds/WebsiteEmbed.yaml
-            - $ref: ../Embeds/OrganizationEmbed.yaml
-            - $ref: ../Embeds/LeadSourceEmbed.yaml
-            - $ref: ../Embeds/ShippingRateEmbed.yaml
+        properties:
+          customer:
+            type: object
+          website:
+            type: object
+          organization:
+            type: object
+          leadSource:
+            type: object
+          shippingRate:
+            type: object

--- a/openapi/components/schemas/Invoices/InvoiceItem.yaml
+++ b/openapi/components/schemas/Invoices/InvoiceItem.yaml
@@ -80,11 +80,11 @@ properties:
             - self
             - product
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ../Embeds/ProductEmbed.yaml
-        - $ref: ../Embeds/PlanEmbed.yaml
+    properties:
+      product:
+        type: object
+      plan:
+        type: object

--- a/openapi/components/schemas/Journal/JournalRecord.yaml
+++ b/openapi/components/schemas/Journal/JournalRecord.yaml
@@ -59,15 +59,15 @@ properties:
     readOnly: true
     properties:
       customer:
-        $ref: ../Customer.yaml
+        type: object
       invoice:
-        $ref: ../Invoices/Invoice.yaml
+        type: object
       invoiceItem:
-        $ref: ../Invoices/InvoiceItem.yaml
+        type: object
       debitAccount:
-        $ref: ./JournalAccount.yaml
+        type: object
       creditAccount:
-        $ref: ./JournalAccount.yaml
+        type: object
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/KhelocardCard.yaml
+++ b/openapi/components/schemas/KhelocardCard.yaml
@@ -33,10 +33,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ./Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/KycDocument/ProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/KycDocument/ProofOfAddressKycDocument.yaml
@@ -45,10 +45,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/KycDocument/ProofOfCreditFileKycDocument.yaml
+++ b/openapi/components/schemas/KycDocument/ProofOfCreditFileKycDocument.yaml
@@ -27,10 +27,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/KycDocument/ProofOfFundsKycDocument.yaml
+++ b/openapi/components/schemas/KycDocument/ProofOfFundsKycDocument.yaml
@@ -33,10 +33,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/KycDocument/ProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/KycDocument/ProofOfIdentityKycDocument.yaml
@@ -47,10 +47,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/KycDocument/ProofOfPurchaseKycDocument.yaml
+++ b/openapi/components/schemas/KycDocument/ProofOfPurchaseKycDocument.yaml
@@ -35,10 +35,9 @@ allOf:
                 - customer
                 - paymentInstrument
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/PayPalAccount.yaml
+++ b/openapi/components/schemas/PayPalAccount.yaml
@@ -39,11 +39,11 @@ allOf:
                 - authTransaction
                 - approvalUrl
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ./Embeds/AuthTransactionEmbed.yaml
-            - $ref: ./Embeds/CustomerEmbed.yaml
+        properties:
+          authTransaction:
+            type: object
+          customer:
+            type: object

--- a/openapi/components/schemas/PaymentCards/PaymentCard.yaml
+++ b/openapi/components/schemas/PaymentCards/PaymentCard.yaml
@@ -61,11 +61,11 @@ allOf:
                 - authTransaction
                 - approvalUrl
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/AuthTransactionEmbed.yaml
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          authTransaction:
+            type: object
+          customer:
+            type: object

--- a/openapi/components/schemas/PaymentInstruments/AlternativeInstrument.yaml
+++ b/openapi/components/schemas/PaymentInstruments/AlternativeInstrument.yaml
@@ -45,10 +45,9 @@ allOf:
                 - self
                 - customer
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        minItems: 1
-        items:
-          anyOf:
-            - $ref: ../Embeds/CustomerEmbed.yaml
+        properties:
+          customer:
+            type: object

--- a/openapi/components/schemas/Role.yaml
+++ b/openapi/components/schemas/Role.yaml
@@ -54,12 +54,9 @@ properties:
             - seniorRoles
             - juniorRoles
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ./Embeds/JuniorRolesEmbed.yaml
-
-
+    properties:
+      juniorRoles:
+        type: object

--- a/openapi/components/schemas/Storefront/Account.yaml
+++ b/openapi/components/schemas/Storefront/Account.yaml
@@ -34,10 +34,9 @@ properties:
   _links:
     $ref: ../SelfLink.yaml
   _embedded:
-    type: array
+    type: object
     description: Embedded objects that are requested by the `expand` query parameter.
     readOnly: true
-    minItems: 1
-    items:
-      anyOf:
-        - $ref: ../Embeds/WebsiteEmbed.yaml
+    properties:
+      website:
+        type: object

--- a/openapi/components/schemas/Storefront/StorefrontKycRequest.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontKycRequest.yaml
@@ -24,6 +24,4 @@ allOf:
         properties:
           documents:
             type: array
-            items:
-              $ref: ./StorefrontKycDocument.yaml
 

--- a/openapi/components/schemas/Storefront/StorefrontPlan.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontPlan.yaml
@@ -7,6 +7,6 @@ allOf:
         readOnly: true
         properties:
           product:
-            $ref: ./StorefrontProduct.yaml
+            type: object
       _links:
         $ref: ../SelfLink.yaml

--- a/openapi/components/schemas/Transactions/Transaction.yaml
+++ b/openapi/components/schemas/Transactions/Transaction.yaml
@@ -347,17 +347,31 @@ allOf:
                 - queryUrl
                 - redirectUrl
       _embedded:
-        type: array
+        type: object
         description: Embedded objects that are requested by the `expand` query parameter.
         readOnly: true
-        items:
-          anyOf:
-            - $ref: ../Embeds/ParentTransactionEmbed.yaml
-            - $ref: ../Embeds/GatewayAccountEmbed.yaml
-            - $ref: ../Embeds/CustomerEmbed.yaml
-            - $ref: ../Embeds/LeadSourceEmbed.yaml
-            - $ref: ../Embeds/WebsiteEmbed.yaml
-            - $ref: ../Embeds/PaymentCardEmbed.yaml
-            - $ref: ../Embeds/BankAccountEmbed.yaml
-            - $ref: ../Embeds/InvoicesEmbed.yaml
-            - $ref: ../Embeds/ChildTransactionsEmbed.yaml
+        properties:
+          parentTransaction:
+            type: object
+          childTransactions:
+            type: array
+            maxItems: 10
+            description: Most recent child transactions.
+          gatewayAccount:
+            type: object
+          customer:
+            type: object
+          leadSource:
+            type: object
+          website:
+            type: object
+          invoices:
+            type: array
+            maxItems: 10
+            description: Most recent related invoices.
+          paymentCard:
+            type: object
+            # TODO: should this be replaced by `paymentInstrument`?
+          bankAccount:
+            type: object
+            # TODO: should this be replaced by `paymentInstrument`?

--- a/openapi/paths/applications.yaml
+++ b/openapi/paths/applications.yaml
@@ -15,7 +15,6 @@ get:
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionFilter.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
     - $ref: ../components/parameters/collectionFields.yaml
     - $ref: ../components/parameters/collectionSort.yaml
   responses:

--- a/openapi/paths/credit-memos.yaml
+++ b/openapi/paths/credit-memos.yaml
@@ -17,7 +17,6 @@ get:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: List of credit memos retrieved.

--- a/openapi/paths/credit-memos@{id}.yaml
+++ b/openapi/paths/credit-memos@{id}.yaml
@@ -13,8 +13,6 @@ get:
     - JWT: []
     - ApplicationJWT: []
   description: Retrieves a credit memo with a specified ID.
-  parameters:
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Credit memo retrieved.

--- a/openapi/paths/data-exports.yaml
+++ b/openapi/paths/data-exports.yaml
@@ -20,8 +20,6 @@ post:
   operationId: PostDataExport
   x-sdk-operation-name: queue
   description: Requests the export of a specific data resource.
-  parameters:
-    - $ref: ../components/parameters/collectionExpand.yaml
   requestBody:
     $ref: ../components/requestBodies/DataExport.yaml
   responses:
@@ -61,7 +59,6 @@ get:
     - $ref: ../components/parameters/collectionLimit.yaml
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionSort.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
     - $ref: ../components/parameters/collectionFilter.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
     - $ref: ../components/parameters/collectionCriteria.yaml

--- a/openapi/paths/data-exports@{id}.yaml
+++ b/openapi/paths/data-exports@{id}.yaml
@@ -22,8 +22,6 @@ get:
   operationId: GetDataExport
   x-sdk-operation-name: get
   description: Retrieves a data export request.
-  parameters:
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Data export request.
@@ -61,8 +59,6 @@ put:
   operationId: PutDataExport
   x-sdk-operation-name: update
   description: Modifies a pending data export.
-  parameters:
-    - $ref: ../components/parameters/collectionExpand.yaml
   requestBody:
     $ref: ../components/requestBodies/DataExport.yaml
   responses:

--- a/openapi/paths/events@{eventType}@rules@drafts.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts.yaml
@@ -18,7 +18,6 @@ get:
     - $ref: ../components/parameters/collectionQuery.yaml
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionFields.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Draft rulesets retrieved.

--- a/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
@@ -12,7 +12,6 @@ get:
   description: Retrieves a draft ruleset with a specified ID and event type.
   parameters:
     - $ref: ../components/parameters/collectionFields.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Draft ruleset retrieved.

--- a/openapi/paths/events@{eventType}@rules@history.yaml
+++ b/openapi/paths/events@{eventType}@rules@history.yaml
@@ -18,7 +18,6 @@ get:
     - $ref: ../components/parameters/collectionQuery.yaml
     - $ref: ../components/parameters/collectionSort.yaml
     - $ref: ../components/parameters/collectionFields.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Ruleset history retrieved.

--- a/openapi/paths/events@{eventType}@rules@history@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@history@{version}.yaml
@@ -14,7 +14,6 @@ get:
     A history record is created each time rules are changed.
   parameters:
     - $ref: ../components/parameters/collectionFields.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Ruleset history record retrieved.

--- a/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
@@ -14,7 +14,6 @@ get:
     A new version is created each time you change a rule.
   parameters:
     - $ref: ../components/parameters/collectionFields.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     '200':
       description: Ruleset version retrieved.

--- a/openapi/paths/files.yaml
+++ b/openapi/paths/files.yaml
@@ -12,7 +12,6 @@ get:
     - $ref: ../components/parameters/collectionOffset.yaml
     - $ref: ../components/parameters/collectionFilter.yaml
     - $ref: ../components/parameters/collectionQuery.yaml
-    - $ref: ../components/parameters/collectionExpand.yaml
     - $ref: ../components/parameters/collectionFields.yaml
     - $ref: ../components/parameters/collectionSort.yaml
   responses:

--- a/openapi/paths/payout-requests@{id}.yaml
+++ b/openapi/paths/payout-requests@{id}.yaml
@@ -9,8 +9,6 @@ get:
   operationId: GetPayoutRequest
   x-sdk-operation-name: get
   description: Retrieves a payout request with a specified ID.
-  parameters:
-    - $ref: ../components/parameters/collectionExpand.yaml
   responses:
     200:
       description: Payout request retrieved.

--- a/openapi/paths/storefront/invoices@{id}.yaml
+++ b/openapi/paths/storefront/invoices@{id}.yaml
@@ -11,8 +11,6 @@ get:
   security:
     - CustomerJWT: []
   description: Retrieves an invoice with a specified ID.
-  parameters:
-    - $ref: ../../components/parameters/collectionExpand.yaml
   responses:
     200:
       description: Invoice retrieved.

--- a/openapi/paths/storefront/payout-requests@{id}.yaml
+++ b/openapi/paths/storefront/payout-requests@{id}.yaml
@@ -11,8 +11,6 @@ get:
   security:
     - CustomerJWT: []
   description: Retrieves a payout request with a specified ID.
-  parameters:
-    - $ref: ../../components/parameters/collectionExpand.yaml
   responses:
     200:
       description: Payout request retrieved.


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

The `_embedded` descriptions had recursions before. The API actually doesn't support recursion for embedded objects. This reworks how it is described.

In addition, there were some APIs marked as accepting the expand query parameter that don't have any embedded objects, so the query parameter was removed from those descriptions.

## Links
<!-- add any related links to other PRs or docs -->

- Internal discussions on slack.

## Checklist

- [x] Writing style
- [x] API design standards
