### PR TITLE
Make SubscriptionReactivation effectiveTime writeOnly

### DIFF
--- a/openapi/components/schemas/SubscriptionReactivation.yaml
+++ b/openapi/components/schemas/SubscriptionReactivation.yaml
@@ -35,6 +35,7 @@ properties:
       If this field is omitted, this value defaults to the current time.
     type: string
     format: date-time
+    writeOnly: true
   renewalTime:
     description: |-
       Date and time of the next subscription renewal.


### PR DESCRIPTION
Changes effectiveTime to writeOnly on the SubscriptionReactivation. This value is used during reactivation and not present in the response.

## Checklist

- [X] Writing style
- [X] API design standards
