### PR TITLE
fix(ci): update workflow name for js sdk trigger

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yaml
+++ b/.github/workflows/trigger-downstream-updates.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Trigger update workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: Updates JS SDK resources based on api-definitions
+          workflow: FE/Rebilly JS SDK/Updates JS SDK resources based on api-definitions
           ref: main
           repo: Rebilly/rebilly
           token: ${{ secrets.MACHINE_USER_PAT }}


### PR DESCRIPTION
The workflow name for the JS SDK building has changed, this PR updates it to the correct one.