### PR TITLE
Fix nullable enum for sourceType, and nullable for taxCategoryId

### DIFF
--- a/openapi/components/schemas/Files/File.yaml
+++ b/openapi/components/schemas/Files/File.yaml
@@ -22,6 +22,7 @@ properties:
       - camera
       - organization-export
       - organization-closure-export
+      - null
     example: upload
   tags:
     description: List of tags associated with the file.

--- a/openapi/components/schemas/Product.yaml
+++ b/openapi/components/schemas/Product.yaml
@@ -53,6 +53,7 @@ properties:
       For a complete list of supported tax categories, see [TaxJar sales tax API reference](https://developers.taxjar.com/api/reference/#get-list-tax-categories).
       If none of the tax categories from the list are applicable for your product, use the general tax category `00000`.
     type: string
+    nullable: true
     example: '00000'
   accountingCode:
     description: Accounting code of the product.


### PR DESCRIPTION
## Summary

> Note that null must be explicitly included in the list of enum values. Using nullable: true alone [is not enough](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md#if-a-schema-specifies-nullable-true-and-enum-1-2-3-does-that-schema-allow-null-values-see-1900) here.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
