### PR TITLE
Add DataImport endpoints

### DIFF
--- a/openapi/components/schemas/DataImports/DataImport.yaml
+++ b/openapi/components/schemas/DataImports/DataImport.yaml
@@ -1,0 +1,84 @@
+type: object
+properties:
+  id:
+    readOnly: true
+    allOf:
+      - $ref: ../ResourceId.yaml
+  userId:
+    description: ID of the user who requested the organization data import.
+    readOnly: true
+    type: string
+  fileId:
+    description: ID of the linked file object.
+    readOnly: true
+    type: string
+    nullable: true
+  type:
+    description: Type of imported entity import data.
+    type: string
+    enum:
+      - products
+      - plans
+      - websites
+      - gateway-accounts
+  status:
+    description: Status of organization data import request.
+    readOnly: true
+    type: string
+    enum:
+      - pending
+      - processing
+      - completed
+      - queued
+      - failed
+  processedRows:
+    description: The number of processed rows.
+    readOnly: true
+    type: integer
+  unprocessedRows:
+    description: The number of unprocessed rows.
+    readOnly: true
+    type: integer
+  createdTime:
+    $ref: ../CreatedTime.yaml
+  updatedTime:
+    $ref: ../UpdatedTime.yaml
+  processingStartTime:
+    description: |-
+      Date and time when the data import was completed.
+    readOnly: true
+    type: string
+    nullable: true
+    format: date-time
+  completionTime:
+    description: |-
+      Date and time when the data import was completed.
+    readOnly: true
+    type: string
+    nullable: true
+    format: date-time
+  _embedded:
+    type: object
+    description: Embedded objects.
+    properties:
+      dataImportUnprocessedRows:
+        type: array
+        description: Unprocessed rows.
+        readOnly: true
+        items:
+          $ref: ../../schemas/DataImports/DataImportUnprocessedRows.yaml
+  _links:
+    type: array
+    description: Related links.
+    readOnly: true
+    items:
+      type: object
+      properties:
+        href:
+          description: Link URL.
+          type: string
+        rel:
+          description: Type of link.
+          type: string
+          enum:
+            - self

--- a/openapi/components/schemas/DataImports/DataImportUnproccedRows
+++ b/openapi/components/schemas/DataImports/DataImportUnproccedRows
@@ -1,0 +1,41 @@
+type: object
+properties:
+  id:
+    readOnly: true
+    allOf:
+      - $ref: ../ResourceId.yaml
+  dataImportId:
+    description: ID of the organization data import.
+    readOnly: true
+    type: string
+  content:
+    description: Content of the unprocessed row.
+    type: string
+  createdTime:
+    $ref: ../CreatedTime.yaml
+  updatedTime:
+    $ref: ../UpdatedTime.yaml
+  terminationTime:
+    description: |-
+      Date and time when the unprocessed row will be terminated.
+    readOnly: true
+    type: string
+    nullable: true
+    format: date-time
+  _links:
+    type: array
+    description: Related links.
+    readOnly: true
+    items:
+      type: object
+      properties:
+        href:
+          description: Link URL.
+          type: string
+        rel:
+          description: Type of link.
+          type: string
+          enum:
+            - self
+            - user
+            - signedLink

--- a/openapi/paths/data-imports.yaml
+++ b/openapi/paths/data-imports.yaml
@@ -1,0 +1,67 @@
+get:
+  x-products:
+    - DataImports
+  tags:
+    - Data imports
+  summary: Retrieve data imports
+  operationId: GetDataImportCollection
+  x-sdk-operation-name: getAll
+  description: Retrieves a list of data imports.
+  parameters:
+    - $ref: ../components/parameters/collectionLimit.yaml
+    - $ref: ../components/parameters/collectionOffset.yaml
+    - $ref: ../components/parameters/collectionFilter.yaml
+    - $ref: ../components/parameters/collectionQuery.yaml
+    - $ref: ../components/parameters/collectionSort.yaml
+  responses:
+    '200':
+      description: List of data imports retrieved.
+      headers:
+        Pagination-Total:
+          $ref: ../components/headers/Pagination-Total.yaml
+        Pagination-Limit:
+          $ref: ../components/headers/Pagination-Limit.yaml
+        Pagination-Offset:
+          $ref: ../components/headers/Pagination-Offset.yaml
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/DataImports/DataImport.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+post:
+  x-products:
+    - Users
+  tags:
+    - Data imports
+  summary: Request a data import
+  operationId: PostDataImport
+  x-sdk-operation-name: create
+  description: |-
+    Request a data import.
+    The data import is asynchronously processed.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/DataImports/DataImport.yaml
+  responses:
+    '201':
+      description: Organization data export request received.
+      headers:
+        Location:
+          $ref: ../components/headers/Location.yaml
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/DataImports/DataImport.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+    '422':
+      $ref: ../components/responses/ValidationError.yaml

--- a/openapi/paths/data-imports@{id}.yaml
+++ b/openapi/paths/data-imports@{id}.yaml
@@ -1,0 +1,24 @@
+parameters:
+  - $ref: ../components/parameters/resourceId.yaml
+get:
+  x-products:
+    - DataImports
+  tags:
+    - Data imports
+  summary: Retrieve a data import request
+  operationId: GetDataImport
+  x-sdk-operation-name: get
+  description: Retrieve a data import request with a specified ID.
+  responses:
+    '200':
+      description: Data import request.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/DataImports/DataImport.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml


### PR DESCRIPTION
## Summary
DataImport can be used to import predefined data-sets into Rebilly. 

## Checklist

- [ ] Writing style
- [ ] API design standards
