### PR TITLE
Adjust schedule methods

### DIFF
--- a/openapi/components/schemas/GatewayAccounts/RiskReservePeriod.yaml
+++ b/openapi/components/schemas/GatewayAccounts/RiskReservePeriod.yaml
@@ -4,10 +4,5 @@ discriminator:
   propertyName: method
   mapping:
     date-interval: ../Scheduling/Methods/date-interval.yaml
-required:
-  - method
-properties:
-  method:
-    type: string
-    enum:
-      - date-interval
+anyOf:
+  - $ref: ../Scheduling/Methods/date-interval.yaml

--- a/openapi/components/schemas/GatewayAccounts/RiskReservePeriod.yaml
+++ b/openapi/components/schemas/GatewayAccounts/RiskReservePeriod.yaml
@@ -1,8 +1,20 @@
 type: object
 description: Instruction for the calculation of reserve release time.
-discriminator:
-  propertyName: method
-  mapping:
-    date-interval: ../Scheduling/Methods/date-interval.yaml
-anyOf:
-  - $ref: ../Scheduling/Methods/date-interval.yaml
+properties:
+  method:
+    type: string
+    enum:
+      - date-interval
+  duration:
+    type: integer
+    description: Number of time units.
+    minimum: 1
+  unit:
+    description: Unit of time.
+    oneOf:
+      - $ref: ../TimeUnit.yaml
+      - $ref: ../TimePluralUnit.yaml
+required:
+  - method
+  - duration
+  - unit

--- a/openapi/components/schemas/GatewayAccounts/SettlementPeriodAnchor.yaml
+++ b/openapi/components/schemas/GatewayAccounts/SettlementPeriodAnchor.yaml
@@ -9,16 +9,11 @@ discriminator:
   mapping:
     day-of-month: ../Scheduling/Methods/day-of-month.yaml
     day-of-week: ../Scheduling/Methods/day-of-week.yaml
-    immediately: ../Scheduling/Methods/immediately.yaml
-default:
-  method: immediately
 required:
   - method
 properties:
   method:
     type: string
-    default: immediately
     enum:
-      - immediately
       - day-of-month
       - day-of-week

--- a/openapi/components/schemas/GatewayAccounts/SettlementPeriodAnchor.yaml
+++ b/openapi/components/schemas/GatewayAccounts/SettlementPeriodAnchor.yaml
@@ -9,11 +9,6 @@ discriminator:
   mapping:
     day-of-month: ../Scheduling/Methods/day-of-month.yaml
     day-of-week: ../Scheduling/Methods/day-of-week.yaml
-required:
-  - method
-properties:
-  method:
-    type: string
-    enum:
-      - day-of-month
-      - day-of-week
+anyOf:
+  - $ref: ../Scheduling/Methods/day-of-month.yaml
+  - $ref: ../Scheduling/Methods/day-of-week.yaml

--- a/openapi/components/schemas/Scheduling/Methods/day-of-week.yaml
+++ b/openapi/components/schemas/Scheduling/Methods/day-of-week.yaml
@@ -17,7 +17,6 @@ properties:
       - Saturday
   week:
     type: string
-    default: next
     enum:
       - next
       - first-in-month
@@ -26,4 +25,5 @@ properties:
     $ref: ../../TimeIso8601Extended.yaml
 required:
   - day
+  - week
   - method


### PR DESCRIPTION
## Summary
Remove `immediately` schedule method from settlement period anchor
Make `day-of-week` schedule method consistent with API: make week required

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
