### PR TITLE
StorefrontInvoice: remove tax id numbers

### DIFF
--- a/openapi/components/schemas/StorefrontInvoice.yaml
+++ b/openapi/components/schemas/StorefrontInvoice.yaml
@@ -56,44 +56,6 @@ properties:
     $ref: ./Shipping.yaml
   tax:
     $ref: ./Invoices/InvoiceTax.yaml
-  organizationTaxIdNumber:
-    description: Organization tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
-    required:
-      - type
-      - value
-    properties:
-      type:
-        type: string
-        description: Type of the tax ID number.
-        enum:
-          - eu-vat
-          - other
-        example: eu-vat
-      value:
-        type: string
-        description: Value of the tax ID number.
-        example: GB980780684
-  customerTaxIdNumber:
-    description: Customer tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
-    required:
-      - type
-      - value
-    properties:
-      type:
-        type: string
-        description: Type of the tax ID number.
-        enum:
-          - eu-vat
-          - other
-        example: eu-vat
-      value:
-        type: string
-        description: Value of the tax ID number.
-        example: GB980780684
   billingAddress:
     description: Billing address of the invoice.
     allOf:


### PR DESCRIPTION
## Summary
This PR removes customer and organization tax ID numbers from StorefrontInvoice schema since it is not needed.

## Checklist

- [x] Writing style
- [x] API design standards
