### PR TITLE
chore(ci): Switch js sdk trigger to monorepo

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yaml
+++ b/.github/workflows/trigger-downstream-updates.yaml
@@ -66,9 +66,9 @@ jobs:
       - name: Trigger update workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: Updates SDK resources based on api-definitions
+          workflow: Updates JS SDK resources based on api-definitions
           ref: main
-          repo: Rebilly/rebilly-js-sdk
+          repo: Rebilly/rebilly
           token: ${{ secrets.MACHINE_USER_PAT }}
           inputs: '{ "trigger-reason": "${{needs.generate-trigger-reason.outputs.reason}}" }'
 


### PR DESCRIPTION
## Summary

This PR switches the downstream trigger to generate a new JS SDK to the new `rebilly` monorepo.
