### PR TITLE
chore: re-add build local commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
   "private": true,
   "scripts": {
     "start": "portal develop",
-    "build-for-js-sdk": "npm run build-core && npm run build-storefront && npm run build-users && npm run build-reports",
-    "build-core": "redocly bundle core@latest -o dist/core --ext json",
-    "build-storefront": "redocly bundle storefront@latest -o dist/storefront --ext json",
-    "build-users": "redocly bundle users@latest -o dist/users --ext json",
-    "build-reports": "redocly bundle reports@latest -o dist/reports --ext json"
+    "build-for-js-sdk": "redocly bundle all@latest -o dist/all --ext json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   },
   "private": true,
   "scripts": {
-    "start": "portal develop"
+    "start": "portal develop",
+    "build-for-js-sdk": "npm run build-core && npm run build-storefront && npm run build-users && npm run build-reports",
+    "build-core": "redocly bundle core@latest -o dist/core --ext json",
+    "build-storefront": "redocly bundle storefront@latest -o dist/storefront --ext json",
+    "build-users": "redocly bundle users@latest -o dist/users --ext json",
+    "build-reports": "redocly bundle reports@latest -o dist/reports --ext json"
   }
 }


### PR DESCRIPTION
## Summary
This PR re-adds some local build commands, which were removed a few days ago in https://github.com/Rebilly/api-definitions/pull/1667 and are used elsewhere.

They are updated to work with the new bundle format