### PR TITLE
Add parameters for GetAllowlistCollection

### DIFF
--- a/openapi/paths/allowlists.yaml
+++ b/openapi/paths/allowlists.yaml
@@ -10,6 +10,11 @@ get:
     - SecretApiKey: []
     - JWT: []
   description: Retrieves allowlist collection.
+  parameters:
+    - $ref: ../components/parameters/collectionFilter.yaml
+    - $ref: ../components/parameters/collectionSort.yaml
+    - $ref: ../components/parameters/collectionLimit.yaml
+    - $ref: ../components/parameters/collectionOffset.yaml
   responses:
     '200':
       description: Allowlist collection retrieved.


### PR DESCRIPTION
## Summary
The parameters are currently missing for `GetAllowlistCollection`. This PR adds those parameters.