### PR TITLE
Revert "Rename js method for stop review"

### DIFF
--- a/openapi/paths/aml-checks@{id}@stop-review.yaml
+++ b/openapi/paths/aml-checks@{id}@stop-review.yaml
@@ -7,7 +7,7 @@ post:
     - AML
   summary: Stop review of an AML check
   operationId: PostAmlCheckStopReview
-  x-sdk-operation-name: stopReview
+  x-sdk-operation-name: stopAmlCheckReview
   description: |-
     Stops the manual review process for an AML check with a specified ID.
 


### PR DESCRIPTION
Reverts Rebilly/api-definitions#1616 as it was previously merged incorrectly