### PR TITLE
fix: password token nullable and required fields

### DIFF
--- a/openapi/components/schemas/ResetPasswordToken.yaml
+++ b/openapi/components/schemas/ResetPasswordToken.yaml
@@ -1,7 +1,6 @@
 type: object
 required:
   - username
-  - password
 properties:
   token:
     description: ID of the token.
@@ -18,5 +17,6 @@ properties:
     description: Date and time when the password expires.
     type: string
     format: date-time
+    nullable: true
   _links:
     $ref: ./SelfLink.yaml


### PR DESCRIPTION
## Summary
Removed required field that's not present in the spec and make `expiredTime` nullable.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
