### PR TITLE
Move Allowlists to separated group

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -596,6 +596,7 @@ x-tagGroups:
   - name: Risk
     tags:
       - Blocklists
+      - Allowlists
       - KYC documents
       - AML
       - Risk score

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -97,9 +97,9 @@ tags:
       An account in which you are subscribed to in order to use the Rebilly product.
   - name: Allowlists
     description: |-
-      Use allowlists to avoid customers from adding to blocklists.
-
-      Allowlists are lists of customer attribute values that are used to avoid [blocklist record](https://www.rebilly.com/docs/automations/blocklists/) creation when [risk score](https://www.rebilly.com/docs/automations/risk-scoring/) threshold reached.
+      Use allowlists to exclude specific customer attribute data from risk score checks.
+      
+      Allowlists are lists of data that are excluded from risk score checks. Allowlists prevent specific data from being added to a [blocklist record](https://www.rebilly.com/docs/automations/blocklists/) when a [risk score](https://www.rebilly.com/docs/automations/risk-scoring/) threshold reached.
   - name: AML
     description: |-
       Use Anti-Money Laundering (AML) operations to screen customers and help prevent your business from becoming directly or indirectly involved in criminal activity.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -99,7 +99,7 @@ tags:
     description: |-
       Use allowlists to avoid customers from adding to blocklists.
 
-      Allowlists are lists of customer attribute values that will not be blocking when [risk score](https://www.rebilly.com/docs/automations/risk-scoring/) threshold reached.
+      Allowlists are lists of customer attribute values that are used to avoid [blocklist record](https://www.rebilly.com/docs/automations/blocklists/) creation when [risk score](https://www.rebilly.com/docs/automations/risk-scoring/) threshold reached.
   - name: AML
     description: |-
       Use Anti-Money Laundering (AML) operations to screen customers and help prevent your business from becoming directly or indirectly involved in criminal activity.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -95,6 +95,11 @@ tags:
     description: |-
       Use these operations to manage Rebilly accounts.
       An account in which you are subscribed to in order to use the Rebilly product.
+  - name: Allowlists
+    description: |-
+      Use allowlists to avoid customers from adding to blocklists.
+
+      Allowlists are lists of customer attribute values that will not be blocking when [risk score](https://www.rebilly.com/docs/automations/risk-scoring/) threshold reached.
   - name: AML
     description: |-
       Use Anti-Money Laundering (AML) operations to screen customers and help prevent your business from becoming directly or indirectly involved in criminal activity.

--- a/openapi/paths/allowlists.yaml
+++ b/openapi/paths/allowlists.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Core
   tags:
-    - Risk score
+    - Allowlists
   summary: Retrieve allowlist collection
   operationId: GetAllowlistCollection
   x-sdk-operation-name: getAllowlistCollection
@@ -27,7 +27,7 @@ post:
   x-products:
     - Core
   tags:
-    - Risk score
+    - Allowlists
   summary: Create allowlist record
   operationId: PostAllowlist
   x-sdk-operation-name: storeAllowlist

--- a/openapi/paths/allowlists@{id}.yaml
+++ b/openapi/paths/allowlists@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Core
   tags:
-    - Risk score
+    - Allowlists
   summary: Retrieve allowlist record
   operationId: GetAllowlist
   x-sdk-operation-name: getAllowlist
@@ -27,7 +27,7 @@ delete:
   x-products:
     - Core
   tags:
-    - Risk score
+    - Allowlists
   summary: Delete allowlist record
   operationId: DeleteAllowlist
   x-sdk-operation-name: delete

--- a/plugins/products-bundler/mapping/Combined.yaml
+++ b/plugins/products-bundler/mapping/Combined.yaml
@@ -39,6 +39,7 @@ x-tagGroups:
       - Credit memos timeline
   - name: Risk
     tags:
+      - Allowlists
       - Blocklists
       - KYC documents
       - AML

--- a/plugins/products-bundler/mapping/Core.yaml
+++ b/plugins/products-bundler/mapping/Core.yaml
@@ -36,6 +36,7 @@ x-tagGroups:
       - Credit memos timeline
   - name: Risk
     tags:
+      - Allowlists
       - Blocklists
       - KYC documents
       - AML


### PR DESCRIPTION
## Summary
This PR moves Allowlists to separated group out of Risk Score - similar to Blocklists

## Checklist

- [x] Writing style
- [x] API design standards
