### PR TITLE
Enforce `_embedded` is object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ Rebilly uses the following lint rules:
 - [assert/schema-properties-both-created-time-and-updated-time](.redocly.yaml) (custom rules)
 - [assert/put-200-and-201](.redocly.yaml) (custom rules) (this has some exceptions)
 - [assert/schema-properties-camelCase](.redocly.yaml) (custom rules)
+- [assert/embedded-is-object](.redocly.yaml) (custom rules)
 
 ### Servers
 

--- a/openapi/components/schemas/Applications/UserApplication.yaml
+++ b/openapi/components/schemas/Applications/UserApplication.yaml
@@ -1,11 +1,10 @@
 allOf:
   - $ref: ./Application.yaml
   - properties:
-        _embedded:
-          type: array
-          description: Embedded objects that are requested by the `expand` query parameter.
-          readOnly: true
-          minItems: 1
-          items:
-            anyOf:
-              - $ref: ../Embeds/ApplicationInstanceEmbed.yaml
+      _embedded:
+        type: object
+        description: Embedded objects that are requested by the `expand` query parameter.
+        readOnly: true
+        properties:
+          applicationInstance:
+            $ref: ../Applications/ApplicationInstance.yaml

--- a/openapi/components/schemas/BalanceTransactions/BalanceTransactionLinks.yaml
+++ b/openapi/components/schemas/BalanceTransactions/BalanceTransactionLinks.yaml
@@ -15,13 +15,3 @@ properties:
           type: string
           enum:
             - self
-            - parent
-            - transaction
-  _embedded:
-    type: array
-    description: Embedded objects that are requested by the `expand` query parameter.
-    readOnly: true
-    items:
-      anyOf:
-        - $ref: ../Embeds/BalanceTransactionEmbed.yaml
-        - $ref: ../Embeds/TransactionEmbed.yaml

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -405,6 +405,16 @@ rules:
       disallowed:
         - x-internal
 
+  assert/embedded-is-object:
+    severity: error
+    subject:
+      type: Schema
+      property: type
+      filterInParentKeys:
+        - _embedded
+    assertions:
+      const: object
+
       # Need to account for arrays, etc...
   # assert/mediatype-schema-ref-pattern:
   #   subject: MediaType


### PR DESCRIPTION
## Summary

Enforces `_embedded` to have a type of `object` and fixes existing issues.

## Checklist

- [x] Writing style
- [x] API design standards
