### PR TITLE
Add flag to the Website to prevent auto redirect on transaction complete

### DIFF
--- a/openapi/components/schemas/Website.yaml
+++ b/openapi/components/schemas/Website.yaml
@@ -92,7 +92,7 @@ properties:
                 default: false
               skipRedirectOnPaymentComplete:
                 type: boolean
-                description: Specifies whether the hosted payment form skips the redirect to the website URL when the payment is complete.
+                description: Specifies whether the hosted payment form skips the redirect to the website URL when the payment is completed.
                 nullable: true
                 default: false
   logoId:

--- a/openapi/components/schemas/Website.yaml
+++ b/openapi/components/schemas/Website.yaml
@@ -90,6 +90,11 @@ properties:
                 description: Specifies whether the hosted payment form uses a full page redirect, or the default iframe modal, for approval URL redirects.
                 nullable: true
                 default: false
+              skipRedirectOnPaymentComplete:
+                type: boolean
+                description: Specifies whether the hosted payment form skips the redirect to the website URL when the payment is complete.
+                nullable: true
+                default: false
   logoId:
     type: string
     nullable: true


### PR DESCRIPTION
## Summary
Add a flag to website.settings.paymentForm that would allow merchants to enable or disable the automatic redirect. If disabled, the customer would remain on the thank you or declined page.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
