### PR TITLE
Fix AmlCheck nullable issue

### DIFF
--- a/openapi/components/schemas/AmlCheck.yaml
+++ b/openapi/components/schemas/AmlCheck.yaml
@@ -101,6 +101,7 @@ properties:
             example: Texas
           country:
             type: string
+            nullable: true
             readOnly: true
             description: Customer's country of residence at the time of the AML check.
           postalCode:


### PR DESCRIPTION
## Summary
In this PR was added `nullable` flag for `country ` property

## Checklist

- [x] Writing style
- [x] API design standards
