### PR TITLE
Remove mp3 from permitted file types

### DIFF
--- a/openapi/paths/files.yaml
+++ b/openapi/paths/files.yaml
@@ -64,7 +64,7 @@ post:
      the request body, with the appropriate `Content-Type`. No
      additional properties can be set with the request data.
 
-    Permitted file types: `.jpg`, `.png`, `.gif`, `.pdf`, and `.mp3`.
+    Permitted file types: `.jpg`, `.png`, `.gif`, and `.pdf`.
 
     When using a publishable API key, only private files can be created.
     The files can be modified at a later point or time, or can be


### PR DESCRIPTION
## Summary
mp3 is not supported anymore, remove it from description

## Links
https://github.com/Rebilly/api-definitions/pull/1146

## Checklist

- [x] Writing style
- [x] API design standards
