### PR TITLE
Fix min length constraint

### DIFF
--- a/openapi/components/schemas/EmailNotification.yaml
+++ b/openapi/components/schemas/EmailNotification.yaml
@@ -11,7 +11,6 @@ properties:
   notifications:
     readOnly: true
     type: array
-    minItems: 1
     description: List of notifications.
     items:
       type: object
@@ -19,7 +18,6 @@ properties:
         labels:
           description: Labels of the notification.
           type: array
-          minItems: 1
           items:
             type: string
         title:


### PR DESCRIPTION
## Summary

In this PR a length constraint was removed because both of the array `notifications` and `labels` can be empty

## Checklist

- [x] Writing style
- [x] API design standards
