### PR TITLE
Add 3dsecure.io settings for Amex, Discover and JCB brands

### DIFF
--- a/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
+++ b/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
@@ -18,6 +18,18 @@ allOf:
         type: string
         description: Mastercard acquirer merchant ID (MID).
         maxLength: 35
+      acquirerMerchantIdAmex:
+        type: string
+        description: American Express acquirer merchant ID (MID).
+        maxLength: 35
+      acquirerMerchantIdDiscover:
+        type: string
+        description: Discover/Diners acquirer merchant ID (MID).
+        maxLength: 35
+      acquirerMerchantIdJcb:
+        type: string
+        description: JCB acquirer merchant ID (MID).
+        maxLength: 35
       merchantName:
         type: string
         description: Merchant name.
@@ -30,6 +42,21 @@ allOf:
       merchantAcquirerBinMastercard:
         type: string
         description: Mastercard acquirer BIN.
+        minLength: 6
+        maxLength: 11
+      merchantAcquirerBinAmex:
+        type: string
+        description: American Express acquirer BIN.
+        minLength: 6
+        maxLength: 11
+      merchantAcquirerBinDiscover:
+        type: string
+        description: Discover/Diners acquirer BIN.
+        minLength: 6
+        maxLength: 11
+      merchantAcquirerBinJcb:
+        type: string
+        description: JCB acquirer BIN.
         minLength: 6
         maxLength: 11
       merchantCountry:


### PR DESCRIPTION

## Checklist

- [x] Writing style
- [x] API design standards
