### PR TITLE
Rename js method for stop review

### DIFF
--- a/openapi/paths/aml-checks@{id}@stop-review.yaml
+++ b/openapi/paths/aml-checks@{id}@stop-review.yaml
@@ -7,7 +7,7 @@ post:
     - AML
   summary: Stop review of an AML check
   operationId: PostAmlCheckStopReview
-  x-sdk-operation-name: stopAmlCheckReview
+  x-sdk-operation-name: stopReview
   description: |-
     Stops the manual review process for an AML check with a specified ID.
 


### PR DESCRIPTION
## Summary
Rename `stopAmlCheckReview` to `stopReview` to be consistent with `startReview`

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
