### PR TITLE
Add `remove-php-sample-prefix` decorator

### DIFF
--- a/plugins/decorators.js
+++ b/plugins/decorators.js
@@ -1,3 +1,4 @@
+const RemovePhpSamplePrefix = require('./decorators/remove-php-sample-prefix');
 const RemoveTagGroups = require('./decorators/remove-tag-groups');
 const id = 'plugin';
 
@@ -6,6 +7,7 @@ const id = 'plugin';
 const decorators = {
   oas3: {
     'remove-tag-groups': RemoveTagGroups,
+    'remove-php-sample-prefix': RemovePhpSamplePrefix,
   }
 };
 

--- a/plugins/decorators/remove-php-sample-prefix.js
+++ b/plugins/decorators/remove-php-sample-prefix.js
@@ -1,0 +1,18 @@
+module.exports = RemovePhpSamplePrefix;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+
+function RemovePhpSamplePrefix() {
+  return {
+    XCodeSample: {
+      leave(sample) {
+        if (!sample.lang.includes('PHP')) {
+          return;
+        }
+        if (sample.source.startsWith('<?php')) {
+          sample.source = sample.source.substring(5).trim();
+        }
+      }
+    }
+  }
+};

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -418,6 +418,7 @@ rules:
 
 decorators:
   products-bundler/bundle: error
+  plugin/remove-php-sample-prefix: on
 theme:
   openapi:
     pagination: item


### PR DESCRIPTION
## Summary

This would allow us to start PHP SDK samples with `<?php` enabling IDE highlighting and hints, while not wasting space on showing them on the interface.

## Checklist

- [x] Writing style
- [x] API design standards
