### PR TITLE
Rename organization export resource properties

### DIFF
--- a/openapi/components/schemas/OrganizationExport.yaml
+++ b/openapi/components/schemas/OrganizationExport.yaml
@@ -30,7 +30,7 @@ properties:
       - queued
       - failed
       - expired
-  items:
+  resources:
     description: Organization data export resources array.
     readOnly: true
     type: array

--- a/openapi/components/schemas/OrganizationExports/OrganizationExportResource.yaml
+++ b/openapi/components/schemas/OrganizationExports/OrganizationExportResource.yaml
@@ -1,6 +1,6 @@
 type: object
 properties:
-  name:
+  type:
     description: Exported resource.
     readOnly: true
     type: string


### PR DESCRIPTION
## Summary
In this PR `items` property was renamed to `resources` because of inconsistency with transformer definition. The `name` property was changed to `type` as well for the same reason.

## Checklist

- [x] Writing style
- [x] API design standards
