### PR TITLE
Fix SubscriptionPause nullable issue.

### DIFF
--- a/openapi/components/schemas/SubscriptionPause.yaml
+++ b/openapi/components/schemas/SubscriptionPause.yaml
@@ -73,6 +73,7 @@ properties:
       For more information, see [Service period anchor, billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
     type: string
     example: P3600S
+    nullable: true
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:


### PR DESCRIPTION
## Summary
In this PR was fixed `nullable` issue for `SubscriptionPause` resource

## Checklist

- [x] Writing style
- [x] API design standards
