### PR TITLE
Add dispute credentials for PSiGate

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/PSiGate.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/PSiGate.yaml
@@ -24,6 +24,14 @@ allOf:
             description: Client API key.
             format: password
             writeOnly: true
+          disputeUsername:
+            type: string
+            description: Username for fetching disputes.
+          disputePassword:
+            type: string
+            description: Password for fetching disputes.
+            format: password
+            writeOnly: true
         required:
           - username
           - password


### PR DESCRIPTION
## Summary
A different username and password is used

## Links
https://apistaging.psigate.com/api/docs/index.html#authentication-4

## Checklist

- [x] Writing style
- [x] API design standards
