### PR TITLE
Add SecureTrading notificationPassword credential

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/SecureTrading.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/SecureTrading.yaml
@@ -22,6 +22,13 @@ allOf:
             description: SecureTrading web service password.
             format: password
             writeOnly: true
+          notificationPassword:
+            type: string
+            description: |-
+              SecureTrading notification password.
+              Used to authenticate webhook requests.
+            format: password
+            writeOnly: true
         required:
           - websiteId
           - username

--- a/openapi/components/schemas/GatewayAccountConfig/SecureTrading.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/SecureTrading.yaml
@@ -26,7 +26,7 @@ allOf:
             type: string
             description: |-
               SecureTrading notification password.
-              Used to authenticate webhook requests.
+              This password is used to authenticate webhook requests.
             format: password
             writeOnly: true
         required:


### PR DESCRIPTION
## Summary
Adds a credential named `notificationPassword` to SecureTrading gateway accounts. This value is used to authenticate incoming webhook requests.

## Checklist

- [X] Writing style
- [X] API design standards
