### PR TITLE
Remove downloadCsv examples

### DIFF
--- a/openapi/code_samples/JavaScript/customers/get.js
+++ b/openapi/code_samples/JavaScript/customers/get.js
@@ -2,22 +2,8 @@
 const firstCollection = await api.customers.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.customers.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(customer => console.log(customer.fields.primaryAddress.firstName));
-
-
-
-// alternatively you can get the collection as a CSV
-
-// all parameters are optional
-const firstFile = await api.customers.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.customers.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);

--- a/openapi/code_samples/JavaScript/disputes/get.js
+++ b/openapi/code_samples/JavaScript/disputes/get.js
@@ -2,21 +2,8 @@
 const firstCollection = await api.disputes.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.disputes.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(dispute => console.log(dispute.fields.transactionId));
-
-
-
-// alternatively, you can get disputes as a CSV file
-// all parameters are optional
-const firstFile = await api.disputes.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.disputes.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);

--- a/openapi/code_samples/JavaScript/invoices/get.js
+++ b/openapi/code_samples/JavaScript/invoices/get.js
@@ -2,21 +2,8 @@
 const firstCollection = await api.invoices.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.invoices.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(invoice => console.log(invoice.fields.firstName));
-
-
-
-// alternatively, download as a CSV file
-// all parameters are optional
-const firstFile = await api.invoices.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.invoices.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);

--- a/openapi/code_samples/JavaScript/subscriptions/get.js
+++ b/openapi/code_samples/JavaScript/subscriptions/get.js
@@ -2,22 +2,8 @@
 const firstCollection = await api.subscriptions.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.subscriptions.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(subscription => console.log(subscription.fields.customerId));
-
-
-
-// alternatively, download as CSV file
-
-// all parameters are optional
-const firstFile = await api.subscriptions.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.subscriptions.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);

--- a/openapi/code_samples/JavaScript/transactions/get.js
+++ b/openapi/code_samples/JavaScript/transactions/get.js
@@ -2,22 +2,8 @@
 const firstCollection = await api.transactions.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.transactions.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(transaction => console.log(transaction.fields.type));
-
-
-
-// alternatively, download as a CSV file
-
-// all parameters are optional
-const firstFile = await api.transactions.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.transactions.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);

--- a/openapi/code_samples/JavaScript/websites/get.js
+++ b/openapi/code_samples/JavaScript/websites/get.js
@@ -2,22 +2,8 @@
 const firstCollection = await api.websites.getAll();
 
 // alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
+const params = {limit: 20, offset: 100, sort: '-createdTime'};
 const secondCollection = await api.websites.getAll(params);
 
 // access the collection items, each item is a Member
 secondCollection.items.forEach(website => console.log(website.fields.name));
-
-
-
-// alternatively, download as a CSV file
-
-// all parameters are optional
-const firstFile = await api.websites.downloadCSV();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondFile = await api.websites.downloadCSV(params);
-
-// access the file data to view the CSV content 
-console.log(secondFile.data);


### PR DESCRIPTION
## Summary
Remove the `downloadCsv` examples in various collections. This has been deprecated and removed from the API. A more powerful substitute is to use Data Exports.

## Links

## Checklist

- [x] Writing style
- [x] API design standards
