### PR TITLE
add paymentInstrumentId as writeonly to SubscriptionReactivation

### DIFF
--- a/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
@@ -44,8 +44,10 @@ properties:
     writeOnly: true
     description: |-
       ID of the payment instrument. If this field is omitted, the subscription payment instrument remains unchanged.
-    allOf:
-      - $ref: ../ResourceId.yaml
+    type: string
+    nullable: true
+    maxLength: 50
+    example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
     $ref: ../CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
@@ -43,7 +43,8 @@ properties:
   paymentInstrumentId:
     writeOnly: true
     description: |-
-      ID of the payment instrument. If this field is omitted, the subscription payment instrument remains unchanged.
+      ID of the payment instrument. 
+      If this field is omitted, the subscription payment instrument remains unchanged.
     type: string
     nullable: true
     maxLength: 50

--- a/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
+++ b/openapi/components/schemas/Subscription/SubscriptionReactivation.yaml
@@ -40,6 +40,12 @@ properties:
       it is ignored and the next renewal occurs as scheduled.
     type: string
     format: date-time
+  paymentInstrumentId:
+    writeOnly: true
+    description: |-
+      ID of the payment instrument. If this field is omitted, the subscription payment instrument remains unchanged.
+    allOf:
+      - $ref: ../ResourceId.yaml
   createdTime:
     $ref: ../CreatedTime.yaml
   updatedTime:


### PR DESCRIPTION
## Summary
Add optional field `paymentInstrumentId` on `PostSubscriptionReactivation`

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
