### PR TITLE
Fix name of the field, remove redundant definition

### DIFF
--- a/openapi/components/schemas/FilterString.yaml
+++ b/openapi/components/schemas/FilterString.yaml
@@ -1,7 +1,0 @@
-type: string
-description: |-
-  This field requires a special format.
-  Use `,` for multiple allowed values.  Use `;` for multiple fields.
-
-  For more information, see [Using filter with collections](#section/Using-filter-with-collections).
-example: amount:1..100;currency:USD;bin:411111,444433

--- a/openapi/components/schemas/ShippingRates/ShippingOption.yaml
+++ b/openapi/components/schemas/ShippingRates/ShippingOption.yaml
@@ -13,8 +13,9 @@ properties:
   name:
     type: string
     description: Name of the shipping rate.
-  descriptions:
+  description:
     type: string
+    nullable: true
     description: Description of the shipping rate.
   price:
     description: |-

--- a/openapi/components/schemas/ShippingRates/ShippingRate.yaml
+++ b/openapi/components/schemas/ShippingRates/ShippingRate.yaml
@@ -23,3 +23,5 @@ allOf:
         $ref: ../CreatedTime.yaml
       updatedTime:
         $ref: ../UpdatedTime.yaml
+      _links:
+        $ref: ../SelfLink.yaml

--- a/openapi/components/schemas/ShippingRates/ShippingRate.yaml
+++ b/openapi/components/schemas/ShippingRates/ShippingRate.yaml
@@ -8,8 +8,6 @@ allOf:
           If no filters are used, the rate is always applicable.
         default: ''
         example: 'deliveryAddress.country:US,CA,RU;amount:100..1000'
-        allOf:
-          - $ref: ../FilterString.yaml
       status:
         description: |-
           Status of the shipping rate.


### PR DESCRIPTION
## Summary
In this PR have been fixed name of `description` property. The Filter String.yaml was removed. The definition from this file is overridden in all places.  

## Checklist

- [x] Writing style
- [x] API design standards
