### PR TITLE
Set up catalog with permalinks and replace products bundler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@redocly/cli"
+      - dependency-name: "@redocly/portal"

--- a/.github/workflows/trigger-downstream-updates.yaml
+++ b/.github/workflows/trigger-downstream-updates.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           # Which status checks to wait for. We only care about the combined bundle.
+          # Todo: update with new message
           contexts: 'Redocly Registry (combined/combined) bundle'
           # How long to wait for the Redocly status to be posted, in seconds
           timeout: 600

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Rebilly follows a design-first approach to APIs.
 
 - Use OpenAPI 3.0 to describe APIs according to below.
 - Use [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) (create a branch and open a pull request for any change).
-- Check your work with Redocly CLI which runs `lint` and `bundle` commands controlled through the `.redocly.yaml` configuration file when a pull request is opened (you will see the green checks or red x marks).
+- Check your work with Redocly CLI which runs `lint` and `bundle` commands controlled through the `redocly.yaml` configuration file when a pull request is opened (you will see the green checks or red x marks).
 - In terms of sequence, merge the API definitions before merging and releasing software to production.
 
 To get started:
-- Set up [your environment](./README.md#environment-setup).
+- Set up your environment.
 - Read the remainder of this page to understand how we design APIs and write API definitions.
 
 ## API description writing guidance
@@ -52,14 +52,14 @@ Rebilly uses the following lint rules:
 - [operation-operationId-unique](https://redocly.com/docs/cli/rules/operation-operationId-unique/) (recommended)
 - [operation-operationId-url-safe](https://redocly.com/docs/cli/rules/operation-operationId-url-safe/) (recommended)
 - [operation-summary](https://redocly.com/docs/cli/rules/operation-summary/) (recommended)
-- [assert/x-sdk-operation-name](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/operation-id-delete](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/operation-id-get](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/operation-id-patch](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/operation-id-post](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/operation-id-put](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/no-x-code-samples](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/no-x-internal](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/x-sdk-operation-name](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-id-delete](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-id-get](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-id-patch](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-id-post](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-id-put](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/no-x-code-samples](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/no-x-internal](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
 
 ### Parameters
 
@@ -70,7 +70,7 @@ Rebilly uses the following lint rules:
 - [path-declaration-must-exist](https://redocly.com/docs/cli/rules/path-declaration-must-exist/) (recommended)
 - [path-not-include-query](https://redocly.com/docs/cli/rules/path-not-include-query/) (recommended)
 - [path-parameters-defined](https://redocly.com/docs/cli/rules/path-parameters-defined/) (recommended)
-- [assert/params-must-include-examples](.redocly.yaml) (custom rules)
+- [rule/params-must-include-examples](redocly.yaml) (custom rules)
 
 ### Paths
 
@@ -81,7 +81,7 @@ Rebilly uses the following lint rules:
 - [path-excludes-patterns](https://redocly.com/docs/cli/rules/path-excludes-patterns/)
 - [path-segment-plural](https://redocly.com/docs/cli/rules/path-segment-plural/) (Redocly additional rules)
 - [paths-kebab-case](https://redocly.com/docs/cli/rules/paths-kebab-case/) (Redocly additional rules)
-- [assert/path-must-be-ref-file](.redocly.yaml) (custom rules)
+- [rule/path-must-be-ref-file](redocly.yaml) (custom rules)
 
 ### Requests, Responses, and Schemas
 
@@ -94,11 +94,11 @@ Rebilly uses the following lint rules:
 - [response-contains-header](https://redocly.com/docs/cli/rules/response-contains-header/) (Redocly additional rules)
 - [response-contains-property](https://redocly.com/docs/cli/rules/response-contains-property/)
 - [scalar-property-missing-example](https://redocly.com/docs/cli/rules/scalar-property-missing-example/)
-- [assert/headers-include-example](.redocly.yaml) (custom rules)
-- [assert/schema-properties-both-created-time-and-updated-time](.redocly.yaml) (custom rules)
-- [assert/put-200-and-201](.redocly.yaml) (custom rules) (this has some exceptions)
-- [assert/schema-properties-camelCase](.redocly.yaml) (custom rules)
-- [assert/embedded-is-object](.redocly.yaml) (custom rules)
+- [rule/headers-include-example](redocly.yaml) (custom rules)
+- [rule/schema-properties-both-created-time-and-updated-time](redocly.yaml) (custom rules)
+- [rule/put-200-and-201](redocly.yaml) (custom rules) (this has some exceptions)
+- [rule/schema-properties-camelCase](redocly.yaml) (custom rules)
+- [rule/embedded-is-object](redocly.yaml) (custom rules)
 
 ### Servers
 
@@ -114,19 +114,19 @@ Rebilly uses the following lint rules:
 - [operation-tag-defined](https://redocly.com/docs/cli/rules/operation-tag-defined/) (Redocly additional rules)
 - [tag-description](https://redocly.com/docs/cli/rules/tag-description/)
 - [tags-alphabetical](https://redocly.com/docs/cli/rules/tags-alphabetical/)
-- [custom-rules/no-unused-tags](.redocly.yaml) (custom rules)
+- [custom-rules/no-unused-tags](redocly.yaml) (custom rules)
 
 
 ### Writing style
 
-- [assert/operation-summary](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/tag-description](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/info-description](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/description-capitalization](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/description-punctuation](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/no-anthropmorphic-possessives](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/no-past-future](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
-- [assert/no-description-start-with-the-a-an](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/operation-summary](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/tag-description](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/info-description](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/description-capitalization](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/description-punctuation](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/no-anthropmorphic-possessives](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/no-past-future](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
+- [rule/no-description-start-with-the-a-an](https://redocly.com/docs/cli/rules/custom-rules/) (custom rules)
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rebilly OpenAPI Definitions
 
-- Our website (www.rebilly.com) is powered by the [Redocly Revel](https://redocly.com/developer-portal/).
+- Our website (www.rebilly.com) is powered by [Redocly Revel](https://redocly.com/developer-portal/).
 - Our API reference is powered by [Redocly Realm](https://redocly.com/product-updates/).
 
 TBD: Add Redocly validation status badge.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rebilly OpenAPI Definitions
 
-- Our website (www.rebilly.com) is powered by the [Redocly Portal](https://redocly.com/developer-portal/).
-- Our API reference is powered by [Redocly API docs](https://redocly.com/reference-docs/).
+- Our website (www.rebilly.com) is powered by the [Redocly Revel](https://redocly.com/developer-portal/).
+- Our API reference is powered by [Redocly Realm](https://redocly.com/product-updates/).
 
 TBD: Add Redocly validation status badge.
 
@@ -42,11 +42,11 @@ Rebilly uses [Redocly](https://redocly.com/) to generate, manage, and preview AP
 1. In the **Personal API keys** section, click **Add API key**.
 1. Enter an API key name, then click **Save**.
 1. Copy the API key.
-1. In a terminal, execute the following command: `redocly login`. 
+1. In a terminal, execute the following command: `npx @redocly/cli login`. 
 1. When prompted, paste your API key.
 1. Execute one of the following commands to start a development server docs preview:
-    - Core API docs: `redocly preview-docs core@latest`
-    - All API docs: `redocly preview-docs all@latest`
+    - Core API docs: `npx @redocly/cli preview-docs core@latest`
+    - All API docs: `npx @redocly/cli preview-docs all@latest`
  1. In a web browser, open the preview server URL that is displayed in the terminal.
 
 #### Build
@@ -55,5 +55,5 @@ Run `npm run build` to bundle the definitions into a single file in the `dist` f
 
 #### Validate
 
-Run `npx redocly lint` to validate the definitions.
+Run `npx @redocly/cli lint` to validate the definitions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rebilly-openapi-spec",
       "version": "0.0.4",
       "dependencies": {
-        "@redocly/cli": "1.2.1"
+        "@redocly/cli": "1.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1876,11 +1876,11 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.2.1.tgz",
-      "integrity": "sha512-JvSd1m+4Ki5A5rjMOMD8WILJeDjwltZcmuh3iJeGb/6JWZmF1bm1ZubsWxoOpHy0Shf6Tr6afDCKdf4c6r8AtQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.4.0.tgz",
+      "integrity": "sha512-MARIbVWG0XlwZwnpcd6IUXekJUxqvQCeU5eJ3RsvYzldFSC07RD0wWgdnem3xTLV+k+fHsgycezNz89D+UjBIA==",
       "dependencies": {
-        "@redocly/openapi-core": "1.2.1",
+        "@redocly/openapi-core": "1.4.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
         "core-js": "^3.32.1",
@@ -1920,9 +1920,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.2.1.tgz",
-      "integrity": "sha512-W7FFaG9e1N8vzE0Bbmrhq8XhxQI00EMmOoKvG7d0WiqBcpVEiuJFNjvxCxyfhNJ93o4AS3dQ94iNTCBRq1TqpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.4.0.tgz",
+      "integrity": "sha512-M4f0H3XExPvJ0dwbEou7YKLzkpz2ZMS9JoNvrbEECO7WCwjGZ4AjbiUjp2p0ZzFMNIiNgTVUJJmkxGxsXW471Q==",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",
@@ -5106,11 +5106,11 @@
       }
     },
     "@redocly/cli": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.2.1.tgz",
-      "integrity": "sha512-JvSd1m+4Ki5A5rjMOMD8WILJeDjwltZcmuh3iJeGb/6JWZmF1bm1ZubsWxoOpHy0Shf6Tr6afDCKdf4c6r8AtQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.4.0.tgz",
+      "integrity": "sha512-MARIbVWG0XlwZwnpcd6IUXekJUxqvQCeU5eJ3RsvYzldFSC07RD0wWgdnem3xTLV+k+fHsgycezNz89D+UjBIA==",
       "requires": {
-        "@redocly/openapi-core": "1.2.1",
+        "@redocly/openapi-core": "1.4.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
         "core-js": "^3.32.1",
@@ -5138,9 +5138,9 @@
       }
     },
     "@redocly/openapi-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.2.1.tgz",
-      "integrity": "sha512-W7FFaG9e1N8vzE0Bbmrhq8XhxQI00EMmOoKvG7d0WiqBcpVEiuJFNjvxCxyfhNJ93o4AS3dQ94iNTCBRq1TqpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.4.0.tgz",
+      "integrity": "sha512-M4f0H3XExPvJ0dwbEou7YKLzkpz2ZMS9JoNvrbEECO7WCwjGZ4AjbiUjp2p0ZzFMNIiNgTVUJJmkxGxsXW471Q==",
       "requires": {
         "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",

--- a/package.json
+++ b/package.json
@@ -1,24 +1,12 @@
 {
   "name": "rebilly-openapi-spec",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "dependencies": {
-    "@redocly/cli": "1.2.1"
+    "@redocly/cli": "1.4.0",
+    "@redocly/portal": "0.60.2"
   },
   "private": true,
   "scripts": {
-    "start": "redocly preview-docs",
-    "build": "npm run build-core && npm run build-users && npm run build-reports && npm run build-storefront && npm run build-combined",
-    "build-for-js-sdk": "npm run build-core -- --ext json && npm run build-users -- --ext json && npm run build-reports -- --ext json && npm run build-storefront -- --ext json",
-    "test": "redocly lint",
-    "build-core": "REBILLY_API_PRODUCT=Core redocly bundle openapi -o dist/core",
-    "build-users": "REBILLY_API_PRODUCT=Users redocly bundle openapi -o dist/users",
-    "build-reports": "REBILLY_API_PRODUCT=Reports redocly bundle openapi -o dist/reports",
-    "build-storefront": "REBILLY_API_PRODUCT=Storefront redocly bundle openapi -o dist/storefront",
-    "build-combined": "REBILLY_API_PRODUCT=Combined redocly bundle openapi -o dist/combined",
-    "serve-core": "REBILLY_API_PRODUCT=Core npm run start openapi",
-    "serve-users": "REBILLY_API_PRODUCT=Users npm run start openapi",
-    "serve-reports": "REBILLY_API_PRODUCT=Reports npm run start openapi",
-    "serve-storefront": "REBILLY_API_PRODUCT=Storefront npm run start openapi",
-    "serve-combined": "REBILLY_API_PRODUCT=Combined npm run start openapi"
+    "start": "portal develop"
   }
 }

--- a/plugins/decorators.js
+++ b/plugins/decorators.js
@@ -1,5 +1,7 @@
 const RemovePhpSamplePrefix = require('./decorators/remove-php-sample-prefix');
 const RemoveTagGroups = require('./decorators/remove-tag-groups');
+const ChangeTitle = require('./decorators/change-title');
+const RemoveUnusedTags = require('./decorators/remove-unused-tags');
 const id = 'plugin';
 
 
@@ -8,6 +10,8 @@ const decorators = {
   oas3: {
     'remove-tag-groups': RemoveTagGroups,
     'remove-php-sample-prefix': RemovePhpSamplePrefix,
+    'remove-unused-tags': RemoveUnusedTags,
+    'change-title': ChangeTitle,
   }
 };
 

--- a/plugins/decorators/change-title.js
+++ b/plugins/decorators/change-title.js
@@ -1,0 +1,13 @@
+module.exports = ChangeTitle;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+
+function ChangeTitle({title}) {
+  return {
+    Info: {
+      leave(Info) {
+        Info['title'] = title;
+      }
+    }
+  }
+};

--- a/plugins/decorators/remove-unused-tags.js
+++ b/plugins/decorators/remove-unused-tags.js
@@ -1,0 +1,21 @@
+module.exports = RemoveUnusedTags;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+
+function RemoveUnusedTags() {
+  const usedTags = new Set();
+  return {
+    Operation: {
+      leave(Operation) {
+        if (Operation.tags) {
+          Operation.tags.forEach(tag => usedTags.add(tag));
+        }
+      }
+    },
+    Root: {
+      leave(Root) {
+        Root.tags = Root.tags.filter(tag => usedTags.has(tag.name));
+      }
+    }
+  }
+};

--- a/plugins/products-bundler/README.md
+++ b/plugins/products-bundler/README.md
@@ -1,5 +1,7 @@
 # Products bundler
 
+TODO: remove after spec permalinks are replaced.
+
 File `openapi/openapi.yaml` is a single entrypoint for every bundled API definition.
 It should include all paths, tags and x-webhooks. It is a job of the `products-bundler`
 plugin to bundle specific API definition file for a product.

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,18 +1,86 @@
 apis:
   core@latest:
     root: openapi/openapi.yaml
+    output: catalog/core.yaml
+    metadata:
+      description: The most common APIs used to automate common workflows.
     decorators:
       filter-in:
         property: x-products
         value:
           - Core
+      plugin/change-title:
+        title: Core APIs
   all@latest:
     root: openapi/openapi.yaml
+    output: catalog/all.yaml
+    metadata:
+      description: All Rebilly APIs.
     decorators:
       plugin/remove-tag-groups: on
+      plugin/change-title:
+        title: All APIs
+  storefront@latest:
+    root: openapi/openapi.yaml
+    output: catalog/storefront.yaml
+    metadata:
+      description: APIs intended to be used directly from an untrusted browser.
+    decorators:
+      filter-in:
+        property: x-products
+        value:
+          - Storefront
+      plugin/change-title:
+        title: Storefront APIs
+      plugin/remove-tag-groups: on
+      plugin/remove-unused-tags: on
+  reports@latest:
+    root: openapi/openapi.yaml
+    output: catalog/reports.yaml
+    metadata:
+      description: APIs for reporting purposes.
+    decorators:
+      filter-in:
+        property: x-products
+        value:
+          - Reports
+      plugin/change-title:
+        title: Reports APIs
+      plugin/remove-tag-groups: on
+      plugin/remove-unused-tags: on
+  combined@latest:
+    root: openapi/openapi.yaml
+    output: catalog/combined.yaml
+    metadata:
+      description: Combined APIs for who knows what. Maybe we can remove this since we have "All"?
+    decorators:
+      filter-in:
+        property: x-products
+        value:
+          - Combined
+      plugin/change-title:
+        title: Combined APIs
+      plugin/remove-tag-groups: on
+      plugin/remove-unused-tags: on
+  users@latest:
+    root: openapi/openapi.yaml
+    output: catalog/users.yaml
+    metadata:
+      description: Users APIs for who knows what. Maybe we can remove this since we have "All"?
+    decorators:
+      filter-in:
+        property: x-products
+        value:
+          - Users
+      plugin/change-title:
+        title: Users APIs
+      plugin/remove-tag-groups: on
+      plugin/remove-unused-tags: on
   # The original bundler
   openapi:
     root: openapi/openapi.yaml
+    metadata:
+      description: All Rebilly APIs.
 extends:
   - recommended
 plugins:
@@ -452,3 +520,29 @@ theme:
     hideTryItPanel: false
     expandResponses: '200,201'
     requiredPropsFirst: true
+  catalog:
+    rebilly-catalog:
+      title: Rebilly API catalog
+      description: Discover how our APIs can support your business.
+      slug: /catalog/
+      items:
+        - directory: ./catalog
+          flatten: true
+          includeByMetadata:
+            type: [openapi]
+  navbar:
+    items:
+      - page: /catalog/
+        label: Catalog
+      - page: /contributing/
+        label: Contributing
+  logo:
+    altText: Rebilly API catalog
+    image: ./web/rb_apiLogo.svg
+ignore:
+  - '.github' # works
+  # - 'openapi'
+  - 'plugins'
+  - 'web'
+  # - 'CONTRIBUTING.md'
+  # - 'README.md'

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -1,0 +1,6 @@
+- page: CONTRIBUTING.md
+  label: Contributing
+- page: specification-extensions.md
+  label: Specification extensions
+- page: WRITING-STYLE.md
+  label: Writing style


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
Part 1 to replace the Redocly Workflows with the next Redocly products.

- Bundle APIs to various output locations (in catalog)
- Add catalog page
- Add navbar

Part 2 connects this repo to Redocly SaaS (and set up custom domain).

Part 3 replaces `<RedocResponse>` with the equivalent Markdoc tag.

Part 4 replaces SDK source permalinks and adjusts GHA triggers.


**This is part 1 only.**

## Links
<!-- add any related links to other PRs or docs -->
- Supports objective to use the new Redocly app. Currently, we use "registry" permalinks for SDK generation. This can be changed with this release.

## Checklist

- [x] Writing style
- [x] API design standards
