### PR TITLE
Remove Plan request body

### DIFF
--- a/openapi/components/requestBodies/Plan.yaml
+++ b/openapi/components/requestBodies/Plan.yaml
@@ -1,9 +1,0 @@
-content:
-  application/json:
-    schema:
-      anyOf:
-            - $ref: ../schemas/Plans/PlanTypes/OneTimeSalePlan.yaml
-            - $ref: ../schemas/Plans/PlanTypes/SubscriptionOrderPlan.yaml
-            - $ref: ../schemas/Plans/PlanTypes/TrialOnlyPlan.yaml
-description: Plan resource.
-required: true

--- a/openapi/paths/plans.yaml
+++ b/openapi/paths/plans.yaml
@@ -58,7 +58,12 @@ post:
   x-sdk-operation-name: create
   description: Creates a plan.
   requestBody:
-    $ref: ../components/requestBodies/Plan.yaml
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/Plan.yaml
+    description: Plan resource.
+    required: true
   responses:
     '201':
       description: Plan created.

--- a/openapi/paths/plans@{id}.yaml
+++ b/openapi/paths/plans@{id}.yaml
@@ -47,7 +47,12 @@ put:
   x-sdk-operation-name: update
   description: Creates or updates (upserts) a plan with a specified ID.
   requestBody:
-    $ref: ../components/requestBodies/Plan.yaml
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/Plan.yaml
+    description: Plan resource.
+    required: true
   responses:
     '200':
       description: Plan updated.


### PR DESCRIPTION
## Summary
Plan request body was exactly the same as the schema itself, so there is no need in creating a separate request body.

## Checklist

- [x] Writing style
- [x] API design standards