### PR TITLE
Remove customerId from StorefrontTransaction

### DIFF
--- a/openapi/components/schemas/Storefront/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/Storefront/StorefrontTransaction.yaml
@@ -9,11 +9,6 @@ properties:
     readOnly: true
     allOf:
       - $ref: ../Websites/WebsiteId.yaml
-  customerId:
-    x-basic: true
-    x-sortable: true
-    allOf:
-      - $ref: ../CustomerId.yaml
   type:
     description: Type of transaction.
     type: string


### PR DESCRIPTION
## Summary
It is customer API, so it doesn't have customeId in response

## Checklist

- [x] Writing style
- [x] API design standards
