### PR TITLE
Add 3DS setting to decline on ECI values

### DIFF
--- a/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
+++ b/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
@@ -104,9 +104,9 @@ allOf:
             00: MasterCard 3DS authentication is either failed or could not be attempted; possible reasons being both card and Issuing Bank are not secured by 3DS, technical errors, or improper configuration.
             01: MasterCard 3DS authentication was attempted but was not or could not be completed; possible reasons being either the card or its Issuing Bank has yet to participate in 3DS, or cardholder ran out of time to authorize.
             02: MasterCard 3DS authentication is successful; both card and Issuing Bank are secured by 3DS.
-            05: VISA 3DS authentication is either failed or could not be attempted; possible reasons being both card and Issuing Bank are not secured by 3DS, technical errors, or improper configuration.
+            05: VISA 3DS authentication is successful; both card and Issuing Bank are secured by 3DS.
             06: VISA 3DS authentication was attempted but was not or could not be completed; possible reasons being either the card or its Issuing Bank has yet to participate in 3DS, or cardholder ran out of time to authorize.
-            07: VISA 3DS authentication is successful; both card and Issuing Bank are secured by 3DS.
+            07: VISA 3DS authentication is either failed or could not be attempted; possible reasons being both card and Issuing Bank are not secured by 3DS, technical errors, or improper configuration.
       use3dsForMerchantInitiated:
         type: boolean
         description: Use 3DS for merchant initiated transactions.

--- a/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
+++ b/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
@@ -88,6 +88,25 @@ allOf:
         type: boolean
         description: Specifies whether to decline transactions if a payment card is not enrolled.
         default: false
+      declineOnEci:
+        type: array
+        description: Decline immediately when the following ECI values received from the 3DS provider.
+        items:
+          type: string
+          enum:
+            - '00'
+            - '01'
+            - '02'
+            - '05'
+            - '06'
+            - '07'
+          x-enumDescriptions:
+            00: MasterCard 3DS authentication is either failed or could not be attempted; possible reasons being both card and Issuing Bank are not secured by 3DS, technical errors, or improper configuration.
+            01: MasterCard 3DS authentication was attempted but was not or could not be completed; possible reasons being either the card or its Issuing Bank has yet to participate in 3DS, or cardholder ran out of time to authorize.
+            02: MasterCard 3DS authentication is successful; both card and Issuing Bank are secured by 3DS.
+            05: VISA 3DS authentication is either failed or could not be attempted; possible reasons being both card and Issuing Bank are not secured by 3DS, technical errors, or improper configuration.
+            06: VISA 3DS authentication was attempted but was not or could not be completed; possible reasons being either the card or its Issuing Bank has yet to participate in 3DS, or cardholder ran out of time to authorize.
+            07: VISA 3DS authentication is successful; both card and Issuing Bank are secured by 3DS.
       use3dsForMerchantInitiated:
         type: boolean
         description: Use 3DS for merchant initiated transactions.

--- a/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
+++ b/openapi/components/schemas/ThreeDSecureServers/ThreeDSecureIO3dsServer.yaml
@@ -90,7 +90,7 @@ allOf:
         default: false
       declineOnEci:
         type: array
-        description: Decline immediately when the following ECI values received from the 3DS provider.
+        description: Decline the transaction immediately when one of the following ECI values are received from the 3DS provider.
         items:
           type: string
           enum:


### PR DESCRIPTION
## Summary

Support a feature on gateway account 3DS configuration where we decline immediately when specific ECI values are received from the 3dsecure.io

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
