### PR TITLE
Support creditcard and mastercard methods for Wallet88 payment-card

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Wallet88.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Wallet88.yaml
@@ -20,3 +20,14 @@ allOf:
         required:
           - sid
           - rcode
+      settings:
+        type: object
+        description: Wallet88 settings object.
+        properties:
+          paymentCardMethod:
+            description: Method to send for payment-card.
+            type: string
+            enum:
+              - creditcard
+              - mastercard
+            default: creditcard

--- a/openapi/components/schemas/GatewayAccountConfig/Wallet88.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Wallet88.yaml
@@ -25,7 +25,7 @@ allOf:
         description: Wallet88 settings object.
         properties:
           paymentCardMethod:
-            description: Method to send for payment-card.
+            description: Method to send for payment card.
             type: string
             enum:
               - creditcard


### PR DESCRIPTION
## Summary
`creditcard` is the default method for `payment-card`.  But in some cases we need to send `mastecard` for the MC only MID.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
