### PR TITLE
Add pricing min quantity

### DIFF
--- a/openapi/components/schemas/PlanFormulaFlatRate.yaml
+++ b/openapi/components/schemas/PlanFormulaFlatRate.yaml
@@ -28,6 +28,16 @@ properties:
     type: number
     format: double
     example: 99.95
+  minQuantity:
+    description: |-
+      Minimum permitted unit quantity.
+      If this value is `null`, no limit is in place.
+    type: integer
+    nullable: true
+    default: null
+    example: 1
+    minimum: 1
+    maximum: 65535
   maxQuantity:
     description: |-
       Maximum permitted unit quantity.

--- a/openapi/components/schemas/PlanFormulaStairstep.yaml
+++ b/openapi/components/schemas/PlanFormulaStairstep.yaml
@@ -61,3 +61,13 @@ properties:
           example: 1
           minimum: 1
           maximum: 65535
+  minQuantity:
+    description: |-
+      Minimum permitted unit quantity.
+      If this value is `null`, no limit is in place.
+    type: integer
+    nullable: true
+    default: null
+    example: 1
+    minimum: 1
+    maximum: 65535

--- a/openapi/components/schemas/PlanFormulaTiered.yaml
+++ b/openapi/components/schemas/PlanFormulaTiered.yaml
@@ -66,3 +66,13 @@ properties:
           example: 1
           minimum: 1
           maximum: 65535
+  minQuantity:
+    description: |-
+      Minimum permitted unit quantity.
+      If this value is `null`, no limit is in place.
+    type: integer
+    nullable: true
+    default: null
+    example: 1
+    minimum: 1
+    maximum: 65535

--- a/openapi/components/schemas/PlanFormulaVolume.yaml
+++ b/openapi/components/schemas/PlanFormulaVolume.yaml
@@ -62,3 +62,13 @@ properties:
           example: 1
           minimum: 1
           maximum: 65535
+  minQuantity:
+    description: |-
+      Minimum permitted unit quantity.
+      If this value is `null`, no limit is in place.
+    type: integer
+    nullable: true
+    default: null
+    example: 1
+    minimum: 1
+    maximum: 65535


### PR DESCRIPTION
## Summary

Added `minQuantity` to all `PlanFormula*` schemas except the fixed fee one.
Removed `openapi/components/schemas/Plans/PlanPeriod.yaml` as it's empty and unused.

## Checklist

- [x] Writing style
- [x] API design standards
