### PR TITLE
Simplify ReadyToPaySchema

### DIFF
--- a/openapi/components/requestBodies/PostReadyToPay.yaml
+++ b/openapi/components/requestBodies/PostReadyToPay.yaml
@@ -1,5 +1,7 @@
 allOf:
   - type: object
+    required: 
+      - customerId
     properties:
       customerId:
         $ref: ../schemas/CustomerId.yaml

--- a/openapi/components/requestBodies/PostReadyToPay.yaml
+++ b/openapi/components/requestBodies/PostReadyToPay.yaml
@@ -1,7 +1,5 @@
 allOf:
   - type: object
-    required: 
-      - customerId
     properties:
       customerId:
         $ref: ../schemas/CustomerId.yaml

--- a/openapi/components/schemas/ReadyToPay/ReadyToPay.yaml
+++ b/openapi/components/schemas/ReadyToPay/ReadyToPay.yaml
@@ -1,17 +1,4 @@
 type: object
-required:
-  - websiteId
-  - riskMetadata
-properties:
-  websiteId:
-    $ref: ../WebsiteId.yaml
-  billingAddress:
-    description: Billing address.
-    writeOnly: true
-    allOf:
-      - $ref: ../Contact/ContactObject.yaml
-  riskMetadata:
-    $ref: ../RiskMetadata.yaml
 oneOf:
   - $ref: ReadyToPayAmount.yaml
   - $ref: ReadyToPayItems.yaml

--- a/openapi/components/schemas/ReadyToPay/ReadyToPayAmount.yaml
+++ b/openapi/components/schemas/ReadyToPay/ReadyToPayAmount.yaml
@@ -1,12 +1,23 @@
 type: object
 title: With amount
 required:
+  - websiteId
   - currency
   - amount
+  - riskMetadata
 properties:
+  websiteId:
+    $ref: ../WebsiteId.yaml
   currency:
     $ref: ../CurrencyCode.yaml
   amount:
     description: Amount to pay.
     type: number
     format: double
+  billingAddress:
+    description: Billing address.
+    writeOnly: true
+    allOf:
+      - $ref: ../Contact/ContactObject.yaml
+  riskMetadata:
+    $ref: ../RiskMetadata.yaml

--- a/openapi/components/schemas/ReadyToPay/ReadyToPayItems.yaml
+++ b/openapi/components/schemas/ReadyToPay/ReadyToPayItems.yaml
@@ -1,8 +1,12 @@
 type: object
 title: With items
 required:
+  - websiteId
   - items
+  - riskMetadata
 properties:
+  websiteId:
+    $ref: ../WebsiteId.yaml
   items:
     type: array
     minItems: 1
@@ -20,3 +24,10 @@ properties:
         quantity:
           description: Number of product units in the specified plan.
           type: integer
+  billingAddress:
+    description: Billing address.
+    writeOnly: true
+    allOf:
+      - $ref: ../Contact/ContactObject.yaml
+  riskMetadata:
+    $ref: ../RiskMetadata.yaml


### PR DESCRIPTION
## Summary

`oneOf` with `properties` on a single level is unnecessary, especially assuming there is an `allOf` on the `PostReadyToPay` request schema. Further inlining is out of scope.

## Checklist

- [x] Writing style
- [x] API design standards
