### PR TITLE
Add missed properties to CashierCustomPropertySet resource

### DIFF
--- a/openapi/components/schemas/CashierCustomPropertySet.yaml
+++ b/openapi/components/schemas/CashierCustomPropertySet.yaml
@@ -30,3 +30,9 @@ properties:
           minimum: 0
           exclusiveMaximum: 100
       required: ["email"]
+  createdTime:
+    $ref: ./CreatedTime.yaml
+  updatedTime:
+    $ref: ./UpdatedTime.yaml
+  _links:
+    $ref: ./SelfLink.yaml


### PR DESCRIPTION

## Summary
In this PR were added `_links, createdTime, updatedTime ` properties

## Checklist

- [x] Writing style
- [x] API design standards
