### PR TITLE
Add match priorities to AML settings API

### DIFF
--- a/openapi/components/schemas/AML/Settings/AmlPriority.yaml
+++ b/openapi/components/schemas/AML/Settings/AmlPriority.yaml
@@ -1,5 +1,5 @@
 type: string
-descripton: Priority for the matched confidence level.
+description: Priority for the matched confidence level.
 nullable: true
 default: null
 enum:

--- a/openapi/components/schemas/AML/Settings/AmlPriority.yaml
+++ b/openapi/components/schemas/AML/Settings/AmlPriority.yaml
@@ -1,0 +1,9 @@
+type: string
+descripton: Priority for the matched confidence level.
+nullable: true
+default: null
+enum:
+  - p0
+  - p1
+  - p2
+  - p3

--- a/openapi/components/schemas/AML/Settings/AmlSettingsPriority.yaml
+++ b/openapi/components/schemas/AML/Settings/AmlSettingsPriority.yaml
@@ -1,0 +1,63 @@
+type: object
+description: Priority settings.
+properties:
+  pep:
+    type: object
+    description: Priorities for the PEP source type.
+    properties:
+      very-strong:
+        $ref: ./AmlPriority.yaml
+      strong:
+        $ref: ./AmlPriority.yaml
+      medium:
+        $ref: ./AmlPriority.yaml
+      weak:
+        $ref: ./AmlPriority.yaml
+  enforcements:
+    type: object
+    description: Priorities for the enforcement source type.
+    properties:
+      very-strong:
+        $ref: ./AmlPriority.yaml
+      strong:
+        $ref: ./AmlPriority.yaml
+      medium:
+        $ref: ./AmlPriority.yaml
+      weak:
+        $ref: ./AmlPriority.yaml
+  state-owned-enterprise:
+    type: object
+    description: Priorities for the state-owned-enterprise source type.
+    properties:
+      very-strong:
+        $ref: ./AmlPriority.yaml
+      strong:
+        $ref: ./AmlPriority.yaml
+      medium:
+        $ref: ./AmlPriority.yaml
+      weak:
+        $ref: ./AmlPriority.yaml
+  sanctions:
+    type: object
+    description: Priorities for the sanctions source type.
+    properties:
+      very-strong:
+        $ref: ./AmlPriority.yaml
+      strong:
+        $ref: ./AmlPriority.yaml
+      medium:
+        $ref: ./AmlPriority.yaml
+      weak:
+        $ref: ./AmlPriority.yaml
+    adverse-media:
+      type: object
+      description: Priorities for the adverse-media source type.
+      properties:
+        very-strong:
+          $ref: ./AmlPriority.yaml
+        strong:
+          $ref: ./AmlPriority.yaml
+        medium:
+          $ref: ./AmlPriority.yaml
+        weak:
+          $ref: ./AmlPriority.yaml

--- a/openapi/components/schemas/AML/Settings/AmlSettingsPriority.yaml
+++ b/openapi/components/schemas/AML/Settings/AmlSettingsPriority.yaml
@@ -3,9 +3,9 @@ description: Priority settings.
 properties:
   pep:
     type: object
-    description: Priorities for the PEP source type.
+    description: Priorities for the `pep` source type.
     properties:
-      very-strong:
+      veryStrong:
         $ref: ./AmlPriority.yaml
       strong:
         $ref: ./AmlPriority.yaml
@@ -15,9 +15,9 @@ properties:
         $ref: ./AmlPriority.yaml
   enforcements:
     type: object
-    description: Priorities for the enforcement source type.
+    description: Priorities for the `enforcement` source type.
     properties:
-      very-strong:
+      veryStrong:
         $ref: ./AmlPriority.yaml
       strong:
         $ref: ./AmlPriority.yaml
@@ -25,11 +25,11 @@ properties:
         $ref: ./AmlPriority.yaml
       weak:
         $ref: ./AmlPriority.yaml
-  state-owned-enterprise:
+  stateOwnedEnterprise:
     type: object
-    description: Priorities for the state-owned-enterprise source type.
+    description: Priorities for the `state-owned-enterprise` source type.
     properties:
-      very-strong:
+      veryStrong:
         $ref: ./AmlPriority.yaml
       strong:
         $ref: ./AmlPriority.yaml
@@ -39,9 +39,9 @@ properties:
         $ref: ./AmlPriority.yaml
   sanctions:
     type: object
-    description: Priorities for the sanctions source type.
+    description: Priorities for the `sanctions` source type.
     properties:
-      very-strong:
+      veryStrong:
         $ref: ./AmlPriority.yaml
       strong:
         $ref: ./AmlPriority.yaml
@@ -49,15 +49,15 @@ properties:
         $ref: ./AmlPriority.yaml
       weak:
         $ref: ./AmlPriority.yaml
-    adverse-media:
-      type: object
-      description: Priorities for the adverse-media source type.
-      properties:
-        very-strong:
-          $ref: ./AmlPriority.yaml
-        strong:
-          $ref: ./AmlPriority.yaml
-        medium:
-          $ref: ./AmlPriority.yaml
-        weak:
-          $ref: ./AmlPriority.yaml
+  adverseMedia:
+    type: object
+    description: Priorities for the `adverse-media` source type.
+    properties:
+      veryStrong:
+        $ref: ./AmlPriority.yaml
+      strong:
+        $ref: ./AmlPriority.yaml
+      medium:
+        $ref: ./AmlPriority.yaml
+      weak:
+        $ref: ./AmlPriority.yaml

--- a/openapi/components/schemas/AmlSettings.yaml
+++ b/openapi/components/schemas/AmlSettings.yaml
@@ -4,3 +4,6 @@ properties:
   confidence:
     allOf:
       - $ref: ./AML/Settings/AmlSettingsConfidence.yaml
+  priority:
+    allOf:
+      - $ref: ./AML/Settings/AmlSettingsPriority.yaml


### PR DESCRIPTION
## Summary
Add match priorities to AML settings.

I know we have a camelCase rule for property names, but in this case I'd prefer to keep them named the way they are named for confidence (very-strong, strong, etc.) and source types (pep, adverse-media, etc)

If we have to enforce this it will add a bit of complexity to the use of the API for both confidence and source types as they're both kebab-case enum values elsewhere in the schema. (Admittedly not much extra complexity.)

There's no real breaking issue with that, but it's some sort of cognitive load to remember that the camelCase are mapped 1:1 with the respective kebab-case enum values for whatever use case the API consumer has for it.

## Checklist

- [x] Writing style
- [x] API design standards
