### PR TITLE
Add 'Restrict to customers with tags' coupon restriction type

### DIFF
--- a/openapi/components/schemas/CouponRestriction.yaml
+++ b/openapi/components/schemas/CouponRestriction.yaml
@@ -7,7 +7,9 @@ discriminator:
     minimum-order-amount: ./CouponRestrictionMinimumOrderAmount.yaml
     paid-by-time: ./CouponRestrictionPaidByTime.yaml
     redemptions-per-customer: ./CouponRestrictionRedemptionsPerCustomer.yaml
+    restrict-to-bxgy: ./CouponRestrictionRestrictToBxgy.yaml
     restrict-to-countries: ./CouponRestrictionRestrictToCountries.yaml
+    restrict-to-customer-tags: ./CouponRestrictionRestrictToCustomerTags.yaml
     restrict-to-customers: ./CouponRestrictionRestrictToCustomers.yaml
     restrict-to-exclusive-application: ./CouponRestrictionExclusiveApplication.yaml
     restrict-to-invoices: ./CouponRestrictionRestrictToInvoices.yaml
@@ -15,7 +17,6 @@ discriminator:
     restrict-to-products: ./CouponRestrictionRestrictToProducts.yaml
     restrict-to-subscriptions: ./CouponRestrictionRestrictToSubscriptions.yaml
     total-redemptions: ./CouponRestrictionTotalRedemptions.yaml
-    restrict-to-bxgy: ./CouponRestrictionRestrictToBxgy.yaml
 anyOf:
   - $ref: ./CouponRestrictionDiscountPerRedemption.yaml
   - $ref: ./CouponRestrictionExclusiveApplication.yaml
@@ -24,6 +25,7 @@ anyOf:
   - $ref: ./CouponRestrictionRedemptionsPerCustomer.yaml
   - $ref: ./CouponRestrictionRestrictToBxgy.yaml
   - $ref: ./CouponRestrictionRestrictToCountries.yaml
+  - $ref: ./CouponRestrictionRestrictToCustomerTags.yaml
   - $ref: ./CouponRestrictionRestrictToCustomers.yaml
   - $ref: ./CouponRestrictionRestrictToInvoices.yaml
   - $ref: ./CouponRestrictionRestrictToPlans.yaml

--- a/openapi/components/schemas/CouponRestrictionRestrictToCustomerTags.yaml
+++ b/openapi/components/schemas/CouponRestrictionRestrictToCustomerTags.yaml
@@ -16,10 +16,10 @@ properties:
       type: string
   requireAllTags:
     type: boolean
-    description: Determines a behavior for checking customer tags.
+    description: Determines the behavior for checking customer tags.
     enum:
       - true
       - false
     x-enumDescriptions:
       true: Customer must have all listed tags to redeem a coupon.
-      false: Customer must have at least one of listed tags to redeem a coupon.
+      false: Customer must have at least one of the listed tags to redeem a coupon.

--- a/openapi/components/schemas/CouponRestrictionRestrictToCustomerTags.yaml
+++ b/openapi/components/schemas/CouponRestrictionRestrictToCustomerTags.yaml
@@ -1,0 +1,25 @@
+type: object
+description: Restricts a coupon to customers with specific tags.
+required:
+  - type
+  - tags
+  - requireAllTags
+properties:
+  type:
+    type: string
+    description: Type of coupon restriction.
+    enum: ["restrict-to-customer-tags"]
+  tags:
+    type: array
+    description: Customer tags on which a coupon can be applied.
+    items:
+      type: string
+  requireAllTags:
+    type: boolean
+    description: Determines a behavior for checking customer tags.
+    enum:
+      - true
+      - false
+    x-enumDescriptions:
+      true: Customer must have all listed tags to redeem a coupon.
+      false: Customer must have at least one of listed tags to redeem a coupon.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -191,7 +191,8 @@ tags:
       - `restrict-to-invoices`: Restricts a coupon to specific invoices.
       - `restrict-to-plans`: Restricts a coupon to specific pricing plans.
       - `restrict-to-subscriptions`: Restricts a coupon to specific order subscriptions.
-      - `restrict-to-customers`: Restricts a coupon to specific order subscriptions.
+      - `restrict-to-customer-tags`: Restricts a coupon to customers with specific tags.
+      - `restrict-to-customers`: Restricts a coupon to specific customers.
       - `restrict-to-exclusive-application`: Restricts a coupon so that it cannot be used in combination with other coupons. If more than one coupon is active, a coupon with this restriction is only applied if it provides a larger discount than the other coupons combined. If a coupon with this restriction is applied, all other coupons are removed.
       - `restrict-to-products`: Restricts a coupon to specific products.
       - `paid-by-time`: Specifies a date and time at which a coupon redemption expires if not paid.


### PR DESCRIPTION
## Summary
This PR will add ability to restrict redemption to customers with specific tags only

## Checklist

- [x] Writing style
- [x] API design standards
