### PR TITLE
Add description for items element

### DIFF
--- a/openapi/components/schemas/Quotes/Quote.yaml
+++ b/openapi/components/schemas/Quotes/Quote.yaml
@@ -48,6 +48,7 @@ properties:
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ
   items:
     type: array
+    description: Items included in the qoute.
     minItems: 1
     items:
       $ref: ./QuoteItem.yaml


### PR DESCRIPTION
## Summary

This pull request adds a description for the items element in quotes. I missed this during the review.

### [Preview generated docs](https://preview.redoc.ly/all-rebilly/items-description/tag/Quotes/operation/PostQuote)

## Checklist

- [x] Writing style
- [x] API design standards
