### PR TITLE
Fix countries metadata

### DIFF
--- a/openapi/components/schemas/Metadata/CountriesMetadata.yaml
+++ b/openapi/components/schemas/Metadata/CountriesMetadata.yaml
@@ -1,15 +1,11 @@
 type: object
 description: Countries metadata.
-required:
-  - mode
-properties:
-  mode:
-    description: Specifies how the countries are compared.
-    type: string
-    enum:
-      - unknown
-      - all
-      - subset
-oneOf:
+discriminator:
+  propertyName: mode
+  mapping:
+    unknown: ./CountriesUnrestrictedMetadata.yaml
+    all: ./CountriesUnrestrictedMetadata.yaml
+    subset: ./CountriesSubsetMetadata.yaml
+anyOf:
   - $ref: ./CountriesUnrestrictedMetadata.yaml
   - $ref: ./CountriesSubsetMetadata.yaml

--- a/openapi/components/schemas/Metadata/CountriesSubsetMetadata.yaml
+++ b/openapi/components/schemas/Metadata/CountriesSubsetMetadata.yaml
@@ -1,9 +1,11 @@
 type: object
 title: Subset
 required:
+  - mode
   - values
 properties:
   mode:
+    type: string
     enum:
       - subset
   values:

--- a/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
+++ b/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
@@ -1,7 +1,10 @@
 type: object
 title: Unrestricted
+required:
+  - mode
 properties:
   mode:
+    type: string
     enum:
       - unknown
       - all

--- a/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
+++ b/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
@@ -2,13 +2,18 @@ type: object
 title: Unrestricted
 required:
   - mode
-  - values
 properties:
   mode:
     type: string
     enum:
       - unknown
       - all
-    values:
-      description: List of supported countries.
-      type: array
+  values:
+    description: List of supported countries.
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 2
+      maxLength: 2
+      pattern: '^[A-Z]{2}$'

--- a/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
+++ b/openapi/components/schemas/Metadata/CountriesUnrestrictedMetadata.yaml
@@ -2,9 +2,13 @@ type: object
 title: Unrestricted
 required:
   - mode
+  - values
 properties:
   mode:
     type: string
     enum:
       - unknown
       - all
+    values:
+      description: List of supported countries.
+      type: array


### PR DESCRIPTION
## Summary
```
Schema is not matched
Schema path: #/items/properties/countries/additionalProperties
Instance path: /0/countries/values
Warning: must NOT have additional properties `values`


Schema is not matched
Schema path: #/items/properties/countries/oneOf/0/additionalProperties
Instance path: /0/countries/values
Warning: must NOT have additional properties `values`
```
## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
