### PR TITLE
Remove v1 and v2 ThreeDSecureIO3dsServer properties

### DIFF
--- a/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
+++ b/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
@@ -9,6 +9,7 @@ allOf:
       - merchantAcquirerBinMastercard
       - merchantCountry
       - merchantUrl
+      - transactionType
     properties:
       acquirerMerchantIdVisa:
         type: string
@@ -68,21 +69,6 @@ allOf:
         type: string
         description: Merchant URL.
         maxLength: 2048
-      v1:
-        type: boolean
-        description: |-
-          Value determines if requests can use version 1 of 3DS.
-          In case both v1 and v2 are enabled, v2 is used.
-          If v2 is not supported for the issuer, v1 is used.
-
-          Version 1 has been deprecated by both Visa and Mastercard.
-        deprecated: true
-      v2:
-        type: boolean
-        description: |-
-          Value determines if requests attempt version 2 of 3DS.
-          In case both v1 and v2 are enabled, v2 is used.
-          If v2 is not supported for the issuer, v1 is used.
       transactionType:
         type: string
         enum:
@@ -122,7 +108,7 @@ allOf:
           - '11'
         description: |-
           Indicates the type of 3RI request.
-          Values 06 - 11 are only supported in 3D2 2.2.0.
+          Values 06 - 11 are only supported in 3DS 2.2.0.
         x-enumDescriptions:
           '01': Recurring transaction.
           '02': Instalment transaction.


### PR DESCRIPTION
## Summary
Remove v1 and v2 ThreeDSecureIO3dsServer properties
Make transactionType required

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
