### PR TITLE
Update plan and invoice specs

### DIFF
--- a/openapi/components/schemas/Invoice.yaml
+++ b/openapi/components/schemas/Invoice.yaml
@@ -111,13 +111,11 @@ properties:
     nullable: true
     example: PO123456
     type: string
-    minimum: 0
-    maximum: 50
+    maxLength: 50
   notes:
     description: Notes for the customer that are displayed on the invoice.
     type: string
-    minimum: 0
-    maximum: 65535
+    maxLength: 65535
   items:
     type: array
     description: Invoice items array.

--- a/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
@@ -21,11 +21,13 @@ properties:
     description: |-
       Plain-text description of the plan.
       This field accepts plain-text only.
+    maxLength: 65535
   richDescription:
     type: string
     description: |-
       Rich-text description of the plan.
       This field accepts rich text formatting, such as: bold, underline, italic, and hyperlinks.
+    maxLength: 65535
   productId:
     type: string
     description: ID of the related product.

--- a/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
@@ -22,11 +22,13 @@ properties:
     description: |-
       Plain-text description of the plan.
       This field accepts plain-text only.
+    maxLength: 65535
   richDescription:
     type: string
     description: |-
       Rich-text description of the plan.
       This field accepts rich text formatting, such as: bold, underline, italic, and hyperlinks.
+    maxLength: 65535
   productId:
     type: string
     description: ID of the related product.

--- a/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
@@ -22,11 +22,13 @@ properties:
     description: |-
       Plain-text description of the plan.
       This field accepts plain-text only.
+    maxLength: 65535
   richDescription:
     type: string
     description: |-
       Rich-text description of the plan.
       This field accepts rich text formatting, such as: bold, underline, italic, and hyperlinks.
+    maxLength: 65535
   productId:
     type: string
     description: ID of the related product.


### PR DESCRIPTION
## Summary
Add `maxLength` to plan description.
Replace `maximum` with `maxLength` for several invoice fields. 

## Checklist

- [x] Writing style
- [x] API design standards
