### PR TITLE
fix: request body does not need readOnly props

### DIFF
--- a/openapi/components/requestBodies/Plan.yaml
+++ b/openapi/components/requestBodies/Plan.yaml
@@ -1,16 +1,7 @@
 content:
   application/json:
     schema:
-      allOf:
-        - type: object
-          properties:
-            id:
-              type: string
-              readOnly: true
-              description: ID of the plan.
-              maxLength: 50
-              example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
-        - anyOf:
+      anyOf:
             - $ref: ../schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
             - $ref: ../schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
             - $ref: ../schemas/Plans/PlanTypes/TrialOnlyPlan.yaml


### PR DESCRIPTION
## Summary

A request body doesn't need any readOnly props.

Also fixes a misunderstanding of allOf.

## Links
<!-- add any related links to other PRs or docs -->
https://github.com/Rebilly/api-definitions/pull/1338/files#r1312743979


## Checklist

- [x] Writing style
- [x] API design standards
