### PR TITLE
Add GatewayAccount setting to allow zero amount authorization for setup transactions

### DIFF
--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -336,7 +336,7 @@ properties:
         This is the default behavior.
   allowZeroAuthorization:
     description: |-
-      Allow a zero dollar authorization. This is not supported by all gateways, the default value for an authroization is $1.00.
+      Allow a zero dollar authorization. This is not supported by all gateways, the default value for an authorization is $1.00.
     type: boolean
     default: false
   createdTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -334,6 +334,11 @@ properties:
       do-nothing: |-
         Does nothing except return an approved `setup` transaction.
         This is the default behavior.
+  allowZeroAuthorization:
+    description: |-
+      Allow a zero dollar authorization. This is not supported by all gateways, the default value for an authroization is $1.00.
+    type: boolean
+    default: false
   createdTime:
     $ref: CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -336,7 +336,7 @@ properties:
         This is the default behavior.
   allowZeroAuthorizationSetup:
     description: |-
-      Allow a zero amount for authorization as part of a setup transaction. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction's currency.
+      Allow a zero amount for authorization as part of a setup transaction. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction currency.
     type: boolean
     default: false
   createdTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -334,9 +334,9 @@ properties:
       do-nothing: |-
         Does nothing except return an approved `setup` transaction.
         This is the default behavior.
-  allowZeroAuthorization:
+  allowZeroAuthorizationSetup:
     description: |-
-      Allow a zero amount for authorization. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction's currency.
+      Allow a zero amount for authorization as part of a setup transaction. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction's currency.
     type: boolean
     default: false
   createdTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -336,7 +336,8 @@ properties:
         This is the default behavior.
   allowZeroAuthorizationSetup:
     description: |-
-      Allow a zero amount for authorization as part of a setup transaction. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction currency.
+      Allow a zero amount for authorization as part of a setup transaction.
+      This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction currency.
     type: boolean
     default: false
   createdTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -336,7 +336,7 @@ properties:
         This is the default behavior.
   allowZeroAuthorization:
     description: |-
-      Allow a zero dollar authorization. This is not supported by all gateways, the default value for an authorization is $1.00.
+      Allow a zero amount for authorization. This is not supported by all gateways, the default value for an authorization is 1.00 in the transaction's currency.
     type: boolean
     default: false
   createdTime:


### PR DESCRIPTION
## Summary

Some gateways allow $0 authorizations.  Right now we do $1 instead.

We can change this for setup transactions.

Alternatively, we could add a new setup instruction "verify" that does a $0 auth

## Checklist

- [x] Writing style
- [x] API design standards
