### PR TITLE
Add fields to tax report response

### DIFF
--- a/openapi/components/schemas/ReportTax.yaml
+++ b/openapi/components/schemas/ReportTax.yaml
@@ -55,10 +55,10 @@ properties:
           type: number
           format: double
         taxableSalesAmount:
-          description: Amount of sales to which sales tax was applied.
+          description: Amount of taxable sales.
           type: number
           format: double
         nontaxableSalesAmount:
-          description: Amount of sales to which sales tax was not applicable.
+          description: Amount of nontaxable sales.
           type: number
           format: double

--- a/openapi/components/schemas/ReportTax.yaml
+++ b/openapi/components/schemas/ReportTax.yaml
@@ -22,23 +22,43 @@ properties:
           description: Name of city to which the tax is owed.
           type: string
           example: 'AUSTIN'
+        stateRate:
+          description: Percentage rate of state tax.
+          type: number
+          format: double
         stateAmount:
           description: Amount of state tax.
+          type: number
+          format: double
+        countyRate:
+          description: Percentage rate of county tax.
           type: number
           format: double
         countyAmount:
           description: Amount of county tax.
           type: number
           format: double
+        cityRate:
+          description: Percentage rate of city tax.
+          type: number
+          format: double
         cityAmount:
           description: Amount of city tax.
+          type: number
+          format: double
+        specialDistrictRate:
+          description: Percentage rate of special district tax.
           type: number
           format: double
         specialDistrictAmount:
           description: Amount of special district tax.
           type: number
           format: double
-        salesAmount:
-          description: Amount of total sales.
+        taxableSalesAmount:
+          description: Amount of sales to which sales tax was applied.
+          type: number
+          format: double
+        nontaxableSalesAmount:
+          description: Amount of sales to which sales tax was not applicable.
           type: number
           format: double


### PR DESCRIPTION
## Summary

Adds the following fields to the Tax Report response:
- `taxableSalesAmount` to show the amount of sales against which sales tax was assessed
- `nontaxableSalesAmount` to show the amount of sales which did not incur sales tax
- `stateRate` to show the percentage rate of state sales tax
- `countyRate` to show the percentage rate of county sales tax
- `cityRate` to show the percentage rate of city sales tax
- `specialDistrictRate` to show the percentage rate of special district sales tax

## Checklist

- [X] Writing style
- [X] API design standards
