### PR TITLE
Promote to top level directory schemas referenced at paths [Part 4]

### DIFF
--- a/openapi/components/requestBodies/RuleSet.yaml
+++ b/openapi/components/requestBodies/RuleSet.yaml
@@ -1,6 +1,6 @@
 content:
   application/json:
     schema:
-      $ref: ../schemas/Rules/RuleSet.yaml
+      $ref: ../schemas/RuleSet.yaml
 description: Ruleset resource.
 required: true

--- a/openapi/components/requestBodies/RuleSetDraft.yaml
+++ b/openapi/components/requestBodies/RuleSetDraft.yaml
@@ -1,6 +1,6 @@
 content:
   application/json:
     schema:
-      $ref: ../schemas/Rules/RuleSetDraft.yaml
+      $ref: ../schemas/RuleSetDraft.yaml
 description: Draft ruleset resource.
 required: true

--- a/openapi/components/schemas/DigitalWalletValidation.yaml
+++ b/openapi/components/schemas/DigitalWalletValidation.yaml
@@ -4,7 +4,7 @@ required:
 discriminator:
   propertyName: type
   mapping:
-    'Apple Pay': ./ApplePayValidation.yaml
+    'Apple Pay': ./PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
 properties:
   type:
     description: Type of digital wallet to validate.

--- a/openapi/components/schemas/EmailDeliverySetting.yaml
+++ b/openapi/components/schemas/EmailDeliverySetting.yaml
@@ -50,8 +50,8 @@ properties:
     description: Specifies if the email delivery setting is used by default.
     default: false
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
-    $ref: ../SelfLink.yaml
+    $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/EmailMessage.yaml
+++ b/openapi/components/schemas/EmailMessage.yaml
@@ -99,8 +99,8 @@ properties:
           maxLength: 50
           example: att_0YV7J787J0DW0918MQQMDHWA7M
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
-    $ref: ../SelfLink.yaml
+    $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/EmailNotification.yaml
+++ b/openapi/components/schemas/EmailNotification.yaml
@@ -3,7 +3,7 @@ description: Email notification event.
 readOnly: true
 properties:
   eventType:
-    $ref: ../EventType.yaml
+    $ref: ./EventType.yaml
   count:
     type: integer
     readOnly: true
@@ -26,4 +26,4 @@ properties:
           type: string
           description: Title of the notification.
   _links:
-    $ref: ../SelfLink.yaml
+    $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
+++ b/openapi/components/schemas/PaymentTokens/DigitalWalletValidation/ApplePayValidation.yaml
@@ -1,6 +1,6 @@
 description: Apple Pay session validation.
 allOf:
-  - $ref: ./DigitalWalletValidation.yaml
+  - $ref: ../../DigitalWalletValidation.yaml
   - type: object
     required:
       - validationRequest

--- a/openapi/components/schemas/RuleSet.yaml
+++ b/openapi/components/schemas/RuleSet.yaml
@@ -1,27 +1,29 @@
 type: object
-description: Version of ruleset.
-readOnly: true
+description: Ruleset for a specific event.
 properties:
   version:
     description: Version of the ruleset.
     type: integer
+    readOnly: true
   binds:
     type: array
     description: |-
       Binds always execute, regardless of rule based events.
       A bind is a configuration of an event and one or more actions.
     items:
-      $ref: ./Bind.yaml
+      $ref: ./Rules/Bind.yaml
   rules:
     type: array
     description: |-
       Rules can be configured to stop subsequent rules in the event list from being executed.
       A rule is a configuration of an event and one or more actions.
     items:
-      $ref: ./Rule.yaml
+      $ref: ./Rules/Rule.yaml
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
-    $ref: ../SelfLink.yaml
+    $ref: ./SelfLink.yaml
+required:
+  - rules

--- a/openapi/components/schemas/RuleSetDraft.yaml
+++ b/openapi/components/schemas/RuleSetDraft.yaml
@@ -22,14 +22,14 @@ properties:
       Binds always execute, regardless of rule based events.
       A rule is a configuration of an event and one or more actions.
     items:
-      $ref: ./Bind.yaml
+      $ref: ./Rules/Bind.yaml
   rules:
     type: array
     description: |-
       Rule can be configured to stop subsequent rules in the event list from being executed.
       A rule is a configuration of an event and one or more actions.
     items:
-      $ref: ./Rule.yaml
+      $ref: ./Rules/Rule.yaml
   author:
     description: Author of the draft.
     readOnly: true
@@ -39,7 +39,7 @@ properties:
         description: Author's user ID.
         type: string
         allOf:
-          - $ref: ../ResourceId.yaml
+          - $ref: ./ResourceId.yaml
       name:
         description: Author's first and last name.
         type: string
@@ -50,9 +50,9 @@ properties:
     type: string
     description: Detailed description of the drafted ruleset.
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/RuleSetHistoryItem.yaml
+++ b/openapi/components/schemas/RuleSetHistoryItem.yaml
@@ -6,9 +6,9 @@ properties:
     description: Version of the ruleset.
     type: integer
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/RuleSetVersion.yaml
+++ b/openapi/components/schemas/RuleSetVersion.yaml
@@ -11,7 +11,7 @@ properties:
       Binds always execute, regardless of rule based events.
       A bind is a configuration of an event and one or more actions.
     items:
-      $ref: ./Bind.yaml
+      $ref: ./Rules/Bind.yaml
   rules:
     type: array
     description: |-

--- a/openapi/components/schemas/RuleSetVersion.yaml
+++ b/openapi/components/schemas/RuleSetVersion.yaml
@@ -1,10 +1,10 @@
 type: object
-description: Ruleset for a specific event.
+description: Version of ruleset.
+readOnly: true
 properties:
   version:
     description: Version of the ruleset.
     type: integer
-    readOnly: true
   binds:
     type: array
     description: |-
@@ -18,12 +18,10 @@ properties:
       Rules can be configured to stop subsequent rules in the event list from being executed.
       A rule is a configuration of an event and one or more actions.
     items:
-      $ref: ./Rule.yaml
+      $ref: ./Rules/Rule.yaml
   createdTime:
-    $ref: ../CreatedTime.yaml
+    $ref: ./CreatedTime.yaml
   updatedTime:
-    $ref: ../UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
-    $ref: ../SelfLink.yaml
-required:
-  - rules
+    $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/RulesEngineTimeline.yaml
+++ b/openapi/components/schemas/RulesEngineTimeline.yaml
@@ -26,11 +26,11 @@ properties:
     description: Contents of the timeline message.
     type: string
   extraData:
-    $ref: ./TimelineExtraData.yaml
+    $ref: ./Timelines/TimelineExtraData.yaml
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
     allOf:
-      - $ref: ../ServerTimestamp.yaml
+      - $ref: ./ServerTimestamp.yaml
   _links:
-    $ref: ../SelfLink.yaml
+    $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/SystemEvent.yaml
+++ b/openapi/components/schemas/SystemEvent.yaml
@@ -3,7 +3,7 @@ description: Application event.
 readOnly: true
 properties:
   eventType:
-    $ref: ../EventType.yaml
+    $ref: ./EventType.yaml
   title:
     description: Title of the system event.
     type: string

--- a/openapi/paths/digital-wallets@validation.yaml
+++ b/openapi/paths/digital-wallets@validation.yaml
@@ -14,7 +14,7 @@ post:
     content:
       application/json:
         schema:
-           $ref: ../components/schemas/PaymentTokens/DigitalWalletValidation/DigitalWalletValidation.yaml
+           $ref: ../components/schemas/DigitalWalletValidation.yaml
     description: Digital wallet validation request.
     required: true
   security:
@@ -30,7 +30,7 @@ post:
       content:
         application/json:
           schema:
-             $ref: ../components/schemas/PaymentTokens/DigitalWalletValidation/DigitalWalletValidation.yaml
+             $ref: ../components/schemas/DigitalWalletValidation.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/email-delivery-setting-verifications@{token}.yaml
+++ b/openapi/paths/email-delivery-setting-verifications@{token}.yaml
@@ -16,7 +16,7 @@ put:
         application/json:
           schema:
             $ref: >-
-              ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+              ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/email-delivery-settings.yaml
+++ b/openapi/paths/email-delivery-settings.yaml
@@ -29,7 +29,7 @@ get:
             type: array
             items:
               $ref: >-
-                ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+                ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -56,7 +56,7 @@ post:
         application/json:
           schema:
             $ref: >-
-              ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+              ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -68,6 +68,6 @@ post:
       application/json:
         schema:
           $ref: >-
-            ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+            ../components/schemas/EmailDeliverySetting.yaml
     description: Email delivery setting resource.
     required: true

--- a/openapi/paths/email-delivery-settings@{id}.yaml
+++ b/openapi/paths/email-delivery-settings@{id}.yaml
@@ -17,7 +17,7 @@ get:
         application/json:
           schema:
             $ref: >-
-              ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+              ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -52,7 +52,7 @@ patch:
       application/json:
         schema:
           $ref: >-
-            ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+            ../components/schemas/EmailDeliverySetting.yaml
     description: Email delivery setting resource.
     required: true
   responses:
@@ -62,7 +62,7 @@ patch:
         application/json:
           schema:
             $ref: >-
-              ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+              ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
+++ b/openapi/paths/email-delivery-settings@{id}@resend-email-verification.yaml
@@ -16,7 +16,7 @@ post:
         application/json:
           schema:
             $ref: >-
-              ../components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+              ../components/schemas/EmailDeliverySetting.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/email-messages.yaml
+++ b/openapi/paths/email-messages.yaml
@@ -28,7 +28,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/EmailMessages/EmailMessage.yaml
+              $ref: ../components/schemas/EmailMessage.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -51,7 +51,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/EmailMessages/EmailMessage.yaml
+            $ref: ../components/schemas/EmailMessage.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -62,6 +62,6 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/EmailMessages/EmailMessage.yaml
+          $ref: ../components/schemas/EmailMessage.yaml
     description: Email message resource.
     required: true

--- a/openapi/paths/email-messages@{id}.yaml
+++ b/openapi/paths/email-messages@{id}.yaml
@@ -15,7 +15,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/EmailMessages/EmailMessage.yaml
+            $ref: ../components/schemas/EmailMessage.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -51,7 +51,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/EmailMessages/EmailMessage.yaml
+            $ref: ../components/schemas/EmailMessage.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/email-notifications.yaml
+++ b/openapi/paths/email-notifications.yaml
@@ -25,7 +25,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/EmailNotifications/EmailNotification.yaml
+              $ref: ../components/schemas/EmailNotification.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events.yaml
+++ b/openapi/paths/events.yaml
@@ -22,7 +22,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/Events/SystemEvent.yaml
+              $ref: ../components/schemas/SystemEvent.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}.yaml
+++ b/openapi/paths/events@{eventType}.yaml
@@ -15,7 +15,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Events/SystemEvent.yaml
+            $ref: ../components/schemas/SystemEvent.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules.yaml
+++ b/openapi/paths/events@{eventType}@rules.yaml
@@ -15,7 +15,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSet.yaml
+            $ref: ../components/schemas/RuleSet.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -41,7 +41,7 @@ put:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSet.yaml
+            $ref: ../components/schemas/RuleSet.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules@drafts.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts.yaml
@@ -33,7 +33,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/Rules/RuleSetDraft.yaml
+              $ref: ../components/schemas/RuleSetDraft.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -58,7 +58,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetDraft.yaml
+            $ref: ../components/schemas/RuleSetDraft.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
+++ b/openapi/paths/events@{eventType}@rules@drafts@{id}.yaml
@@ -18,7 +18,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetDraft.yaml
+            $ref: ../components/schemas/RuleSetDraft.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -56,7 +56,7 @@ put:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetDraft.yaml
+            $ref: ../components/schemas/RuleSetDraft.yaml
     '201':
       description: Draft ruleset created.
       headers:
@@ -65,7 +65,7 @@ put:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetDraft.yaml
+            $ref: ../components/schemas/RuleSetDraft.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules@history.yaml
+++ b/openapi/paths/events@{eventType}@rules@history.yaml
@@ -33,7 +33,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/Rules/RuleSetHistoryItem.yaml
+              $ref: ../components/schemas/RuleSetHistoryItem.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules@history@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@history@{version}.yaml
@@ -20,7 +20,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetHistoryItem.yaml
+            $ref: ../components/schemas/RuleSetHistoryItem.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
+++ b/openapi/paths/events@{eventType}@rules@versions@{version}.yaml
@@ -20,7 +20,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Rules/RuleSetVersion.yaml
+            $ref: ../components/schemas/RuleSetVersion.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@timeline.yaml
+++ b/openapi/paths/events@{eventType}@timeline.yaml
@@ -30,7 +30,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../components/schemas/Timelines/RulesEngineTimeline.yaml
+              $ref: ../components/schemas/RulesEngineTimeline.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':
@@ -48,7 +48,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/Timelines/RulesEngineTimeline.yaml
+          $ref: ../components/schemas/RulesEngineTimeline.yaml
     description: Rules engine timeline resource.
     required: true
   responses:
@@ -60,7 +60,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Timelines/RulesEngineTimeline.yaml
+            $ref: ../components/schemas/RulesEngineTimeline.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
+++ b/openapi/paths/events@{eventType}@timeline@{messageId}.yaml
@@ -21,7 +21,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Timelines/RulesEngineTimeline.yaml
+            $ref: ../components/schemas/RulesEngineTimeline.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':


### PR DESCRIPTION
## Summary
In order to simplify directory tree, the schemas that are referenced at the paths will be at the top level directory schemas. All other schemas will be moved to a second level directory.

## Links
[Part 3](https://github.com/Rebilly/api-definitions/pull/1453)

## Checklist

- [x] Writing style
- [x] API design standards
