### PR TITLE
Make Plan.id readOnly

### DIFF
--- a/openapi/components/schemas/FlexiblePlan.yaml
+++ b/openapi/components/schemas/FlexiblePlan.yaml
@@ -8,4 +8,7 @@ allOf:
         description: ID of the plan.
         maxLength: 50
         example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
-  - $ref: ./Plan.yaml
+  - anyOf:
+      - $ref: ./OneTimeSalePlan.yaml
+      - $ref: ./SubscriptionOrderPlan.yaml
+      - $ref: ./TrialOnlyPlan.yaml

--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -10,6 +10,7 @@ properties:
     description: ID of the plan.
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
+    readOnly: true
   name:
     description: |-
       Name of the plan.

--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -5,12 +5,6 @@ required:
   - productId
   - pricing
 properties:
-  id:
-    type: string
-    description: ID of the plan.
-    maxLength: 50
-    example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
-    readOnly: true
   name:
     description: |-
       Name of the plan.

--- a/openapi/components/schemas/Plan.yaml
+++ b/openapi/components/schemas/Plan.yaml
@@ -1,4 +1,14 @@
-anyOf:
-  - $ref: ./OneTimeSalePlan.yaml
-  - $ref: ./SubscriptionOrderPlan.yaml
-  - $ref: ./TrialOnlyPlan.yaml
+allOf:
+  - type: object
+    properties:
+      id:
+        type: string
+        description: ID of the plan.
+        maxLength: 50
+        example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
+        readOnly: true
+  - anyOf:
+      - $ref: ./OneTimeSalePlan.yaml
+      - $ref: ./SubscriptionOrderPlan.yaml
+      - $ref: ./TrialOnlyPlan.yaml
+

--- a/openapi/components/schemas/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/SubscriptionOrderPlan.yaml
@@ -6,12 +6,6 @@ required:
   - pricing
   - recurringInterval
 properties:
-  id:
-    type: string
-    description: ID of the plan.
-    maxLength: 50
-    example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
-    readOnly: true
   name:
     description: |-
       Name of the plan.

--- a/openapi/components/schemas/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/SubscriptionOrderPlan.yaml
@@ -11,6 +11,7 @@ properties:
     description: ID of the plan.
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
+    readOnly: true
   name:
     description: |-
       Name of the plan.

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -6,12 +6,6 @@ required:
   - pricing
   - trial
 properties:
-  id:
-    type: string
-    description: ID of the plan.
-    maxLength: 50
-    example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
-    readOnly: true
   name:
     description: |-
       Name of the plan.

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -11,6 +11,7 @@ properties:
     description: ID of the plan.
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
+    readOnly: true
   name:
     description: |-
       Name of the plan.


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
Make `id` readOnly, but leave it writable for Flexible plans.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
