### PR TITLE
Migrate to OpenAPI 3.1

### DIFF
--- a/openapi/components/requestBodies/CreditTransactionRequest.yaml
+++ b/openapi/components/requestBodies/CreditTransactionRequest.yaml
@@ -40,11 +40,9 @@ content:
             the billing address associated with the payment instrument is used.
             If no billing address is associated with the payment instrument,
             the customer's billing address is used.
-          type:
-            - 'object'
-            - 'null'
-          allOf:
+          oneOf:
             - $ref: ../schemas/ContactObject.yaml
+            - type: 'null'
         requestId:
           description: |-
             Use this field to prevent duplicate transaction requests that may occur within a short period of time.

--- a/openapi/components/requestBodies/CreditTransactionRequest.yaml
+++ b/openapi/components/requestBodies/CreditTransactionRequest.yaml
@@ -21,8 +21,9 @@ content:
           example: 97.97
         invoiceIds:
           description: Array of invoice IDs.
-          nullable: true
-          type: array
+          type:
+            - 'array'
+            - 'null'
           items:
             $ref: ../schemas/ResourceId.yaml
         paymentInstruction:
@@ -39,8 +40,9 @@ content:
             the billing address associated with the payment instrument is used.
             If no billing address is associated with the payment instrument,
             the customer's billing address is used.
-          nullable: true
-          type: object
+          type:
+            - 'object'
+            - 'null'
           allOf:
             - $ref: ../schemas/ContactObject.yaml
         requestId:
@@ -51,8 +53,9 @@ content:
             This value must be unique within a 24-hour period.
 
             > **Important:** This field is recommended.
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           pattern: '^[\-\w]+$'
           example: 44433322-2c4y-483z-a0a9-158621f77a21
@@ -63,17 +66,18 @@ content:
             To prevent Rebilly from making the gateway account selection,
             supply a gateway account ID in this field.
             Only use this field if you intend to override the settings.
-          nullable: true
-          type: string
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: gw_acc_0YVCXMF26DDNKAERE5NW727S34
         description:
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: Payment description.
-          type: string
           maxLength: 255
         notificationUrl:
-          nullable: true
           description: |-
             URL where a server-to-server `POST` notification is sent.
             This notification is sent when the transaction result is finalized after a timeout or an offsite interaction.
@@ -85,16 +89,19 @@ content:
 
             The following placeholders are available to use in this URI: `{id}` and `{result}`.
             These placeholders are replaced the with the transaction ID and result accordingly.
-          type: string
+          type: 
+            - 'string'
+            - 'null'
           format: uri
         redirectUrl:
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: |-
             URL to redirect the end-user when an offsite transaction is completed.
             Defaults to the configured URL of the website.
             You may use `{id}` or `{result}` as placeholders in the URL,
             these are replaced the with the transaction ID and result accordingly.
-          type: string
           format: uri
         customFields:
           $ref: ../schemas/ResourceCustomFields.yaml

--- a/openapi/components/requestBodies/FileCreateFromInline.yaml
+++ b/openapi/components/requestBodies/FileCreateFromInline.yaml
@@ -22,8 +22,9 @@ properties:
     example: My file description
   sourceType:
     description: Source of the file.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     enum:
       - upload
       - camera

--- a/openapi/components/requestBodies/FileCreateFromUrl.yaml
+++ b/openapi/components/requestBodies/FileCreateFromUrl.yaml
@@ -23,8 +23,9 @@ properties:
     example: My file description
   sourceType:
     description: Source of the file.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     enum:
       - upload
       - camera

--- a/openapi/components/requestBodies/PatchCreditMemo.yaml
+++ b/openapi/components/requestBodies/PatchCreditMemo.yaml
@@ -124,12 +124,8 @@ properties:
           maxLength: 50
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
-          type:
-            - 'object'
-            - 'null'
           description: Credit memo item tax.
-          allOf:
-            - $ref: ../schemas/CreditMemoTaxItem.yaml
+          $ref: ../schemas/CreditMemoTaxItem.yaml
   reason:
     description: Reason for the credit memo.
     type: string

--- a/openapi/components/requestBodies/PatchCreditMemo.yaml
+++ b/openapi/components/requestBodies/PatchCreditMemo.yaml
@@ -89,8 +89,9 @@ properties:
           example: crmm_itm_0YVCNN22TWC3G8H82QNPNVZCHG
         invoiceItemId:
           description: ID of the invoice item to which the credit item is referenced.
-          nullable: true
-          type: string
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: ii_0YVFDEQS2KCFTBN9HXWJFY55GV
         description:
@@ -109,21 +110,24 @@ properties:
           format: double
           readOnly: true
         productId:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: ID of the related product.
           maxLength: 50
           example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
         planId:
           description: ID of the related plan.
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
-          type: object
+          type:
+            - 'object'
+            - 'null'
           description: Credit memo item tax.
-          nullable: true
           allOf:
             - $ref: ../schemas/CreditMemoTaxItem.yaml
   reason:

--- a/openapi/components/requestBodies/PatchCreditMemo.yaml
+++ b/openapi/components/requestBodies/PatchCreditMemo.yaml
@@ -125,7 +125,9 @@ properties:
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
           description: Credit memo item tax.
-          $ref: ../schemas/CreditMemoTaxItem.yaml
+          oneOf:
+            - $ref: ../schemas/CreditMemoTaxItem.yaml
+            - type: 'null'
   reason:
     description: Reason for the credit memo.
     type: string

--- a/openapi/components/requestBodies/PatchFee.yaml
+++ b/openapi/components/requestBodies/PatchFee.yaml
@@ -15,16 +15,18 @@ properties:
     minLength: 1
     maxLength: 255
     example: 'type:sale,capture;result:approved'
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   formula:
     $ref: ../schemas/FeeFormula.yaml
   settlementSettings:
     description: |-
       Fee settlement settings.
       This value overrides the gateway account financial settings of the transaction.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ../schemas/SettlementSettings.yaml
 

--- a/openapi/components/requestBodies/PatchFee.yaml
+++ b/openapi/components/requestBodies/PatchFee.yaml
@@ -24,9 +24,7 @@ properties:
     description: |-
       Fee settlement settings.
       This value overrides the gateway account financial settings of the transaction.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ../schemas/SettlementSettings.yaml
+      - type: 'null'
 

--- a/openapi/components/requestBodies/PostDepositRequest.yaml
+++ b/openapi/components/requestBodies/PostDepositRequest.yaml
@@ -28,15 +28,17 @@ properties:
           maximum: 10000
       ```
       For more information, see [Create a deposit strategy](https://all-rebilly.redoc.ly/tag/Deposits/#operation/PostDepositStrategy).
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
-    nullable: true
     example: dep_str_0YVJ64MAHTDPA97H8S7R5MYR1M
   currency:
     $ref: ../schemas/CurrencyCode.yaml
   amounts:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of available deposit amounts.
 
@@ -47,34 +49,38 @@ properties:
       format: double
       minimum: 0.01
   amountLimits:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Deposit amount limit information. Set optional minimum and maximum deposit amounts. Limits override `amounts` and `customAmount` values.
       If this value is `null`, deposit amount limits are not set.
-    nullable: true
     minProperties: 1
     properties:
       minimum:
         description: Minimum deposit amount.
-        type: number
-        nullable: true
+        type:
+          - 'number'
+          - 'null'
         format: double
         default: 0
         minimum: 0
       maximum:
         description: Maximum deposit amount.
-        type: number
-        nullable: true
+        type:
+          - 'number'
+          - 'null'
         format: double
         minimum: 0
   customAmount:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Custom amount restrictions.
       If this value is `null`,  custom amounts are prohibited.
       If `customAmount` is not specified when a deposit request is created, amount restrictions are determined from the chosen strategy.
       For more information, see the [`strategyId` property](https://all-rebilly.redoc.ly/tag/Deposits/#operation/PostDepositRequest#!path=strategyId&t=request).
-    nullable: true
     required:
       - minimum
       - multipleOf
@@ -102,17 +108,20 @@ properties:
         minimum: 0.01
   redirectUrl:
     description: URL to redirect the customer to when a deposit is completed. The default value is the website URL.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   expirationTime:
     description: Date and time at which the deposit request expires. The default expiration time is one hour after the time the request is created.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   customPropertySetId:
     description: ID of a custom property set to apply to the request `propertiesSchema`.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
-    nullable: true
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21

--- a/openapi/components/requestBodies/TransactionRequest.yaml
+++ b/openapi/components/requestBodies/TransactionRequest.yaml
@@ -69,11 +69,9 @@ content:
             the billing address associated with the payment instrument is used.
             If no billing address is associated with the payment instrument,
             the customer's billing address is used.
-          type:
-            - 'object'
-            - 'null'
-          allOf:
+          oneOf:
             - $ref: ../schemas/ContactObject.yaml
+            - type: 'null'
         requestId:
           description: |-
             Use this field to prevent duplicate transaction requests that may occur within a short period of time.

--- a/openapi/components/requestBodies/TransactionRequest.yaml
+++ b/openapi/components/requestBodies/TransactionRequest.yaml
@@ -50,8 +50,9 @@ content:
           example: 97.97
         invoiceIds:
           description: Array of invoice IDs.
-          nullable: true
-          type: array
+          type:
+            - 'array'
+            - 'null'
           items:
             $ref: ../schemas/ResourceId.yaml
         paymentInstruction:
@@ -68,8 +69,9 @@ content:
             the billing address associated with the payment instrument is used.
             If no billing address is associated with the payment instrument,
             the customer's billing address is used.
-          nullable: true
-          type: object
+          type:
+            - 'object'
+            - 'null'
           allOf:
             - $ref: ../schemas/ContactObject.yaml
         requestId:
@@ -80,8 +82,9 @@ content:
             This value must be unique within a 24-hour period.
 
             > **Important:** This field is recommended.
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           pattern: '^[\-\w]+$'
           example: 44433322-2c4y-483z-a0a9-158621f77a21
@@ -92,17 +95,18 @@ content:
             To prevent Rebilly from making the gateway account selection,
             supply a gateway account ID in this field.
             Only use this field if you intend to override the settings.
-          nullable: true
-          type: string
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: gw_acc_0YVCXMF26DDNKAERE5NW727S34
         description:
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: Payment description.
-          type: string
           maxLength: 255
         notificationUrl:
-          nullable: true
           description: |-
             URL where a server-to-server `POST` notification is sent.
             This notification is sent when the transaction result is finalized after a timeout or an offsite interaction.
@@ -114,16 +118,19 @@ content:
 
             The following placeholders are available to use in this URI: `{id}` and `{result}`.
             These placeholders are replaced the with the transaction ID and result accordingly.
-          type: string
+          type:
+            - 'string'
+            - 'null'
           format: uri
         redirectUrl:
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: |-
             URL to redirect the end-user when an offsite transaction is completed.
             Defaults to the configured URL of the website.
             You may use `{id}` or `{result}` as placeholders in the URL,
             these are replaced the with the transaction ID and result accordingly.
-          type: string
           format: uri
         customFields:
           $ref: ../schemas/ResourceCustomFields.yaml

--- a/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
@@ -27,11 +27,9 @@ content:
             dispute:
               $ref: ../../schemas/Dispute.yaml
             transaction:
-              type:
-                - 'object'
-                - 'null'
-              allOf:
+              oneOf:
                 - $ref: ../../schemas/Transaction.yaml
+                - type: 'null'
         _links:
           type: array
           description: Related links.

--- a/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/DisputeWebhook.yaml
@@ -8,9 +8,10 @@ content:
           maxLength: 50
           example: dp_0YVCE8J5F2DE58FV0S8YASW4HK
         transactionId:
-          type: string
+          type:
+            - 'string'
+            - 'null'
           description: ID of the transaction.
-          nullable: true
           maxLength: 50
           example: txn_0YVDTQJ8YWDGQACV2N2N5SPWQ0
         eventType:
@@ -26,8 +27,9 @@ content:
             dispute:
               $ref: ../../schemas/Dispute.yaml
             transaction:
-              type: object
-              nullable: true
+              type:
+                - 'object'
+                - 'null'
               allOf:
                 - $ref: ../../schemas/Transaction.yaml
         _links:

--- a/openapi/components/requestBodies/storefront/PatchOrder.yaml
+++ b/openapi/components/requestBodies/storefront/PatchOrder.yaml
@@ -5,17 +5,13 @@ content:
       properties:
         deliveryAddress:
           description: Order delivery address.
-          type:
-            - 'object'
-            - 'null'
-          allOf:
+          oneOf:
             - $ref: ../../schemas/ContactObject.yaml
+            - type: 'null'
         billingAddress:
           description: Order billing address.
-          type:
-            - 'object'
-            - 'null'
-          allOf:
+          oneOf:
             - $ref: ../../schemas/ContactObject.yaml
+            - type: 'null'
 description: Order resource.
 required: true

--- a/openapi/components/requestBodies/storefront/PatchOrder.yaml
+++ b/openapi/components/requestBodies/storefront/PatchOrder.yaml
@@ -5,14 +5,16 @@ content:
       properties:
         deliveryAddress:
           description: Order delivery address.
-          type: object
-          nullable: true
+          type:
+            - 'object'
+            - 'null'
           allOf:
             - $ref: ../../schemas/ContactObject.yaml
         billingAddress:
           description: Order billing address.
-          type: object
-          nullable: true
+          type:
+            - 'object'
+            - 'null'
           allOf:
             - $ref: ../../schemas/ContactObject.yaml
 description: Order resource.

--- a/openapi/components/requestBodies/storefront/PostOrderPause.yaml
+++ b/openapi/components/requestBodies/storefront/PostOrderPause.yaml
@@ -5,9 +5,10 @@ content:
       properties:
         description:
           description: Description of the pause reason in free form.
-          type: string
+          type:
+            - 'string'
+            - 'null'
           maxLength: 255
-          nullable: true
         effectiveTime:
           description: |-
             Date and time when the service period pauses.
@@ -16,9 +17,10 @@ content:
             If this time is earlier then the current time, the current time is used.
 
             If this field is omitted, this value defaults to the current time.
-          type: string
+          type:
+            - 'string'
+            - 'null'
           format: date-time
-          nullable: true
         endTime:
           description: |-
             Date and time when the pause ends and the subscription resumes billing.
@@ -27,8 +29,9 @@ content:
             use the current time or an earlier time.
             If `endTime` is earlier then the current time, the current time is used.
             If this field is empty, the subscription is indefinitely paused.
-          type: string
+          type:
+            - 'string'
+            - 'null'
           format: date-time
-          nullable: true
 description: Order resource.
 required: true

--- a/openapi/components/requestBodies/storefront/SetupPaymentInstrumentRequest.yaml
+++ b/openapi/components/requestBodies/storefront/SetupPaymentInstrumentRequest.yaml
@@ -22,19 +22,21 @@ content:
             If a billing address is not supplied the address associated with the payment instrument is used.
             If no address is associated with the payment instrument,
             the customer's address is used.
-          nullable: true
-          type: object
+          type:
+            - 'object'
+            - 'null'
           allOf:
             - $ref: ../../schemas/ContactObject.yaml
         redirectUrl:
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: |-
             URL to redirect the end-user when an offsite transaction is completed.
             This field defaults to the configured website URL.
             You may use `{id}` or `{result}` as placeholders in the URL.
             These placeholders are replaced with the transaction ID and result.
             For more information, see [Placeholders](https://www.rebilly.com/docs/automations/email-notifications/#placeholders).
-          type: string
           format: uri
         riskMetadata:
           $ref: ../../schemas/RiskMetadata.yaml

--- a/openapi/components/requestBodies/storefront/SetupPaymentInstrumentRequest.yaml
+++ b/openapi/components/requestBodies/storefront/SetupPaymentInstrumentRequest.yaml
@@ -22,11 +22,9 @@ content:
             If a billing address is not supplied the address associated with the payment instrument is used.
             If no address is associated with the payment instrument,
             the customer's address is used.
-          type:
-            - 'object'
-            - 'null'
-          allOf:
+          oneOf:
             - $ref: ../../schemas/ContactObject.yaml
+            - type: 'null'
         redirectUrl:
           type:
             - 'string'

--- a/openapi/components/requestBodies/storefront/StorefrontTransactionRedirectUrl.yaml
+++ b/openapi/components/requestBodies/storefront/StorefrontTransactionRedirectUrl.yaml
@@ -1,4 +1,6 @@
-type: string
+type:
+  - 'string'
+  - 'null'
 description: |-
   URL to redirect the end-user when an offsite transaction is completed.
   If `website.url` is `https://example.com`, then the `redirectUrl` could be set to any of these:
@@ -15,4 +17,3 @@ description: |-
   You may use `{id}` or `{result}` as placeholders in the URL and we replace them with the transaction id and result accordingly.
 format: uri
 writeOnly: true
-nullable: true

--- a/openapi/components/schemas/AML.yaml
+++ b/openapi/components/schemas/AML.yaml
@@ -6,10 +6,11 @@ properties:
     readOnly: true
     example: Benjamin
   lastName:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Last name of the individual. Returns a `null` value for single-named entities.
     readOnly: true
-    nullable: true
     example: Franklin
   source:
     type: string
@@ -31,14 +32,16 @@ properties:
         - enforcements
         - state-owned-enterprise
   gender:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
     description: If `type`=`individual`, this field describes the gender of the individual.
   title:
-    type: array
+    type:
+      - 'array'
+      - 'null'
     readOnly: true
-    nullable: true
     description: Individual's job title.
     example:
       - Postmaster General
@@ -61,10 +64,11 @@ properties:
     items:
       type: string
   regime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     description: Describes the government, administration, or political entity.
-    nullable: true
     example: United States Government
   confidence:
     type: string
@@ -87,28 +91,33 @@ properties:
       type: object
       properties:
         address:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           readOnly: true
           description: Street address line 1.
         address2:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           readOnly: true
           description: Street address line 2.
         city:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           readOnly: true
           description: City.
         region:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           readOnly: true
           description: State, province, or region.
         country:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           readOnly: true
           description: Country.
         birthplace:
@@ -166,9 +175,10 @@ properties:
           readOnly: true
           description: Passport registration date.
   comments:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
     description: Additional information. This content varies per list.
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/AcquirerName.yaml
+++ b/openapi/components/schemas/AcquirerName.yaml
@@ -1,6 +1,7 @@
 description: Acquirer name.
-nullable: true
-type: string
+type:
+  - 'string'
+  - 'null'
 enum:
   - Adyen
   - ACI

--- a/openapi/components/schemas/AdjustReadyToPayAch.yaml
+++ b/openapi/components/schemas/AdjustReadyToPayAch.yaml
@@ -6,8 +6,9 @@ properties:
     enum:
       - ach
   feature:
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Feature name.
     enum:
       - Plaid

--- a/openapi/components/schemas/AdjustReadyToPayGeneric.yaml
+++ b/openapi/components/schemas/AdjustReadyToPayGeneric.yaml
@@ -9,5 +9,6 @@ properties:
           enum:
             - paypal
   feature:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'

--- a/openapi/components/schemas/AdjustReadyToPayPaymentCard.yaml
+++ b/openapi/components/schemas/AdjustReadyToPayPaymentCard.yaml
@@ -6,8 +6,9 @@ properties:
     enum:
       - payment-card
   feature:
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Name of the feature.
     enum:
       - Apple Pay

--- a/openapi/components/schemas/AdjustReadyToPayPaypal.yaml
+++ b/openapi/components/schemas/AdjustReadyToPayPaypal.yaml
@@ -6,8 +6,9 @@ properties:
     enum:
       - paypal
   feature:
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Feature name.
     enum:
       - PayPal billing agreement

--- a/openapi/components/schemas/AllowedIps.yaml
+++ b/openapi/components/schemas/AllowedIps.yaml
@@ -2,8 +2,9 @@ description: |-
   List of IP addresses that are permitted access.
   Private subnets are prohibited.
   To remove restrictions, set this value to `null`.
-nullable: true
-type: array
+type:
+  - 'array'
+  - 'null'
 items:
   type: string
   format: ip

--- a/openapi/components/schemas/AlternativeInstrument.yaml
+++ b/openapi/components/schemas/AlternativeInstrument.yaml
@@ -50,8 +50,9 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   referenceData:
     description: Payment instrument reference data.
@@ -61,8 +62,9 @@ properties:
     example:
       gatewayTransactionId: GAT123
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   revision:

--- a/openapi/components/schemas/AlternativeInstrument.yaml
+++ b/openapi/components/schemas/AlternativeInstrument.yaml
@@ -62,11 +62,9 @@ properties:
     example:
       gatewayTransactionId: GAT123
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   revision:
     description: |-
       Number of times the payment instrument data has been modified.

--- a/openapi/components/schemas/AlternativePaymentToken.yaml
+++ b/openapi/components/schemas/AlternativePaymentToken.yaml
@@ -34,11 +34,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/AlternativePaymentToken.yaml
+++ b/openapi/components/schemas/AlternativePaymentToken.yaml
@@ -34,8 +34,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -48,14 +49,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/AmlCheck.yaml
+++ b/openapi/components/schemas/AmlCheck.yaml
@@ -17,28 +17,33 @@ properties:
     maxLength: 50
     example: web_0YV7DE4Z26DQSA1AC92FBJ7SEG
   reviewerId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     description: User ID of the person who reviewed the AML check.
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: First and last name of the person who reviewed the AML check.
   reviewStartTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
     description: Date and time when the AML check review is started.
   reviewTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
     description: Date and time when the AML check review is completed.
   priority:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     default: null
     description: Highest matched priority of all hits within an AML check.
   source:
@@ -84,48 +89,55 @@ properties:
             maxLength: 45
             description: Customer's last name at the time of the AML check.
           dob:
-            type: string
+            type:
+              - 'string'
+              - 'null'
             format: date
-            nullable: true
             description: Customer's date of birth.
             example: 1971-02-14
           address:
             description: First line of the customer's street address at the time of the AML check.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             pattern: '^[\w\s\-\/\p{L},.#;:()''&]+$'
             maxLength: 60
             example: 36 Craven St
-            nullable: true
           address2:
             description: Second line of the customer's street address at the time of the AML check.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             pattern: '^[\w\s\-\/\p{L},.#;:()''&]+$'
             maxLength: 60
-            nullable: true
           city:
             description: Customer's city of residence at the time of the AML check.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             pattern: '^[\w\s\-\p{L},.'']+$'
             maxLength: 45
-            nullable: true
             example: Austin
           region:
             description: Customer's region of residence at the time of the AML check.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             pattern: '^[\w\s\-\/\p{L},.#;:()'']+$'
             maxLength: 45
-            nullable: true
             example: Texas
           country:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             description: Customer's country of residence at the time of the AML check.
           postalCode:
             description: Customer's postal code at the time of the AML check.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             pattern: '^[\w\s\-]+$'
             maxLength: 10
-            nullable: true
             example: WC2N 5NF
       tags:
         description: List of tags that have been assigned to the customer.

--- a/openapi/components/schemas/AmlChecksDataExport.yaml
+++ b/openapi/components/schemas/AmlChecksDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/AmlConfidence.yaml
+++ b/openapi/components/schemas/AmlConfidence.yaml
@@ -1,6 +1,7 @@
-type: string
+type:
+  - 'string'
+  - 'null'
 description: Degree of confidence to assign.
-nullable: true
 enum:
   - weak
   - medium

--- a/openapi/components/schemas/AmlPriority.yaml
+++ b/openapi/components/schemas/AmlPriority.yaml
@@ -1,6 +1,7 @@
-type: string
+type:
+  - 'string'
+  - 'null'
 description: Priority level of matched AML customer information.
-nullable: true
 default: null
 enum:
   - p0

--- a/openapi/components/schemas/Application.yaml
+++ b/openapi/components/schemas/Application.yaml
@@ -25,10 +25,11 @@ properties:
     description: Name of the application author.
     type: string
   authorLogoId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: File ID of the author's logo.
     maxLength: 50
-    nullable: true
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   tagline:
     description: Tagline of the application.
@@ -86,9 +87,10 @@ properties:
       - GetCustomerCollection
   configurationUrl:
     description: External URL where the application is configured during installation.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: url
-    nullable: true
   configuredBy:
     type: string
     description: Specifies who can configure the application.

--- a/openapi/components/schemas/ArrayCustomField.yaml
+++ b/openapi/components/schemas/ArrayCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - array
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       allowedValues:

--- a/openapi/components/schemas/AuthenticationOptions.yaml
+++ b/openapi/components/schemas/AuthenticationOptions.yaml
@@ -2,8 +2,9 @@ type: object
 properties:
   passwordPattern:
     description: Allowed password pattern.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   credentialTtl:
     description: Default credential lifetime, in seconds.
     type: integer

--- a/openapi/components/schemas/AuthenticationTokenResponse.yaml
+++ b/openapi/components/schemas/AuthenticationTokenResponse.yaml
@@ -24,8 +24,9 @@ properties:
       - $ref: ./ResourceId.yaml
   expiredTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/AvalaraCredential.yaml
+++ b/openapi/components/schemas/AvalaraCredential.yaml
@@ -31,8 +31,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/BankAccount.yaml
+++ b/openapi/components/schemas/BankAccount.yaml
@@ -80,11 +80,9 @@ properties:
       - 'null'
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   useAsBackup:
     $ref: ./UseAsBackup.yaml
   createdTime:

--- a/openapi/components/schemas/BankAccount.yaml
+++ b/openapi/components/schemas/BankAccount.yaml
@@ -41,8 +41,9 @@ properties:
       - other
   bic:
     description: Bank Identifier Code (BIC).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   billingAddress:
     description: Customer's billing address.
     allOf:
@@ -74,12 +75,14 @@ properties:
       All future payments are processed by this gateway account.
 
       For more information, see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   useAsBackup:

--- a/openapi/components/schemas/BankAccountCreatePlain.yaml
+++ b/openapi/components/schemas/BankAccountCreatePlain.yaml
@@ -10,7 +10,6 @@ discriminator:
     IBAN: ./IBANType.yaml
 properties:
   accountNumberType:
-    nullable: false
     type: string
     enum:
       - IBAN

--- a/openapi/components/schemas/BankAccountToken.yaml
+++ b/openapi/components/schemas/BankAccountToken.yaml
@@ -28,11 +28,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/BankAccountToken.yaml
+++ b/openapi/components/schemas/BankAccountToken.yaml
@@ -28,8 +28,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -42,14 +43,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/BillingPortal.yaml
+++ b/openapi/components/schemas/BillingPortal.yaml
@@ -29,9 +29,10 @@ properties:
     description: |-
       Custom domain for the billing portal.
       The default domain is: `portal.secure-payments.app`.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
-    nullable: true
   features:
     description: Features that can be enabled for the billing portal.
     type: object
@@ -65,10 +66,11 @@ properties:
     type: object
     properties:
       logoId:
-        type: string
+        type:
+          - 'string'
+          - 'null'
         description: File ID of the billing portal logo.
         maxLength: 50
-        nullable: true
         example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
       colors:
         description: Various colors used in the billing portal.
@@ -90,19 +92,22 @@ properties:
         properties:
           refundPolicy:
             description: Website refund policy URL.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             format: url
-            nullable: true
           privacyPolicy:
             description: Website privacy policy URL.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             format: url
-            nullable: true
           termsOfService:
             description: Website terms of service URL.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             format: url
-            nullable: true
   status:
     description: |-
       Status of the billing portal. If the status is `inactive`,

--- a/openapi/components/schemas/Blocklist.yaml
+++ b/openapi/components/schemas/Blocklist.yaml
@@ -28,8 +28,9 @@ properties:
     type: string
   expirationTime:
     description: Date and time when the blocklist expires.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   createdTime:
     $ref: CreatedTime.yaml

--- a/openapi/components/schemas/BooleanCustomField.yaml
+++ b/openapi/components/schemas/BooleanCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - boolean
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       required:

--- a/openapi/components/schemas/BroadcastMessage.yaml
+++ b/openapi/components/schemas/BroadcastMessage.yaml
@@ -10,8 +10,9 @@ properties:
     maxLength: 50
     example: mail_bcst_0YV8XW5EXWDVEAP64XP8CY2X40
   filter:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Use this filter to select customers during broadcast message processing.
 
@@ -112,8 +113,9 @@ properties:
         - templates
   splitTestStartTime:
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     description: Date and time when the split test messages are scheduled to send.
   startSendingTime:

--- a/openapi/components/schemas/BuyFeeTransaction.yaml
+++ b/openapi/components/schemas/BuyFeeTransaction.yaml
@@ -26,8 +26,9 @@ properties:
 
       Some types of transactions relate to parent transactions.
       For example, a `risk-reserve` relates to a `charge`, and a `risk-reserve-release` relates a to `risk-reserve`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
@@ -43,8 +44,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -54,8 +56,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/ChargeTransaction.yaml
+++ b/openapi/components/schemas/ChargeTransaction.yaml
@@ -20,8 +20,9 @@ properties:
 
       Some types of transactions relate to parent transactions.
       For example, a `risk-reserve` relates to a `charge`, and a `risk-reserve-release` relates a to `risk-reserve`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
@@ -37,8 +38,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -48,8 +50,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/CheckoutForm.yaml
+++ b/openapi/components/schemas/CheckoutForm.yaml
@@ -14,9 +14,10 @@ properties:
     $ref: ./WebsiteId.yaml
   customDomain:
     description: Custom domain for the checkout form.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
-    nullable: true
   plans:
     type: array
     description: |-
@@ -64,9 +65,10 @@ properties:
       Limits the number of purchases that can be made using a specific checkout form.
       If a purchase limit value is set, each purchase decreases this value.
       When the purchases limit value reaches zero, the checkout form becomes inactive.
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     minimum: 0
-    nullable: true
     default: null
   paymentMethods:
     description: |-
@@ -82,14 +84,16 @@ properties:
     properties:
       logoId:
         description: ID of the linked file object.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         maxLength: 50
         example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
       summary:
         description: Summary text.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       buttonText:
         description: Button text. Use the `{{amount}}` placeholder to display the checkout form total.
         type: string
@@ -114,18 +118,21 @@ properties:
         properties:
           refundPolicy:
             description: Website refund policy URL.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             format: url
           privacyPolicy:
             description: Website privacy policy URL.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             format: url
           termsOfService:
             description: Website terms of service URL.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             format: url
       tracking:
         description: Tracking system IDs.
@@ -133,35 +140,41 @@ properties:
         properties:
           googleAnalytics:
             description: Google Analytics tracking ID.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: UA-XXXXX-YY
           googleTagManager:
             description: Google Tag Manager tracking ID.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: GTM-XXXXX
           gtagJs:
             description: |-
               Google Analytics tracking ID.
               This value is used by Google Global Site Tag (gtag.js) service.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: UA-XXXXX-YY
           facebookPixel:
             description: Facebook Pixel tracking ID.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: '1234567890'
           segmentAnalytics:
             description: Segment Analytics tracking ID.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: '1234567890'
           heapIo:
             description: Heap.io tracking ID.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             example: '1234567890'
       requiredAdditionalFields:
         description: List of required fields.

--- a/openapi/components/schemas/Company.yaml
+++ b/openapi/components/schemas/Company.yaml
@@ -1,40 +1,47 @@
-type: object
+type:
+  - 'object'
+  - 'null'
 description: |-
   Company information that is associated with the customer's primary email address domain.
 
   This is a paid feature, to enable it [contact Rebilly](https://www.rebilly.com/support/).
-nullable: true
 readOnly: true
 properties:
   name:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Name of the company.
-    nullable: true
   domain:
     type: string
     description: Website domain of the company.
   yearFounded:
-    type: number
+    type:
+      - 'number'
+      - 'null'
     description: Founding year of the company.
     format: integer
-    nullable: true
   industry:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Industry the company is associated with.
-    nullable: true
   employeesCount:
-    type: number
+    type:
+      - 'number'
+      - 'null'
     description: Number of employees in the company.
     format: integer
-    nullable: true
   country:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Country where the company is based.
-    nullable: true
   locality:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Locality or region where the company is based.
-    nullable: true
   _links:
     type: array
     items:

--- a/openapi/components/schemas/ContactObject.yaml
+++ b/openapi/components/schemas/ContactObject.yaml
@@ -3,67 +3,76 @@ description: Contact's information.
 properties:
   firstName:
     description: Contact's first name.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\p{L},.'']+$'
     maxLength: 45
     example: Benjamin
-    nullable: true
   lastName:
     description: Contact's last name.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\p{L},.'']+$'
     maxLength: 45
     example: Franklin
-    nullable: true
   organization:
     description: Contact's organization.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\p{L},.''&]+$'
     maxLength: 255
-    nullable: true
     example: Rebilly
   address:
     description: First line of the contact's street address.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\/\p{L},.#;:()''&]+$'
     maxLength: 60
     example: 36 Craven St
-    nullable: true
   address2:
     description: Second line of the contact's street address.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\/\p{L},.#;:()''&]+$'
     maxLength: 60
-    nullable: true
   city:
     description: Contact's city of residence.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\p{L},.'']+$'
     maxLength: 45
-    nullable: true
     example: Austin
   region:
     description: Contact's region of residence.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\/\p{L},.#;:()'']+$'
     maxLength: 45
-    nullable: true
     example: Texas
   country:
     description: |-
       Contact's country of residence in ISO 3166 alpha-2 country code.
       For examples, see [ISO.org](https://www.iso.org/obp/ui/#search/code/).
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[A-Z]{2}$'
     maxLength: 2
-    nullable: true
     example: GB
   postalCode:
     description: Contact's postal code.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-]+$'
     maxLength: 10
-    nullable: true
     example: WC2N 5NF
   phoneNumbers:
     $ref: ./ContactPhoneNumbers.yaml
@@ -71,16 +80,18 @@ properties:
     $ref: ./ContactEmails.yaml
   dob:
     description: Contact's date of birth in ISO-8601 `YYYY-MM-DD` format.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date
-    nullable: true
     example: 1980-04-01
   jobTitle:
     description: Contact's job title.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[\w\s\-\/\p{L},.#;:()'']+$'
     maxLength: 255
-    nullable: true
     example: CEO
   hash:
     description: Use this value to compare contacts for identical attribute values.

--- a/openapi/components/schemas/Coupon.yaml
+++ b/openapi/components/schemas/Coupon.yaml
@@ -49,8 +49,9 @@ properties:
     format: date-time
   expiredTime:
     description: Date and time when the coupon expires.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-label: Valid until
     x-sortable: true
     x-basic: true

--- a/openapi/components/schemas/CouponRedemption.yaml
+++ b/openapi/components/schemas/CouponRedemption.yaml
@@ -27,8 +27,9 @@ properties:
     description: Date and time when the coupon is canceled.
     readOnly: true
     x-sortable: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   _links:
     type: array

--- a/openapi/components/schemas/CreditFileMatches.yaml
+++ b/openapi/components/schemas/CreditFileMatches.yaml
@@ -89,8 +89,9 @@ properties:
           - $ref: CreditFileCommonDecisionData.yaml
       dualDecision:
         description: Data related to a dual source decision.
-        nullable: true
-        type: array
+        type:
+          - 'array'
+          - 'null'
         items:
           allOf:
             - $ref: CreditFileCommonDecisionData.yaml

--- a/openapi/components/schemas/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemo.yaml
@@ -102,8 +102,9 @@ properties:
           example: crmm_itm_0YVCNN22TWC3G8H82QNPNVZCHG
         invoiceItemId:
           description: ID of the invoice item to which the credit item is referenced.
-          nullable: true
-          type: string
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: ii_0YVFDEQS2KCFTBN9HXWJFY55GV
         description:
@@ -122,21 +123,24 @@ properties:
           format: double
           readOnly: true
         productId:
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           description: ID of the related product.
           maxLength: 50
           example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
         planId:
           description: ID of the related plan.
-          type: string
-          nullable: true
+          type:
+            - 'string'
+            - 'null'
           maxLength: 50
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
-          type: object
+          type:
+            - 'object'
+            - 'null'
           description: Credit memo item tax.
-          nullable: true
           allOf:
             - $ref: ./CreditMemoTaxItem.yaml
   status:
@@ -211,9 +215,10 @@ properties:
     readOnly: true
     $ref: ./CurrencyCode.yaml
   invoiceId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the invoice to which the credit memo is issued.
-    nullable: true
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   createdTime:

--- a/openapi/components/schemas/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemo.yaml
@@ -137,12 +137,8 @@ properties:
           maxLength: 50
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
-          type:
-            - 'object'
-            - 'null'
           description: Credit memo item tax.
-          allOf:
-            - $ref: ./CreditMemoTaxItem.yaml
+          $ref: ./CreditMemoTaxItem.yaml
   status:
     type: string
     description: Status of the credit memo.

--- a/openapi/components/schemas/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemo.yaml
@@ -138,7 +138,9 @@ properties:
           example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         tax:
           description: Credit memo item tax.
-          $ref: ./CreditMemoTaxItem.yaml
+          oneOf:
+            - $ref: ./CreditMemoTaxItem.yaml
+            - type: 'null'
   status:
     type: string
     description: Status of the credit memo.

--- a/openapi/components/schemas/CreditMemoTaxItem.yaml
+++ b/openapi/components/schemas/CreditMemoTaxItem.yaml
@@ -12,75 +12,89 @@ properties:
     description: Description of the tax.
   rate:
     description: Overall sales tax rate which includes state, county, city and district tax.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
   stateAmount:
     description: Amount of sales tax to collect for the state.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.94
   countyAmount:
     description: Amount of sales tax to collect for the county.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.04
   cityAmount:
     description: Amount of sales tax to collect for the city.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0
   specialDistrictAmount:
     description: Amount of sales tax to collect for the special district.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.38
   stateRate:
     description: State sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
   countyRate:
     description: County sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
   cityRate:
     description: City sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
   specialDistrictRate:
     description: Special district sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
   jurisdictions:
     description: Jurisdiction names for the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     properties:
       country:
         description: Two-letter ISO country code for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: US
       state:
         description: Postal abbreviated state name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: CA
       county:
         description: County name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: LOS ANGELES
       city:
         description: City name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: LOS ANGELES

--- a/openapi/components/schemas/CreditMemoTaxItem.yaml
+++ b/openapi/components/schemas/CreditMemoTaxItem.yaml
@@ -1,6 +1,4 @@
-type:
-  - 'object'
-  - 'null'
+type: object
 required:
   - amount
   - description

--- a/openapi/components/schemas/CreditMemoTaxItem.yaml
+++ b/openapi/components/schemas/CreditMemoTaxItem.yaml
@@ -1,4 +1,6 @@
-type: object
+type:
+  - 'object'
+  - 'null'
 required:
   - amount
   - description

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -43,16 +43,15 @@ properties:
       If supplied, the token is converted into a payment instrument and set as the `defaultPaymentInstrument` value.
       If both are supplied, the value of this property overrides the `defaultPaymentInstrument` value.
       The token expires after first use.
+# TODO Check if it's valid. Might require a oneOf instead.
   defaultPaymentInstrument:
-    type:
-      - 'object'
-      - 'null'
     description: Default payment instrument information.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
       - $ref: ./AlternativePaymentInstrument.yaml
       - $ref: ./CashInstrument.yaml
       - $ref: ./CheckInstrument.yaml
+      - type: 'null'
   createdTime:
     $ref: CreatedTime.yaml
   updatedTime:
@@ -61,11 +60,9 @@ properties:
     $ref: ./ResourceCustomFields.yaml
   primaryAddress:
     description: Customer's primary address.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   company:
     $ref: Company.yaml
   averageValue:

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -9,22 +9,25 @@ properties:
     maxLength: 50
   email:
     description: Customer's email address.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: email
-    nullable: true
     readOnly: true
     x-sortable: true
     x-basic: true
   firstName:
     description: Customer's first name.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-basic: true
     readOnly: true
   lastName:
     description: Customer's last name.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-sortable: true
     x-basic: true
     readOnly: true
@@ -41,8 +44,9 @@ properties:
       If both are supplied, the value of this property overrides the `defaultPaymentInstrument` value.
       The token expires after first use.
   defaultPaymentInstrument:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Default payment instrument information.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
@@ -57,8 +61,9 @@ properties:
     $ref: ./ResourceCustomFields.yaml
   primaryAddress:
     description: Customer's primary address.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   company:
@@ -77,10 +82,11 @@ properties:
     x-sortable: true
     x-basic: true
     description: Time and date of the customer's last approved payment.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   lifetimeRevenue:
     $ref: ./CustomerLifetimeRevenue.yaml
   invoiceCount:
@@ -121,9 +127,10 @@ properties:
     allOf:
       - $ref: ./OrganizationId.yaml
   taxNumbers:
-    type: array
+    type:
+      - 'array'
+      - 'null'
     description: Tax numbers of the customer.
-    nullable: true
     items:
       $ref: ./TaxNumber.yaml
   _links:

--- a/openapi/components/schemas/CustomerCredential.yaml
+++ b/openapi/components/schemas/CustomerCredential.yaml
@@ -22,9 +22,10 @@ properties:
     $ref: CustomerId.yaml
   expiredTime:
     description: Date and time when the credential expires.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/CustomerTimeline.yaml
+++ b/openapi/components/schemas/CustomerTimeline.yaml
@@ -99,8 +99,9 @@ properties:
       Timeline custom event type.
       Used with `custom-event` type.
       This value must be defined using the [Create customer timeline custom event type](../PostCustomerTimeline) operation.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     minLength: 1
     maxLength: 255
   customData:

--- a/openapi/components/schemas/CustomersDataExport.yaml
+++ b/openapi/components/schemas/CustomersDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/DashboardResponse.yaml
+++ b/openapi/components/schemas/DashboardResponse.yaml
@@ -68,33 +68,38 @@ items:
             type: string
             description: Name of the segment.
           value:
-            type: number
+            type:
+              - 'number'
+              - 'null'
             format: double
-            nullable: true
             description: Segment value for the specified date range.
           previousValue:
-            type: number
+            type:
+              - 'number'
+              - 'null'
             format: double
-            nullable: true
             description: |-
               Segment value for the previous date range.
               This value is relative to the specified date range.
           humanValue:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             description: |-
               Human readable segment value.
               This field is formatted with a currency sign.
           changeRatio:
-            type: number
+            type:
+              - 'number'
+              - 'null'
             format: double
-            nullable: true
             description: |-
               Ratio of the current value for each previous value.
               A null value represents infinity.
           humanChangeRatio:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             description: |-
               Human readable change ratio.
               This field is formatted percentage sign.
@@ -111,6 +116,7 @@ items:
                   type: string
                   description: Entry date-time.
                 value:
-                  type: number
-                  nullable: true
+                  type:
+                    - 'number'
+                    - 'null'
                   description: Entry value.

--- a/openapi/components/schemas/DateCustomField.yaml
+++ b/openapi/components/schemas/DateCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - date
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       required:

--- a/openapi/components/schemas/DateTimeCustomField.yaml
+++ b/openapi/components/schemas/DateTimeCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - datetime
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       required:

--- a/openapi/components/schemas/DepositRequest.yaml
+++ b/openapi/components/schemas/DepositRequest.yaml
@@ -18,10 +18,11 @@ properties:
   customerId:
     $ref: ./CustomerId.yaml
   transactionId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the transaction that is used in the deposit request.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: txn_0YVDTQJ8YWDGQACV2N2N5SPWQ0
   status:
@@ -52,13 +53,14 @@ properties:
       format: double
       minimum: 0.01
   customAmount:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Custom amount restrictions.
       If this value is `null`,  custom amounts are prohibited.
       If `customAmount` is not specified when a deposit request is created, amount restrictions are determined from the chosen strategy.
       For more information, see the [`strategyId` property](https://all-rebilly.redoc.ly/tag/Deposits/#operation/PostDepositRequest#!path=strategyId&t=request).
-    nullable: true
     required:
       - minimum
       - multipleOf
@@ -97,8 +99,9 @@ properties:
     description: |-
       Defines properties the user can complete when they use the hosted deposit form.
       This field accepts [JSON-schema](https://json-schema.org/) drafts 4, 6, and 7.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     example:
       type: object
       properties:
@@ -114,8 +117,9 @@ properties:
     description: |-
       Properties that are available for the user to complete when they use the hosted deposit form.
       Use this object to describe fields that are rendered and completed on the hosted deposit form.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     additionalProperties:
       type: string
     example:

--- a/openapi/components/schemas/DepositStrategy.yaml
+++ b/openapi/components/schemas/DepositStrategy.yaml
@@ -67,13 +67,14 @@ properties:
 
           If the customer has no successful deposits, `baseAmount` is not adjusted.
   customAmount:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Custom amount restrictions.
       If this value is `null`,  custom amounts are prohibited.
       If `customAmount` is not specified when a deposit request is created, amount restrictions are determined from the chosen strategy.
       For more information, see the [`strategyId` property](https://all-rebilly.redoc.ly/tag/Deposits/#operation/PostDepositRequest#!path=strategyId&t=request).
-    nullable: true
     required:
       - minimum
       - multipleOf

--- a/openapi/components/schemas/DigitalWalletToken.yaml
+++ b/openapi/components/schemas/DigitalWalletToken.yaml
@@ -83,11 +83,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/DigitalWalletToken.yaml
+++ b/openapi/components/schemas/DigitalWalletToken.yaml
@@ -40,8 +40,9 @@ properties:
         description: |-
           Bank Identification Number (BIN) of the payment card.
           This value is the same as the first 6 digits of the associated Primary Account Number (PAN).
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         format: bin
         readOnly: true
       last4:
@@ -82,8 +83,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -96,14 +98,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/DigitalWallets.yaml
+++ b/openapi/components/schemas/DigitalWallets.yaml
@@ -19,8 +19,9 @@ properties:
           String of 64, or fewer, UTF-8 characters containing the canonical name for your store,
           which is suitable for display.
           Do not localize this name.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: "Test merchant"
       country:
         $ref: ./DigitalWalletCountry.yaml
@@ -38,13 +39,15 @@ properties:
         default: false
       merchantName:
         description: Merchant name in Google Pay™.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: "Test merchant"
       merchantOrigin:
         description: Merchant origin in Google Pay™. This uses the fully qualified domain name.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: "www.example.com"
       country:
         $ref: ./DigitalWalletCountry.yaml

--- a/openapi/components/schemas/Dispute.yaml
+++ b/openapi/components/schemas/Dispute.yaml
@@ -33,12 +33,14 @@ properties:
     format: double
   acquirerReferenceNumber:
     description: Acquirer reference number for the dispute.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   caseId:
     description: Case ID of the dispute.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   reasonCode:
     description: Code used in the chargeback that describes the reason for the dispute.
     type: string
@@ -209,8 +211,9 @@ properties:
       - 'B'
   reasonDescription:
     description: Description of the reason for the dispute.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
     readOnly: true
   category:
@@ -254,17 +257,20 @@ properties:
     description: |-
       Latest date and time by when a merchant must submit a representment for a dispute.
       If the deadline is missed, the merchant loses the dispute.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   rawResponse:
     description: Raw response from the payment gateway that processed the disputed transaction.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   resolvedTime:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     description: Date and time when the dispute is resolved.
     readOnly: true

--- a/openapi/components/schemas/Edd.yaml
+++ b/openapi/components/schemas/Edd.yaml
@@ -32,9 +32,10 @@ properties:
         $ref: ./EddScore.yaml
   nextUpdateTime:
     description: Date and time in ISO 8601 format when the EDD score is updated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/EmailDeliverySetting.yaml
+++ b/openapi/components/schemas/EmailDeliverySetting.yaml
@@ -30,8 +30,9 @@ properties:
       - pending
       - verified
   credentialId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the SMTP or Email Service Provider (ESP) credential.
     example: b120c2ca-6c2b-4690-9dff-3b0d87852dc7
   provider:

--- a/openapi/components/schemas/EmailMessage.yaml
+++ b/openapi/components/schemas/EmailMessage.yaml
@@ -24,15 +24,17 @@ properties:
     default: draft
   metadata:
     description: Metadata associated with the email message.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     additionalProperties:
       type: string
     example:
       eventType: subscription-canceled
   credentialHash:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the SMTP or Email Service Provider (ESP) credential.
     example: b120c2ca-6c2b-4690-9dff-3b0d87852dc7
   from:
@@ -101,25 +103,29 @@ properties:
           maxLength: 50
           example: att_0YV7J787J0DW0918MQQMDHWA7M
   responseCode:
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     description: Status code returned by a mail service after an attempt to send email.
     readOnly: true
     example: 250
   responseBody:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: Body of response returned by a mail service after an attempt to send email.
     readOnly: true
   initiatedTime:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: Date and time when the email is initiated.
     format: date-time
     readOnly: true
   sentTime:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: Date and time when the email is sent.
     format: date-time
     readOnly: true

--- a/openapi/components/schemas/ExperianCredential.yaml
+++ b/openapi/components/schemas/ExperianCredential.yaml
@@ -35,8 +35,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/ExternalServiceSettings.yaml
+++ b/openapi/components/schemas/ExternalServiceSettings.yaml
@@ -52,14 +52,16 @@ properties:
             description: ID of the journal account where all products are created.
             example: jrn_acc_01H32J1C97KWGRCKF1E1JY0QG8
           taxesAccountId:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             default: null
             description: ID of the journal account where all taxes are created.
             example: jrn_acc_01H32J1KGXSRDH0K8Q7YYA552T
           department:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             default: null
             description: ID of the QuickBooks Online department that invoices are related to.
             example: jrn_acc_01H32J1KGXSRDH0K8Q7YYA552T
@@ -117,8 +119,9 @@ properties:
             description: ID of the journal account where all payments and refund receipts are deposited.
             example: jrn_acc_01H32J1C97KWGRCKF1E1JY0QG8
           department:
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
             default: null
             description: ID of the QuickBooks Online department that payments and refund receipts are related to.
             example: jrn_acc_01H32J1KGXSRDH0K8Q7YYA552T

--- a/openapi/components/schemas/Fee.yaml
+++ b/openapi/components/schemas/Fee.yaml
@@ -34,11 +34,9 @@ properties:
     description: |-
       Fee settlement settings.
       This value overrides the gateway account financial settings of the transaction.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./SettlementSettings.yaml
+      - type: 'null'
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/Fee.yaml
+++ b/openapi/components/schemas/Fee.yaml
@@ -25,16 +25,18 @@ properties:
     minLength: 1
     maxLength: 255
     example: 'type:sale,capture;result:approved'
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   formula:
     $ref: ./FeeFormula.yaml
   settlementSettings:
     description: |-
       Fee settlement settings.
       This value overrides the gateway account financial settings of the transaction.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./SettlementSettings.yaml
   createdTime:

--- a/openapi/components/schemas/File.yaml
+++ b/openapi/components/schemas/File.yaml
@@ -17,8 +17,9 @@ properties:
     type: string
   sourceType:
     description: Source of the file.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     enum:
       - upload
       - camera
@@ -58,8 +59,9 @@ properties:
     readOnly: true
   exifData:
     description: Collection of EXIF tags contained in the image metadata. This field applicable to images only.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     example:
       FileSize: 120

--- a/openapi/components/schemas/FundsMatches.yaml
+++ b/openapi/components/schemas/FundsMatches.yaml
@@ -4,19 +4,22 @@ properties:
     description: |-
       First name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: John
   lastName:
     description: |-
       Last name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: Doe
   documentSubtype:
     description: Interpreted subtype of the uploaded document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     allOf:
       - $ref: ./KycDocumentSubtypes.yaml

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -244,24 +244,28 @@ properties:
     default: '0000'
   dccMarkup:
     description: Dynamic currency conversion markup in basis points.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     minimum: -10000
     maximum: 10000
   dccForceCurrency:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Forces Dynamic Currency Conversion (DCC) to the specified currency on each sale.
       To disable forced DCC, leave this field empty.
   descriptor:
     description: Gateway account descriptor value.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   cityField:
     description: Gateway account city field. This value is also known as a line 2 descriptor.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   excludedDccQuoteCurrencies:
     description: Excluded Dynamic Currency Conversion (DCC) quote currencies.
     type: array
@@ -269,8 +273,9 @@ properties:
       type: string
   monthlyLimit:
     description: Monthly limit on the amount money that the gateway account can process.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
     minimum: 0
   approvalWindowTtl:
@@ -285,8 +290,9 @@ properties:
     default: false
   reconciliationWindowTtl:
     description: Allotted time, in seconds, in which a reconciliation must occur before it is automatically `abandoned`.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     minimum: 300
     maximum: 16777215
   threeDSecure:
@@ -312,19 +318,22 @@ properties:
 
       For more information see,
       [Using filters](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: amount:1..100;bin:411111,444433
   timeout:
     description: Gateway account request timeout, in seconds.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     minimum: 10
     maximum: 120
   token:
     description: Gateway account token.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     example: TwiX3f92k4AiBE27BzTbQ38hHjicBz_w
   sticky:

--- a/openapi/components/schemas/GatewayName.yaml
+++ b/openapi/components/schemas/GatewayName.yaml
@@ -1,6 +1,7 @@
 description: Payment gateway name.
-type: string
-nullable: true
+type:
+  - 'string'
+  - 'null'
 enum:
   - A1Gateway
   - ACI

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -76,8 +76,9 @@ properties:
 
       For more information,
       see [Placeholders](https://www.rebilly.com/docs/automations/email-notifications/#placeholders).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   filter:
     description: |-
       Filter that determines whether to send the webhook.
@@ -87,8 +88,9 @@ properties:
 
       For more information,
       see [Using filters](https://all-rebilly.redoc.ly/#section/Using-filter-with-collections).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   createdTime:
     $ref: CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/IntegerCustomField.yaml
+++ b/openapi/components/schemas/IntegerCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - integer
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       minimum:

--- a/openapi/components/schemas/Invoice.yaml
+++ b/openapi/components/schemas/Invoice.yaml
@@ -62,8 +62,9 @@ properties:
     $ref: ./Taxes.yaml
   organizationTaxIdNumber:
     description: Organization tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     required:
       - type
       - value
@@ -81,8 +82,9 @@ properties:
         example: GB980780684
   customerTaxIdNumber:
     description: Customer tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     required:
       - type
       - value
@@ -108,9 +110,10 @@ properties:
       - $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
     maxLength: 50
   notes:
     description: Notes for the customer that are displayed on the invoice.
@@ -150,8 +153,9 @@ properties:
           $ref: ./DiscountContext.yaml
   autopayScheduledTime:
     description: Date and time when an automatic payment (autopay) is scheduled.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-sortable: true
     format: date-time
   autopayRetryNumber:
@@ -190,15 +194,17 @@ properties:
   abandonedTime:
     description: Date and time when the invoice is abandoned.
     x-sortable: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   voidedTime:
     description: Date and time when the invoice is voided.
     x-sortable: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   paidTime:
@@ -206,8 +212,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Date and time when the invoice is paid.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   dueTime:
@@ -227,8 +234,9 @@ properties:
   updatedTime:
     $ref: ./UpdatedTime.yaml
   paymentFormUrl:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     format: url
     description: |-
@@ -251,8 +259,9 @@ properties:
     description: |-
       Invoice payment retry instruction.
       This object specifies how to proceed if a payment related to the invoice fails.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     properties:
       attempts:
         type: array
@@ -314,14 +323,16 @@ properties:
     readOnly: true
   dueReminderTime:
     description: Date and time when a past due reminder event is triggered.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   dueReminderNumber:
     description: Number of past due reminder events that have been triggered.
-    nullable: true
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   organizationId:
     readOnly: true

--- a/openapi/components/schemas/InvoiceIssue.yaml
+++ b/openapi/components/schemas/InvoiceIssue.yaml
@@ -4,13 +4,15 @@ properties:
     description: |-
       Date and time when the invoice is issued.
       If this field is `null` or omitted, the invoice is issued immediately.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   dueTime:
     description: |-
       Date and time when the invoice is due for payment.
       If this field is `null` or omitted, this value is set to the `issuedTime` value.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true

--- a/openapi/components/schemas/InvoiceItem.yaml
+++ b/openapi/components/schemas/InvoiceItem.yaml
@@ -87,11 +87,9 @@ properties:
   tax:
     description: Invoice item tax.
     readOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./TaxItem.yaml
+      - type: 'null'
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/InvoiceItem.yaml
+++ b/openapi/components/schemas/InvoiceItem.yaml
@@ -33,21 +33,24 @@ properties:
     format: double
     readOnly: true
   productId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the product.
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   planId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the plan.
     maxLength: 50
     readOnly: true
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
   subscriptionId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the order.
     maxLength: 50
     readOnly: true
@@ -59,21 +62,24 @@ properties:
     readOnly: true
   periodStartTime:
     description: Date and time when the billing period starts.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   periodEndTime:
     description: Date and time when the billing period ends.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   periodNumber:
     description: |-
       Billing period number that is associated with the invoice item.
       For example, an invoice item for a service is included in billing period number 3.
       The invoice item is only applied to billing period number 3.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:
@@ -81,8 +87,9 @@ properties:
   tax:
     description: Invoice item tax.
     readOnly: true
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./TaxItem.yaml
   _links:

--- a/openapi/components/schemas/InvoiceItemsDataExport.yaml
+++ b/openapi/components/schemas/InvoiceItemsDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/InvoiceReissue.yaml
+++ b/openapi/components/schemas/InvoiceReissue.yaml
@@ -4,6 +4,7 @@ properties:
     description: |-
       Date and time when the invoice is due for payment.
       If this field is `null` or omitted, this value is set to the current date-time.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true

--- a/openapi/components/schemas/InvoiceTimeShift.yaml
+++ b/openapi/components/schemas/InvoiceTimeShift.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 description: |-
   Use invoice time shift to control the billing time.
 

--- a/openapi/components/schemas/InvoicesDataExport.yaml
+++ b/openapi/components/schemas/InvoicesDataExport.yaml
@@ -65,10 +65,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/JournalAccount.yaml
+++ b/openapi/components/schemas/JournalAccount.yaml
@@ -13,8 +13,9 @@ properties:
     description: Name of the journal account.
     example: Unearned revenue
   description:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   createdTime:
     description: Date and time when the journal record is created.
     allOf:

--- a/openapi/components/schemas/JournalRecord.yaml
+++ b/openapi/components/schemas/JournalRecord.yaml
@@ -42,22 +42,26 @@ properties:
     description: |-
       Amount of revenue estimated to be recognized at the schedule date.
       This value is ignored when updating a journal record with a `type` of `automated`.
-    nullable: true
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
   recognizedAmount:
     description: Amount of revenue recognized at the journal period end.
-    nullable: true
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
   debitAccountId:
     description: ID of the debit journal account.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
   creditAccountId:
     description: ID of the credit journal account.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/KhelocardCard.yaml
+++ b/openapi/components/schemas/KhelocardCard.yaml
@@ -64,11 +64,9 @@ properties:
       - 'null'
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   revision:
     description: |-
       Number of times the payment instrument data has been modified.

--- a/openapi/components/schemas/KhelocardCard.yaml
+++ b/openapi/components/schemas/KhelocardCard.yaml
@@ -59,12 +59,14 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   revision:

--- a/openapi/components/schemas/KhelocardCardToken.yaml
+++ b/openapi/components/schemas/KhelocardCardToken.yaml
@@ -51,11 +51,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/KhelocardCardToken.yaml
+++ b/openapi/components/schemas/KhelocardCardToken.yaml
@@ -51,8 +51,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -65,14 +66,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/KlarnaToken.yaml
+++ b/openapi/components/schemas/KlarnaToken.yaml
@@ -23,8 +23,9 @@ properties:
         type: string
   billingAddress:
     description: Billing address object.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   id:
@@ -38,8 +39,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -52,14 +54,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/KlarnaToken.yaml
+++ b/openapi/components/schemas/KlarnaToken.yaml
@@ -23,11 +23,9 @@ properties:
         type: string
   billingAddress:
     description: Billing address object.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   id:
     description: ID of the token.
     readOnly: true
@@ -39,11 +37,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/KycAddressMatches.yaml
+++ b/openapi/components/schemas/KycAddressMatches.yaml
@@ -5,43 +5,49 @@ properties:
     description: |-
       First name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: John
   lastName:
     description: |-
       Last name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: Doe
   line1:
     description: |-
       Address of the customer's residence.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: 36 Craven St
   city:
     description: |-
       Customer's city of residence.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: London
   region:
     description: |-
       Customer's region of residence.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: London
   postalCode:
     description: |-
       Postal code of the customer's residence.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: WC2N 5NF
   wordCount:
     description: Total number of words in the document.
@@ -55,19 +61,22 @@ properties:
     description: |-
       Date detected on the document.
       Use this field to determine if the document is recent.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date
-    nullable: true
     example: 2021-01-01
   phone:
     description: Phone number of the company or agency that issued the document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: (123) 456-7890
   documentSubtype:
     description: Interpreted subtype of the uploaded document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     allOf:
       - $ref: ./KycDocumentSubtypes.yaml
   isTampered:

--- a/openapi/components/schemas/KycDocumentRejection.yaml
+++ b/openapi/components/schemas/KycDocumentRejection.yaml
@@ -1,6 +1,7 @@
 description: Reason the document is rejected.
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 readOnly: true
 properties:
   type:

--- a/openapi/components/schemas/KycDocumentSubtypes.yaml
+++ b/openapi/components/schemas/KycDocumentSubtypes.yaml
@@ -1,5 +1,6 @@
-type: string
-nullable: true
+type:
+  - 'string'
+  - 'null'
 enum:
   - passport
   - id-card

--- a/openapi/components/schemas/KycIdentityMatches.yaml
+++ b/openapi/components/schemas/KycIdentityMatches.yaml
@@ -24,77 +24,88 @@ properties:
     description: |-
       First name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: John
   lastName:
     description: |-
       Last name of the customer.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: Doe
   dateOfBirth:
     description: |-
       Date of birth detected on the document.
       This value is null if no match is detected.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   expirationDate:
     description: |-
       Expiration date detected on the document.
       This value is null if no expiration date is detected.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   issueDate:
     description: |-
       Issue date detected on the document.
       This value is null if no issue date is detected.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   hasMinimalAge:
     description: |-
       Specifies that the individual is older than the minimal age limit.
       The minimal age is 21+ the for USA and 18+ for all other countries.
       This value is null if `dateOfBirth` is not determined.
-    type: boolean
-    nullable: true
+    type:
+      - 'boolean'
+      - 'null'
     readOnly: true
     example: true
   nationality:
     description: |-
       Nationality detected on a passport or citizenship document.
       This value is null if no nationality is detected.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: US
     maxLength: 3
   issuanceCountry:
     description: Country that issued the document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: CA
     minLength: 2
     maxLength: 2
   issuanceRegion:
     description: Region, state, province, or territory that issued the document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: Ontario
   documentNumber:
     description: |-
       Unique number on the identity document.
       This value may contain alphanumeric characters.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: '1234567890'
   documentSubtype:
     description: Interpreted subtype of the uploaded document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     allOf:
       - $ref: ./KycDocumentSubtypes.yaml
   hasMatchingFaceProof:
@@ -109,7 +120,8 @@ properties:
   # deprecated
   expiryDate:
     description: Use `expirationDate` field instead.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
     deprecated: true

--- a/openapi/components/schemas/KycRequest.yaml
+++ b/openapi/components/schemas/KycRequest.yaml
@@ -75,14 +75,16 @@ properties:
           For example, this may occur when a proof of address document is analyzed but proof of ID is not.
 
       Example: `https://example.com?info=success`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   reason:
     description: Reason for uploading.
     example: spend limit
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: |-
       Tolerance level setting for document matches.

--- a/openapi/components/schemas/KycRequestDocument.yaml
+++ b/openapi/components/schemas/KycRequestDocument.yaml
@@ -8,8 +8,9 @@ properties:
       - $ref: ./KycDocumentTypes.yaml
   subtypes:
     description: Permitted document subtype.
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     items:
       $ref: ./KycDocumentSubtypes.yaml
   maxAttempts:

--- a/openapi/components/schemas/LeadSourceData.yaml
+++ b/openapi/components/schemas/LeadSourceData.yaml
@@ -5,64 +5,75 @@ properties:
     description: |-
       Category of the lead source traffic.
       For example, the medium could be organic search, Google ads, Display ads, and so on.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   source:
     description: Domain, platform, or channel from which the lead source originates.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   campaign:
     description: Campaign name of the lead source.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   term:
     description: Term associated with a lead source.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   content:
     description: |-
       Content contained in the lead source content.
       For example, content could be graphics, video, and so on.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   affiliate:
     description: Individual or entity that is affiliated with the lead source.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   subAffiliate:
     description: |-
       Individual or entity that is associated with a lead source affiliate.
       In other products, this field may also be referred to as sub ID or click ID in some.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   salesAgent:
     description: Name of the sales agent associated with the lead source.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   clickId:
     description: |-
       ID of the lead source click.
       This value is passed in the ad click URL for tracking and campaign attribution.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   path:
     description: URL from which the lead source originates.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   referrer:
     description: Lead source [`referrer` URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: url
     maxLength: 2083
   createdTime:

--- a/openapi/components/schemas/MailgunCredential.yaml
+++ b/openapi/components/schemas/MailgunCredential.yaml
@@ -32,8 +32,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/MonetaryCustomField.yaml
+++ b/openapi/components/schemas/MonetaryCustomField.yaml
@@ -17,11 +17,13 @@ properties:
       - monetary
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       required:

--- a/openapi/components/schemas/NumberCustomField.yaml
+++ b/openapi/components/schemas/NumberCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - number
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       minimum:

--- a/openapi/components/schemas/OAuth2Credential.yaml
+++ b/openapi/components/schemas/OAuth2Credential.yaml
@@ -32,8 +32,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/OneTimeOrder.yaml
+++ b/openapi/components/schemas/OneTimeOrder.yaml
@@ -66,8 +66,9 @@ properties:
   initialInvoiceId:
     description: ID of the initial invoice (`null` for one-time orders).
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   recentInvoiceId:
@@ -75,8 +76,9 @@ properties:
       ID of the most recently issued invoice.
       The invoice might not be `paid` yet.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
@@ -87,40 +89,46 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   voidTime:
     description: Date and time when the order is voided.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   abandonTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Date and time when the pending order is automatically abandoned.
       If this value is not passed during order creation,
       a [pending order TTL](https://all-rebilly.redoc.ly/tag/Organizations/operation/PatchOrganization/#!path=settings/billing/pendingOrderTtl&t=request) setting is used to calculate the value.
     format: date-time
-    nullable: true
   couponIds:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of coupons to redeem on the customer and restrict to this order.
 
@@ -141,9 +149,10 @@ properties:
       description: ID of the coupon.
   poNumber:
     description: Purchase order number displayed on the issued invoices.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   shipping:
     $ref: ./Shipping.yaml
   notes:
@@ -159,8 +168,9 @@ properties:
     type: integer
     readOnly: true
   riskMetadata:
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     example: null
     description: |-
       Risk metadata.

--- a/openapi/components/schemas/OneTimeOrder.yaml
+++ b/openapi/components/schemas/OneTimeOrder.yaml
@@ -89,18 +89,14 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
@@ -168,15 +164,13 @@ properties:
     type: integer
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
     example: null
     description: |-
       Risk metadata.
       If this value is `null`, this field uses risk metadata that is captured when creating the payment token.
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   customFields:
     $ref: ./ResourceCustomFields.yaml
   createdTime:

--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -29,8 +29,9 @@ properties:
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   productOptions:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Name-value pairs that specify the product options.
     additionalProperties:
       type: string
@@ -46,8 +47,9 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Set up information of the plan.
     required:
       - price

--- a/openapi/components/schemas/OrderPreview.yaml
+++ b/openapi/components/schemas/OrderPreview.yaml
@@ -28,15 +28,17 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   couponIds:

--- a/openapi/components/schemas/OrderPreview.yaml
+++ b/openapi/components/schemas/OrderPreview.yaml
@@ -28,19 +28,15 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   couponIds:
     type: array
     writeOnly: true

--- a/openapi/components/schemas/Organization.yaml
+++ b/openapi/components/schemas/Organization.yaml
@@ -28,33 +28,38 @@ properties:
     example: https://example.com
   address:
     description: Street address of the organization.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 60
-    nullable: true
     x-sortable: true
   address2:
     description: Second line of the street address.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 60
-    nullable: true
     x-sortable: true
   city:
     description: City where the organization is located.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 45
-    nullable: true
     x-sortable: true
   region:
     description: Region or state where the organization is located.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 45
-    nullable: true
     x-sortable: true
   country:
     description: Country where the organization is located, in [ISO Alpha-2 code format](https://www.iso.org/obp/ui/#search/code/).
-    type: string
+    type:
+      - 'string'
+      - 'null'
     pattern: '^[A-Z]{2}$'
-    nullable: true
     x-sortable: true
   postalCode:
     description: Postal code of the organization.
@@ -67,8 +72,9 @@ properties:
     $ref: ./ContactEmails.yaml
   taxDescriptor:
     description: Tax label of the organization. This information is displayed on the invoice.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
   invoiceTimeZone:
     description: Specifies the time zone to display on an invoice. UTC is used by default.
@@ -83,31 +89,37 @@ properties:
     pattern: '^[A-Z]{3}$'
     example: USD
   questionnaire:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Organization questionnaire.
     properties:
       role:
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         description: Role of the owner.
       monthlyTransactions:
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         description: Amount of monthly processed transactions.
       products:
-        type: array
-        nullable: true
+        type:
+          - 'array'
+          - 'null'
         description: List of products the organization is interested in.
         items:
           type: string
       integrationType:
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         description: Type of integration the organization would like.
       launchTiming:
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         description: When the organization would like to go live.
   settings:
     type: object
@@ -127,20 +139,23 @@ properties:
               - avalara
               - flat
           rate:
-            type: number
-            nullable: true
+            type:
+              - 'number'
+              - 'null'
             format: float
             description: Rate for flat tax calculation.
       billing:
         description: Global organization settings for billing.
-        type: object
-        nullable: true
+        type:
+          - 'object'
+          - 'null'
         properties:
           pendingOrderTtl:
             description: Length of time, in ISO-8601 durations format, before which a pending order is automatically abandoned.
-            type: string
+            type:
+              - 'string'
+              - 'null'
             example: P7D
-            nullable: true
             default: null
       taxLocations:
         type: array
@@ -155,28 +170,32 @@ properties:
           properties:
             address:
               description: Street address of the tax location.
-              type: string
+              type:
+                - 'string'
+                - 'null'
               maxLength: 60
-              nullable: true
             city:
               description: City of the tax location.
-              type: string
+              type:
+                - 'string'
+                - 'null'
               maxLength: 45
-              nullable: true
             region:
               description: Region or state of the tax location.
-              type: string
+              type:
+                - 'string'
+                - 'null'
               maxLength: 45
-              nullable: true
             country:
               description: Country of the tax location, in [ISO Alpha-2 code format](https://www.iso.org/obp/ui/#search/code/).
               type: string
               pattern: '^[A-Z]{2}$'
             postalCode:
               description: Postal code of the tax location.
-              type: string
+              type:
+                - 'string'
+                - 'null'
               maxLength: 10
-              nullable: true
       notifications:
         description: Organization access-related notification settings.
         type: object
@@ -197,9 +216,10 @@ properties:
               format: email
             default: [ ]
   taxNumbers:
-    type: array
+    type:
+      - 'array'
+      - 'null'
     description: Tax numbers of the organization.
-    nullable: true
     items:
       $ref: ./TaxNumber.yaml
   features:

--- a/openapi/components/schemas/OrganizationExport.yaml
+++ b/openapi/components/schemas/OrganizationExport.yaml
@@ -13,10 +13,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the linked file object.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   status:
@@ -90,8 +91,9 @@ properties:
       Date and time when retention ends.
       After this date, files are removed.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   _links:
     type: array

--- a/openapi/components/schemas/PayPalAccount.yaml
+++ b/openapi/components/schemas/PayPalAccount.yaml
@@ -53,11 +53,9 @@ properties:
       - 'null'
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   revision:
     description: |-
       Number of times the payment instrument data has been modified.

--- a/openapi/components/schemas/PayPalAccount.yaml
+++ b/openapi/components/schemas/PayPalAccount.yaml
@@ -48,12 +48,14 @@ properties:
       All future payments are processed by this gateway account.
 
       For more information, see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   revision:

--- a/openapi/components/schemas/PayPalToken.yaml
+++ b/openapi/components/schemas/PayPalToken.yaml
@@ -23,11 +23,9 @@ properties:
         type: string
   billingAddress:
     description: Billing address object.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   id:
     description: ID of the token.
     readOnly: true
@@ -39,11 +37,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/PayPalToken.yaml
+++ b/openapi/components/schemas/PayPalToken.yaml
@@ -23,8 +23,9 @@ properties:
         type: string
   billingAddress:
     description: Billing address object.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   id:
@@ -38,8 +39,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -52,14 +54,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expires.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/PaymentCard.yaml
+++ b/openapi/components/schemas/PaymentCard.yaml
@@ -136,11 +136,9 @@ properties:
       - Google Pay
       - null
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   revision:
     description: |-
       Number of times the payment instrument data has been modified.

--- a/openapi/components/schemas/PaymentCard.yaml
+++ b/openapi/components/schemas/PaymentCard.yaml
@@ -70,8 +70,9 @@ properties:
       - $ref: ./PaymentCardBrand.yaml
   bankCountry:
     description: Bank country of the payment instrument.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   bankName:
     description: Bank name of the payment instrument.
@@ -100,19 +101,22 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   expirationReminderTime:
     description: Date and time when an expiration reminder event is triggered.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationReminderNumber:
     description: Number of expiration reminder events that have triggered.
-    nullable: true
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   referenceData:
     description: Payment instrument reference data.
@@ -124,15 +128,17 @@ properties:
   digitalWallet:
     readOnly: true
     description: Digital wallet type.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     enum:
       - Apple Pay
       - Google Pay
       - null
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   revision:

--- a/openapi/components/schemas/PaymentCardToken.yaml
+++ b/openapi/components/schemas/PaymentCardToken.yaml
@@ -41,14 +41,16 @@ properties:
         description: |-
           Bank Identification Number (BIN) of the payment card.
           This value is the first 6 digits of the payment card number.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         format: bin
         readOnly: true
       last4:
         description: Last 4 digits of the Primary Account Number (PAN) of the payment card.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         readOnly: true
       brand:
         readOnly: true
@@ -72,8 +74,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -86,14 +89,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/PaymentCardToken.yaml
+++ b/openapi/components/schemas/PaymentCardToken.yaml
@@ -74,11 +74,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/PaymentGatewayMetadata.yaml
+++ b/openapi/components/schemas/PaymentGatewayMetadata.yaml
@@ -41,12 +41,14 @@ properties:
     description: |-
       Short description of the payment gateway.
       This field supports Markdown.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   homepage:
     description: URL of the payment gateway home page.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   externalDocs:
     description: |-
@@ -70,15 +72,17 @@ properties:
           type: string
   publishedPricing:
     description: Pricing description for the payment gateway, if pricing is published.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   setupInstructions:
     description: |-
       Special gateway account set up instructions for merchants.
       For example: After adding this gateway account,
       set the IPN to `//example.com/ipns/{gateway-name}/{organization-id}` by contacting your account rep.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   paymentMethods:
     description: Array of supported payment methods. For example, `payment-card` and `bitcoin`.
     type: array
@@ -189,8 +193,9 @@ properties:
     type: boolean
     default: false
   ipn:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Describes the Instant Payment Notification (IPN) that a payment gateway supports.
       If this value is null, IPN is not supported.

--- a/openapi/components/schemas/PaymentMethodMetadata.yaml
+++ b/openapi/components/schemas/PaymentMethodMetadata.yaml
@@ -17,13 +17,15 @@ properties:
     pattern: '^[\w\. -]+$'
   landscapeLogo:
     description: URL for the payment method logo optimized for landscape orientation.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   portraitLogo:
     description: URL for the payment method logo optimized for portrait orientation.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   summary:
     description: |-

--- a/openapi/components/schemas/PayoutRequest.yaml
+++ b/openapi/components/schemas/PayoutRequest.yaml
@@ -18,8 +18,9 @@ properties:
     allOf:
       - $ref: ./CustomerId.yaml
   paymentInstrumentId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the requested payment instrument to offer for the payout.
     maxLength: 50
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
@@ -40,8 +41,9 @@ properties:
     x-type: Money
   description:
     description: Description of payout request.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   status:
     description: Status of the request.
     type: string

--- a/openapi/components/schemas/PlaidAccountToken.yaml
+++ b/openapi/components/schemas/PlaidAccountToken.yaml
@@ -42,8 +42,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   leadSource:
@@ -56,14 +57,16 @@ properties:
     $ref: ./UpdatedTime.yaml
   usageTime:
     description: Date and time when the token is used.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   expirationTime:
     description: Date and time when the token expired.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/PlaidAccountToken.yaml
+++ b/openapi/components/schemas/PlaidAccountToken.yaml
@@ -42,11 +42,9 @@ properties:
     default: false
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   leadSource:
     allOf:
       - $ref: ./LeadSource.yaml

--- a/openapi/components/schemas/PlaidCredential.yaml
+++ b/openapi/components/schemas/PlaidCredential.yaml
@@ -34,8 +34,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/PlanFormulaFlatRate.yaml
+++ b/openapi/components/schemas/PlanFormulaFlatRate.yaml
@@ -32,8 +32,9 @@ properties:
     description: |-
       Minimum permitted unit quantity.
       If this value is `null`, no limit is in place.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     default: null
     example: 1
     minimum: 1
@@ -42,8 +43,9 @@ properties:
     description: |-
       Maximum permitted unit quantity.
       If this value is `null`, no limit is in place.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     example: 1
     minimum: 1
     maximum: 65535

--- a/openapi/components/schemas/PlanFormulaStairstep.yaml
+++ b/openapi/components/schemas/PlanFormulaStairstep.yaml
@@ -56,8 +56,9 @@ properties:
             This value starts from the end of the previous quantity range.
             If there are no previous quantity ranges,
             this value starts at 1.
-          type: integer
-          nullable: true
+          type:
+            - 'integer'
+            - 'null'
           example: 1
           minimum: 1
           maximum: 65535
@@ -65,8 +66,9 @@ properties:
     description: |-
       Minimum permitted unit quantity.
       If this value is `null`, no limit is in place.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     default: null
     example: 1
     minimum: 1

--- a/openapi/components/schemas/PlanFormulaTiered.yaml
+++ b/openapi/components/schemas/PlanFormulaTiered.yaml
@@ -61,8 +61,9 @@ properties:
             This value starts from the end of the previous quantity range.
             If there are no previous quantity ranges,
             this value starts at 1.
-          type: integer
-          nullable: true
+          type:
+            - 'integer'
+            - 'null'
           example: 1
           minimum: 1
           maximum: 65535
@@ -70,8 +71,9 @@ properties:
     description: |-
       Minimum permitted unit quantity.
       If this value is `null`, no limit is in place.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     default: null
     example: 1
     minimum: 1

--- a/openapi/components/schemas/PlanFormulaVolume.yaml
+++ b/openapi/components/schemas/PlanFormulaVolume.yaml
@@ -57,8 +57,9 @@ properties:
             If there are no previous quantity ranges,
             this value starts at 1.
 
-          type: integer
-          nullable: true
+          type:
+            - 'integer'
+            - 'null'
           example: 1
           minimum: 1
           maximum: 65535
@@ -66,8 +67,9 @@ properties:
     description: |-
       Minimum permitted unit quantity.
       If this value is `null`, no limit is in place.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     default: null
     example: 1
     minimum: 1

--- a/openapi/components/schemas/PostmarkCredential.yaml
+++ b/openapi/components/schemas/PostmarkCredential.yaml
@@ -30,8 +30,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/Product.yaml
+++ b/openapi/components/schemas/Product.yaml
@@ -29,8 +29,9 @@ properties:
     default: unit
   description:
     description: Description of the product.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   requiresShipping:
     description: |-
@@ -52,26 +53,31 @@ properties:
       Tax category of the product.
       For a complete list of supported tax categories, see [TaxJar sales tax API reference](https://developers.taxjar.com/api/reference/#get-list-tax-categories).
       If none of the tax categories from the list are applicable for your product, use the general tax category `00000`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: '00000'
   accountingCode:
     description: Accounting code of the product.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: '4010'
   recognition:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     properties:
       debitAccountId:
         description: ID of the debit journal account.
-        nullable: true
-        type: string
+        type:
+          - 'string'
+          - 'null'
       creditAccountId:
         description: ID of the credit journal account.
-        nullable: true
-        type: string
+        type:
+          - 'string'
+          - 'null'
   customFields:
     $ref: ./ResourceCustomFields.yaml
   createdTime:

--- a/openapi/components/schemas/Profile.yaml
+++ b/openapi/components/schemas/Profile.yaml
@@ -22,13 +22,15 @@ properties:
   businessPhone:
     description: User's business phone number.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   mobilePhone:
     description: User's mobile phone number.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   permissions:
     description: |-
       Permissions that the user has within organizations.
@@ -54,8 +56,9 @@ properties:
     readOnly: true
   loginTime:
     description: Date and time when the user last logged in.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   status:
@@ -76,8 +79,9 @@ properties:
     description: |-
       User preferences, such as: timezone, language, and more.
       This is an object with custom properties.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
   hasPermissionsEmulation:
     type: boolean
     description: Specifies if the current user session has permissions emulation enabled.

--- a/openapi/components/schemas/ProfileMfa.yaml
+++ b/openapi/components/schemas/ProfileMfa.yaml
@@ -11,8 +11,9 @@ properties:
       Type of MFA enrollment.
       Type `duo` cannot be updated or deleted.
       If you need to reset your Duo MFA, [Contact support](https://www.rebilly.com/support/).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     enum:
       - duo
       - guardian
@@ -21,8 +22,9 @@ properties:
     description: |-
       Date and time when MFA verification is most recently passed.
       To disable MFA, no more than 10 minutes must elapse between this value and the request to disable MFA.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   _links:

--- a/openapi/components/schemas/ProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfAddressKycDocument.yaml
@@ -53,9 +53,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
@@ -64,40 +65,46 @@ properties:
     $ref: ./UpdatedTime.yaml
   processedTime:
     description: Date and time when the KYC document is processed.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   customerId:
     $ref: ./CustomerId.yaml
   reviewerId:
     description: ID of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 50
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
     description: First and last name of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   reviewStartTime:
     description: Date and time when the manual review starts.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reviewTime:
     description: Date and time of manual review.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   notes:
     description: Reviewer notes.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   tags:
     description: List of KYC document tags.
     readOnly: true
@@ -106,8 +113,9 @@ properties:
       $ref: ./Tag.yaml
   reason:
     description: Reason for uploading.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: Tolerance level setting for document matches.
     type: integer
@@ -122,8 +130,9 @@ properties:
     type: integer
     readOnly: true
   documentMatches:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       score:
@@ -134,8 +143,9 @@ properties:
       data:
         $ref: ./KycAddressMatches.yaml
   parsedData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       score:
@@ -146,9 +156,10 @@ properties:
       data:
         $ref: ./KycAddressMatches.yaml
   settings:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: Settings used to score the document.
-    nullable: true
     readOnly: true
     allOf:
       - $ref: ./KycSettingsAddress.yaml

--- a/openapi/components/schemas/ProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfAddressKycDocument.yaml
@@ -156,13 +156,11 @@ properties:
       data:
         $ref: ./KycAddressMatches.yaml
   settings:
-    type:
-      - 'object'
-      - 'null'
     description: Settings used to score the document.
     readOnly: true
-    allOf:
+    oneOf:
       - $ref: ./KycSettingsAddress.yaml
+      - type: 'null'
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/ProofOfCreditFileKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfCreditFileKycDocument.yaml
@@ -53,9 +53,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
@@ -64,40 +65,46 @@ properties:
     $ref: ./UpdatedTime.yaml
   processedTime:
     description: Date and time when the KYC document is processed.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   customerId:
     $ref: ./CustomerId.yaml
   reviewerId:
     description: ID of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 50
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
     description: First and last name of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   reviewStartTime:
     description: Date and time when the manual review starts.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reviewTime:
     description: Date and time of manual review.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   notes:
     description: Reviewer notes.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   tags:
     description: List of KYC document tags.
     readOnly: true
@@ -106,8 +113,9 @@ properties:
       $ref: ./Tag.yaml
   reason:
     description: Reason for uploading.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: Tolerance level setting for document matches.
     type: integer
@@ -116,8 +124,9 @@ properties:
     example: 2
   settings:
     description: Settings used to score the document.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
   revision:
     description: |-
       Number of times the KYC document data has been modified.
@@ -127,8 +136,9 @@ properties:
     readOnly: true
   documentMatches:
     description: Proof of credit document matches.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       data:

--- a/openapi/components/schemas/ProofOfFundsKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfFundsKycDocument.yaml
@@ -53,9 +53,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
@@ -64,40 +65,46 @@ properties:
     $ref: ./UpdatedTime.yaml
   processedTime:
     description: Date and time when the KYC document is processed.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   customerId:
     $ref: ./CustomerId.yaml
   reviewerId:
     description: ID of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 50
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
     description: First and last name of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   reviewStartTime:
     description: Date and time when the manual review starts.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reviewTime:
     description: Date and time of manual review.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   notes:
     description: Reviewer notes.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   tags:
     description: List of KYC document tags.
     readOnly: true
@@ -106,8 +113,9 @@ properties:
       $ref: ./Tag.yaml
   reason:
     description: Reason for uploading.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: Tolerance level setting for document matches.
     type: integer
@@ -116,8 +124,9 @@ properties:
     example: 2
   settings:
     description: Settings used to score the document.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
   revision:
     description: |-
       Number of times the KYC document data has been modified.
@@ -126,16 +135,18 @@ properties:
     type: integer
     readOnly: true
   documentMatches:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     description: Proof of funds document matches.
     properties:
       data:
         $ref: ./FundsMatches.yaml
   parsedData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       data:

--- a/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
@@ -53,9 +53,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
@@ -64,40 +65,46 @@ properties:
     $ref: ./UpdatedTime.yaml
   processedTime:
     description: Date and time when the KYC document is processed.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   customerId:
     $ref: ./CustomerId.yaml
   reviewerId:
     description: ID of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 50
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
     description: First and last name of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   reviewStartTime:
     description: Date and time when the manual review starts.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reviewTime:
     description: Date and time of manual review.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   notes:
     description: Reviewer notes.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   tags:
     description: List of KYC document tags.
     readOnly: true
@@ -106,8 +113,9 @@ properties:
       $ref: ./Tag.yaml
   reason:
     description: Reason for uploading.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: Tolerance level setting for document matches.
     type: integer
@@ -122,8 +130,9 @@ properties:
     type: integer
     readOnly: true
   documentMatches:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     description: Proof of identity document matches.
     properties:
@@ -135,8 +144,9 @@ properties:
       data:
         $ref: ./KycIdentityMatches.yaml
   parsedData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     description: Parsed data.
     properties:
@@ -148,9 +158,10 @@ properties:
       data:
         $ref: ./KycIdentityMatches.yaml
   settings:
-    type: object
+    type:
+      - 'object'
+      - 'null'
     description: Settings used to score the document.
-    nullable: true
     readOnly: true
     allOf:
       - $ref: ./KycSettingsIdentity.yaml

--- a/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
@@ -158,13 +158,11 @@ properties:
       data:
         $ref: ./KycIdentityMatches.yaml
   settings:
-    type:
-      - 'object'
-      - 'null'
     description: Settings used to score the document.
     readOnly: true
-    allOf:
+    oneOf:
       - $ref: ./KycSettingsIdentity.yaml
+      - type: 'null'
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/ProofOfPurchaseKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfPurchaseKycDocument.yaml
@@ -53,9 +53,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:
@@ -64,40 +65,46 @@ properties:
     $ref: ./UpdatedTime.yaml
   processedTime:
     description: Date and time when the KYC document is processed.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   customerId:
     $ref: ./CustomerId.yaml
   reviewerId:
     description: ID of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 50
     example: 44433322-2c4y-483z-a0a9-158621f77a21
   reviewerName:
     description: First and last name of the KYC document reviewer.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   reviewStartTime:
     description: Date and time when the manual review starts.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reviewTime:
     description: Date and time of manual review.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   notes:
     description: Reviewer notes.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   tags:
     description: List of KYC document tags.
     readOnly: true
@@ -106,8 +113,9 @@ properties:
       $ref: ./Tag.yaml
   reason:
     description: Reason for uploading.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   matchLevel:
     description: Tolerance level setting for document matches.
     type: integer
@@ -116,8 +124,9 @@ properties:
     example: 2
   settings:
     description: Settings used to score the document.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
   revision:
     description: |-
       Number of times the KYC document data has been modified.
@@ -126,16 +135,18 @@ properties:
     type: integer
     readOnly: true
   documentMatches:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     description: Proof of purchase document matches.
     properties:
       data:
         $ref: ./PurchaseMatches.yaml
   parsedData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     description: Parsed data.
     properties:

--- a/openapi/components/schemas/PurchaseBumpOffer.yaml
+++ b/openapi/components/schemas/PurchaseBumpOffer.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 description: Purchase bump offer.
 required:
   - offerId

--- a/openapi/components/schemas/PurchaseMatches.yaml
+++ b/openapi/components/schemas/PurchaseMatches.yaml
@@ -4,26 +4,30 @@ properties:
     description: |-
       First name of the customer if it is matched.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: John
   lastName:
     description: |-
       Last name of the customer if it is matched.
       This value is null if no match is found.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: Doe
   paymentInstrumentId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       ID of the payment instrument related to the document.
       This value is null if no match is found.
-    nullable: true
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
   documentSubtype:
     description: Interpreted subtype of the uploaded document.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     allOf:
       - $ref: ./KycDocumentSubtypes.yaml

--- a/openapi/components/schemas/Quote.yaml
+++ b/openapi/components/schemas/Quote.yaml
@@ -98,18 +98,14 @@ properties:
               type: object
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   invoicePreview:
     type: object
     description: Preview of the quote invoice.

--- a/openapi/components/schemas/Quote.yaml
+++ b/openapi/components/schemas/Quote.yaml
@@ -42,8 +42,9 @@ properties:
   orderId:
     description: ID of the order.
     readOnly: true
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ
   items:
@@ -97,14 +98,16 @@ properties:
               type: object
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   invoicePreview:
@@ -146,12 +149,13 @@ properties:
             x-type: Money
             format: double
       recurringAmounts:
-        type: object
+        type:
+          - 'object'
+          - 'null'
         description: |-
           Total amounts of the recurring invoice.
           This includes recurring items only.
           If the quote does not have recurring items, the value of this field is `null`.
-        nullable: true
         properties:
           amount:
             description: Amount of the invoice.
@@ -211,45 +215,53 @@ properties:
               maxLength: 255
             unitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             quantity:
               description: Quantity of the invoice item.
               type: integer
             period:
               description: Date interval of the invoice item.
-              type: string
-              nullable: true
+              type:
+                - 'string'
+                - 'null'
             setupUnitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialUnitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialPeriod:
               description: Date interval of the invoice item trial.
-              type: string
-              nullable: true
+              type:
+                - 'string'
+                - 'null'
             taxAmount:
               description: Invoice item tax.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             setupTaxAmount:
               description: Tax amount of the setup that is applied to the invoice.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialTaxAmount:
               description: Tax amount of the trial that is applied to the invoice.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string
@@ -257,32 +269,37 @@ properties:
     description: |-
       Date and time when the quote expires. The default expiration time is one month from the time the quote is issued.
       In a `draft` state, this field may be `null`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   issuedTime:
     description: Date and time when the quote is issued.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   acceptedTime:
     description: Date and time when the quote is accepted.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   rejectedTime:
     description: Date and time when the quote is rejected.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   canceledTime:
     description: Date and time when the quote is canceled.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   redirectUrl:
     description: URL to redirect the customer to when a quote is rejected. The default value is the website URL.
@@ -296,17 +313,19 @@ properties:
         default: false
         description: Specifies whether to show written signature lines.
       organizationPrintedName:
-        type: string
+        type:
+          - 'string'
+          - 'null'
         description: Printed name of the organization.
-        nullable: true
         default: null
   shipping:
     $ref: ./Shipping.yaml
   tax:
     $ref: ./Taxes.yaml
   couponIds:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of coupons to redeem on the customer and apply to the order when the quote is accepted.
 

--- a/openapi/components/schemas/ReadyToPayAchMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayAchMethod.yaml
@@ -9,8 +9,9 @@ properties:
     enum:
       - ach
   feature:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet or a processor.

--- a/openapi/components/schemas/ReadyToPayAchMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayAchMethod.yaml
@@ -9,14 +9,12 @@ properties:
     enum:
       - ach
   feature:
-    type:
-      - 'object'
-      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet or a processor.
       If the method does not have any features, this value is null.
     oneOf:
       - $ref: ./AchPlaidFeature.yaml
+      - type: 'null'
   filters:
     $ref: ./ReadyToPayMethodFilters.yaml

--- a/openapi/components/schemas/ReadyToPayKlarnaMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayKlarnaMethod.yaml
@@ -9,14 +9,12 @@ properties:
     enum:
       - Klarna
   feature:
-    type:
-      - 'object'
-      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet or a processor.
       If the method does not have any features, this value is null.
     oneOf:
       - $ref: ./KlarnaFeature.yaml
+      - type: 'null'
   filters:
     $ref: ./ReadyToPayMethodFilters.yaml

--- a/openapi/components/schemas/ReadyToPayKlarnaMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayKlarnaMethod.yaml
@@ -9,8 +9,9 @@ properties:
     enum:
       - Klarna
   feature:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet or a processor.

--- a/openapi/components/schemas/ReadyToPayPayPalMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayPayPalMethod.yaml
@@ -9,11 +9,9 @@ properties:
     enum:
       - paypal
   feature:
-    type:
-      - 'object'
-      - 'null'
     description: Specific features of PayPal.
     oneOf:
       - $ref: ./PayPalBillingAgreementFeature.yaml
+      - type: 'null'
   filters:
     $ref: ./ReadyToPayMethodFilters.yaml

--- a/openapi/components/schemas/ReadyToPayPayPalMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayPayPalMethod.yaml
@@ -9,8 +9,9 @@ properties:
     enum:
       - paypal
   feature:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Specific features of PayPal.
     oneOf:
       - $ref: ./PayPalBillingAgreementFeature.yaml

--- a/openapi/components/schemas/ReadyToPayPaymentCardMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayPaymentCardMethod.yaml
@@ -9,15 +9,13 @@ properties:
     enum:
       - payment-card
   feature:
-    type:
-      - 'object'
-      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet.
       If the method does not have any features, this value is null.
-    allOf:
+    oneOf:
       - $ref: ./PaymentCardFeature.yaml
+      - type: 'null'
   brands:
     type: array
     description: List of supported brands.

--- a/openapi/components/schemas/ReadyToPayPaymentCardMethod.yaml
+++ b/openapi/components/schemas/ReadyToPayPaymentCardMethod.yaml
@@ -9,8 +9,9 @@ properties:
     enum:
       - payment-card
   feature:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Specific feature of this method.
       For example, a digital wallet.

--- a/openapi/components/schemas/RebillyShipping.yaml
+++ b/openapi/components/schemas/RebillyShipping.yaml
@@ -10,8 +10,9 @@ properties:
       - rebilly
   rateId:
     description: ID of the shipping rate. If unset the cheapest applicable shipping rate is chosen.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: shipping-123-456
   amount:

--- a/openapi/components/schemas/RefundTransaction.yaml
+++ b/openapi/components/schemas/RefundTransaction.yaml
@@ -20,8 +20,9 @@ properties:
 
       Some types of transactions relate to parent transactions.
       For example, a `risk-reserve` relates to a `charge`, and a `risk-reserve-release` relates a to `risk-reserve`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
@@ -37,8 +38,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -48,8 +50,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/ResetPasswordToken.yaml
+++ b/openapi/components/schemas/ResetPasswordToken.yaml
@@ -15,8 +15,9 @@ properties:
     readOnly: true
   expiredTime:
     description: Date and time when the password expires.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/RevenueAuditDataExport.yaml
+++ b/openapi/components/schemas/RevenueAuditDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/RevenueEntry.yaml
+++ b/openapi/components/schemas/RevenueEntry.yaml
@@ -15,14 +15,16 @@ properties:
     example: ii_0YVFDEQS2KCFTBN9HXWJFY55GV
   productId:
     description: ID of the product related to the invoice item.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   planId:
     description: ID of the plan related to the invoice item.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
   accountingCode:
@@ -63,7 +65,8 @@ properties:
     readOnly: true
   recognizedTime:
     description: Date and time when the entry is recognized.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true

--- a/openapi/components/schemas/ReverseTransaction.yaml
+++ b/openapi/components/schemas/ReverseTransaction.yaml
@@ -36,8 +36,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -47,8 +48,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -21,11 +21,9 @@ properties:
     maxLength: 50
     example: pIUt3xbgX3l9g3YDiLbx
   httpHeaders:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./HttpHeaders.yaml
+      - type: 'null'
   browserData:
     type:
       - 'object'

--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -4,8 +4,9 @@ description: Risk metadata used for 3D Secure and risk scoring.
 properties:
   ipAddress:
     description: Customer's IP address.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: ipv4 or ipv6
     example: 93.92.91.90
   fingerprint:
@@ -14,18 +15,21 @@ properties:
       A device fingerprint is a unique token that is used to identify the customer.
       The device fingerprint is generated based on device attributes, such as: hardware,
       software, IP address, language, browser, and more.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: pIUt3xbgX3l9g3YDiLbx
   httpHeaders:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./HttpHeaders.yaml
   browserData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Browser data used for 3D Secure and risk scoring.
     required:
       - colorDepth
@@ -72,8 +76,9 @@ properties:
         maximum: 1410
         example: 300
   extraData:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Third-party data used for risk scoring.
     properties:
       kountFraudSessionId:
@@ -113,31 +118,36 @@ properties:
     readOnly: true
   vpnServiceName:
     description: VPN service name, if available.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   isp:
     description: Internet Service Provider (ISP) name, if available.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
   country:
     description: Country ISO Alpha-2 code of the specified IP address.
     maxLength: 2
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     example: US
   region:
     description: Region of the specified IP address.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     example: NY
   city:
     description: City of the specified IP address.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     example: New York
   latitude:
@@ -147,31 +157,36 @@ properties:
     readOnly: true
   longitude:
     description: Longitude of the specified IP address.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
     readOnly: true
   postalCode:
     description: Postal code of the specified IP address.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 10
     readOnly: true
   timeZone:
     description: Time zone of the specified IP address.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     example: America/New_York
   accuracyRadius:
     description: Accuracy radius of the specified IP address, in kilometers.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   distance:
     description: Distance between the customer's IP address and the billing address geolocation, in kilometers.
-    type: integer
-    nullable: true
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   hasMismatchedBillingAddressCountry:
     description: Specifies if the customer's billing address country and geo-IP address are not the same.

--- a/openapi/components/schemas/RiskReserveReleaseTransaction.yaml
+++ b/openapi/components/schemas/RiskReserveReleaseTransaction.yaml
@@ -36,8 +36,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -47,8 +48,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/RiskReserveTransaction.yaml
+++ b/openapi/components/schemas/RiskReserveTransaction.yaml
@@ -19,8 +19,9 @@ properties:
     properties:
       releaseTime:
         description: Time of risk reserve release.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         format: date-time
         readOnly: true
   parentId:
@@ -45,8 +46,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -56,8 +58,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/RiskScoreBlocklistType.yaml
+++ b/openapi/components/schemas/RiskScoreBlocklistType.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 required:
   - riskScoreThreshold
   - ttl

--- a/openapi/components/schemas/RiskScoreBoolean.yaml
+++ b/openapi/components/schemas/RiskScoreBoolean.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 required:
   - value
 properties:

--- a/openapi/components/schemas/RiskScoreBracket.yaml
+++ b/openapi/components/schemas/RiskScoreBracket.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - 'object'
+  - 'null'
 required:
   - brackets
 properties:

--- a/openapi/components/schemas/Role.yaml
+++ b/openapi/components/schemas/Role.yaml
@@ -13,8 +13,9 @@ properties:
     type: string
     description: Name of the user role.
   description:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: Description of the role.
   acl:
     $ref: ./Acl.yaml

--- a/openapi/components/schemas/RuleActionCreateIntuitQuickbooksRefundReceipt.yaml
+++ b/openapi/components/schemas/RuleActionCreateIntuitQuickbooksRefundReceipt.yaml
@@ -8,8 +8,9 @@ allOf:
         type: string
       department:
         description: ID of the QuickBooks department.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       credentialHash:
         type: string
         description: ID of the OAuth2 credential.

--- a/openapi/components/schemas/RuleActionUpdateIntuitQuickbooksInvoice.yaml
+++ b/openapi/components/schemas/RuleActionUpdateIntuitQuickbooksInvoice.yaml
@@ -10,18 +10,21 @@ allOf:
         description: |-
           ID of the taxes QuickBooks account.
           If supplied taxes are represented as separate line items instead of integrated tax field.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       discountsAccount:
         description: |-
           ID of the discounts QuickBooks account.
           If not set `unearnedRevenueAccount` is used for discounts.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       department:
         description: ID of the QuickBooks department.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       template:
         type: object
         properties:

--- a/openapi/components/schemas/SESCredential.yaml
+++ b/openapi/components/schemas/SESCredential.yaml
@@ -32,8 +32,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/SellFeeTransaction.yaml
+++ b/openapi/components/schemas/SellFeeTransaction.yaml
@@ -26,8 +26,9 @@ properties:
 
       Some types of transactions relate to parent transactions.
       For example, a `risk-reserve` relates to a `charge`, and a `risk-reserve-release` relates a to `risk-reserve`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
@@ -43,8 +44,9 @@ properties:
     x-sortable: true
     x-basic: true
     description: Amount of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
@@ -54,8 +56,9 @@ properties:
     description: |-
       If the settlement currency does not match the transaction currency.
       This field displays the exchange rate of the settlement.
-    type: number
-    nullable: true
+    type:
+      - 'number'
+      - 'null'
     format: double
   createdTime:
     $ref: ./CreatedTime.yaml

--- a/openapi/components/schemas/SendGridCredential.yaml
+++ b/openapi/components/schemas/SendGridCredential.yaml
@@ -30,8 +30,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/ShippingOption.yaml
+++ b/openapi/components/schemas/ShippingOption.yaml
@@ -14,8 +14,9 @@ properties:
     type: string
     description: Name of the shipping rate.
   description:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: Description of the shipping rate.
   price:
     description: |-

--- a/openapi/components/schemas/SmtpCredential.yaml
+++ b/openapi/components/schemas/SmtpCredential.yaml
@@ -30,8 +30,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/StorefrontAlternativeInstrument.yaml
+++ b/openapi/components/schemas/StorefrontAlternativeInstrument.yaml
@@ -40,8 +40,9 @@ properties:
     description: |-
       New customer JSON Web Token (JWT) that is used for further requests.
       This value is null if the customer is already authenticated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/StorefrontBankAccount.yaml
+++ b/openapi/components/schemas/StorefrontBankAccount.yaml
@@ -74,8 +74,9 @@ properties:
     description: |-
       New customer JSON Web Token (JWT) that is used for further requests.
       This value is null if the customer is already authenticated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/StorefrontCheckoutForm.yaml
+++ b/openapi/components/schemas/StorefrontCheckoutForm.yaml
@@ -13,9 +13,10 @@ properties:
     $ref: ./WebsiteId.yaml
   customDomain:
     description: Custom domain for the checkout form.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
-    nullable: true
   plans:
     type: array
     description: |-
@@ -63,9 +64,10 @@ properties:
       Limits the number of purchases that can be made using a specific checkout form.
       If a purchase limit value is set, each purchase decreases this value.
       When the purchases limit value reaches zero, the checkout form becomes inactive.
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     minimum: 0
-    nullable: true
     default: null
   paymentMethods:
     description: |-

--- a/openapi/components/schemas/StorefrontInvoice.yaml
+++ b/openapi/components/schemas/StorefrontInvoice.yaml
@@ -66,9 +66,10 @@ properties:
       - $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   notes:
     description: Notes for the customer that are displayed on the invoice.
     type: string

--- a/openapi/components/schemas/StorefrontKhelocardCard.yaml
+++ b/openapi/components/schemas/StorefrontKhelocardCard.yaml
@@ -50,8 +50,9 @@ properties:
     description: |-
       New customer JSON Web Token (JWT) that is used for further requests.
       This value is null if the customer is already authenticated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/StorefrontOneTimeOrder.yaml
+++ b/openapi/components/schemas/StorefrontOneTimeOrder.yaml
@@ -65,18 +65,14 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true

--- a/openapi/components/schemas/StorefrontOneTimeOrder.yaml
+++ b/openapi/components/schemas/StorefrontOneTimeOrder.yaml
@@ -65,14 +65,16 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   activationTime:
@@ -85,16 +87,18 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   abandonTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Date and time when the pending order is automatically abandoned.
       If this value is not passed during order creation,
       a [pending order TTL](https://all-rebilly.redoc.ly/tag/Organizations/operation/PatchOrganization/#!path=settings/billing/pendingOrderTtl&t=request) setting is used to calculate the value.
     format: date-time
-    nullable: true
   couponIds:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of coupons to redeem on the customer and restrict to this order.
 
@@ -115,9 +119,10 @@ properties:
       description: ID of the coupon.
   poNumber:
     description: Purchase order number displayed on the issued invoices.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   shipping:
     $ref: ./Shipping.yaml
   notes:

--- a/openapi/components/schemas/StorefrontOrderPreview.yaml
+++ b/openapi/components/schemas/StorefrontOrderPreview.yaml
@@ -28,15 +28,17 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   couponIds:

--- a/openapi/components/schemas/StorefrontOrderPreview.yaml
+++ b/openapi/components/schemas/StorefrontOrderPreview.yaml
@@ -28,19 +28,15 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   couponIds:
     type: array
     writeOnly: true

--- a/openapi/components/schemas/StorefrontPayPalAccount.yaml
+++ b/openapi/components/schemas/StorefrontPayPalAccount.yaml
@@ -39,8 +39,9 @@ properties:
     description: |-
       New customer JSON Web Token (JWT) that is used for further requests.
       This value is null if the customer is already authenticated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/StorefrontPaymentCard.yaml
+++ b/openapi/components/schemas/StorefrontPaymentCard.yaml
@@ -91,8 +91,9 @@ properties:
     description: |-
       New customer JSON Web Token (JWT) that is used for further requests.
       This value is null if the customer is already authenticated.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/StorefrontPlan.yaml
+++ b/openapi/components/schemas/StorefrontPlan.yaml
@@ -32,8 +32,9 @@ properties:
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   productOptions:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Name-value pairs that specify the product options.
     additionalProperties:
       type: string
@@ -49,8 +50,9 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Set up information of the plan.
     required:
       - price
@@ -75,8 +77,9 @@ properties:
       Number of times the plan is modified.
       Compare this value with materialized subscription item revision values.
   trial:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Trial configuration setting.
       If you do not want to offer a trial, set this value to `null`.

--- a/openapi/components/schemas/StorefrontProduct.yaml
+++ b/openapi/components/schemas/StorefrontProduct.yaml
@@ -29,8 +29,9 @@ properties:
     default: unit
   description:
     description: Description of the product.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 512
   requiresShipping:
     description: |-

--- a/openapi/components/schemas/StorefrontProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfAddressKycDocument.yaml
@@ -47,9 +47,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/StorefrontProofOfCreditFileKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfCreditFileKycDocument.yaml
@@ -47,9 +47,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/StorefrontProofOfFundsKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfFundsKycDocument.yaml
@@ -47,9 +47,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/StorefrontProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfIdentityKycDocument.yaml
@@ -47,9 +47,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/StorefrontProofOfPurchaseKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfPurchaseKycDocument.yaml
@@ -47,9 +47,10 @@ properties:
     $ref: ./KycDocumentRejection.yaml
   requestId:
     readOnly: true
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the KYC request.
-    type: string
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/StorefrontPurchase.yaml
+++ b/openapi/components/schemas/StorefrontPurchase.yaml
@@ -49,15 +49,17 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   shippingRateId:
@@ -79,14 +81,17 @@ properties:
     items:
       type: string
   password:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Customer account password.
       If this value is set, it is used to create a customer account.
     writeOnly: true
-    nullable: true
   redirectUrl:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       URL to redirect the end-user when an offsite transaction is completed.
       If `website.url` is `https://example.com`,
@@ -105,4 +110,3 @@ properties:
       These placeholders are replaced with the transaction ID and result.
     format: uri
     writeOnly: true
-    nullable: true

--- a/openapi/components/schemas/StorefrontPurchase.yaml
+++ b/openapi/components/schemas/StorefrontPurchase.yaml
@@ -49,19 +49,15 @@ properties:
   billingAddress:
     description: Billing address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   deliveryAddress:
     description: Delivery address details.
     writeOnly: true
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   shippingRateId:
     description: |-
       ID of the shipping rate. If this value is not set,

--- a/openapi/components/schemas/StorefrontQuote.yaml
+++ b/openapi/components/schemas/StorefrontQuote.yaml
@@ -83,18 +83,14 @@ properties:
               type: object
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   invoicePreview:
     type: object
     description: Preview of the quote invoice.

--- a/openapi/components/schemas/StorefrontQuote.yaml
+++ b/openapi/components/schemas/StorefrontQuote.yaml
@@ -42,8 +42,9 @@ properties:
   orderId:
     description: ID of the order.
     readOnly: true
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ
   items:
@@ -82,14 +83,16 @@ properties:
               type: object
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   invoicePreview:
@@ -131,12 +134,13 @@ properties:
             x-type: Money
             format: double
       recurringAmounts:
-        type: object
+        type:
+          - 'object'
+          - 'null'
         description: |-
           Total amounts of the recurring invoice.
           This includes recurring items only.
           If the quote does not have recurring items, the value of this field is `null`.
-        nullable: true
         properties:
           amount:
             description: Amount of the invoice.
@@ -196,45 +200,53 @@ properties:
               maxLength: 255
             unitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             quantity:
               description: Quantity of the invoice item.
               type: integer
             period:
               description: Date interval of the invoice item.
-              type: string
-              nullable: true
+              type:
+                - 'string'
+                - 'null'
             setupUnitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialUnitPrice:
               description: Unit price of the invoice item.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialPeriod:
               description: Date interval of the invoice item trial.
-              type: string
-              nullable: true
+              type:
+                - 'string'
+                - 'null'
             taxAmount:
               description: Invoice item tax.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             setupTaxAmount:
               description: Tax amount of the setup that is applied to the invoice.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
             trialTaxAmount:
               description: Tax amount of the trial that is applied to the invoice.
-              type: number
+              type:
+                - 'number'
+                - 'null'
               format: double
-              nullable: true
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string
@@ -242,32 +254,37 @@ properties:
     description: |-
       Date and time when the quote expires. The default expiration time is one month from the time the quote is issued.
       In a `draft` state, this field may be `null`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
   issuedTime:
     description: Date and time when the quote is issued.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   acceptedTime:
     description: Date and time when the quote is accepted.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   rejectedTime:
     description: Date and time when the quote is rejected.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   canceledTime:
     description: Date and time when the quote is canceled.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     format: date-time
   redirectUrl:
     description: URL to redirect the customer to when a quote is rejected. The default value is the website URL.
@@ -281,9 +298,10 @@ properties:
         default: false
         description: Specifies whether to show written signature lines.
       organizationPrintedName:
-        type: string
+        type:
+          - 'string'
+          - 'null'
         description: Printed name of the organization.
-        nullable: true
         default: null
   shipping:
     $ref: ./Shipping.yaml

--- a/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
+++ b/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
@@ -65,18 +65,14 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
@@ -193,12 +189,10 @@ properties:
           To use multiple plans in one subscription,
           all plans must have the same billing period,
           this property enables the customer to subscribe to different plans.
-        type:
-          - 'object'
-          - 'null'
         example: null
-        allOf:
+        oneOf:
           - $ref: ./InvoiceTimeShift.yaml
+          - type: 'null'
       recurringInterval:
         type: 
           - 'object'
@@ -256,12 +250,10 @@ properties:
       To use multiple plans in one subscription,
       all plans must have the same billing period,
       this property enables the customer to subscribe to different plans.
-    type:
-      - 'object'
-      - 'null'
     example: null
-    allOf:
+    oneOf:
       - $ref: ./InvoiceTimeShift.yaml
+      - type: 'null'
   recurringInterval:
     type: 
       - 'object'

--- a/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
+++ b/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
@@ -65,14 +65,16 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   activationTime:
@@ -85,16 +87,18 @@ properties:
     allOf:
       - $ref: ./ServerTimestamp.yaml
   abandonTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Date and time when the pending order is automatically abandoned.
       If this value is not passed during order creation,
       a [pending order TTL](https://all-rebilly.redoc.ly/tag/Organizations/operation/PatchOrganization/#!path=settings/billing/pendingOrderTtl&t=request) setting is used to calculate the value.
     format: date-time
-    nullable: true
   couponIds:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of coupons to redeem on the customer and restrict to this order.
 
@@ -115,9 +119,10 @@ properties:
       description: ID of the coupon.
   poNumber:
     description: Purchase order number displayed on the issued invoices.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   shipping:
     $ref: ./Shipping.yaml
   notes:
@@ -188,13 +193,16 @@ properties:
           To use multiple plans in one subscription,
           all plans must have the same billing period,
           this property enables the customer to subscribe to different plans.
-        nullable: true
-        type: object
+        type:
+          - 'object'
+          - 'null'
         example: null
         allOf:
           - $ref: ./InvoiceTimeShift.yaml
       recurringInterval:
-        type: object
+        type: 
+          - 'object'
+          - 'null'
         description: |-
           Recurring interval to override plan settings.
           To use plan settings, set this value to `null`.
@@ -202,7 +210,6 @@ properties:
           To use multiple plans in one subscription,
           all plans must have the same same recurring period length,
           this property enables the customer to subscribe to different plans.
-        nullable: true
         example: null
         properties:
           periodAnchorInstruction:
@@ -219,11 +226,12 @@ properties:
           Date and time when the subscription starts.
           If this value is `null`, the current time is used.
           This value cannot be more than one service period in the past.
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         x-sortable: true
         x-basic: true
         example: null
-        type: string
         format: date-time
 
       endTime:
@@ -248,13 +256,16 @@ properties:
       To use multiple plans in one subscription,
       all plans must have the same billing period,
       this property enables the customer to subscribe to different plans.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     example: null
     allOf:
       - $ref: ./InvoiceTimeShift.yaml
   recurringInterval:
-    type: object
+    type: 
+      - 'object'
+      - 'null'
     description: |-
       Recurring interval to override plan settings.
       To use plan settings, set this value to `null`.
@@ -262,7 +273,6 @@ properties:
       To use multiple plans in one subscription,
       all plans must have the same same recurring period length,
       this property enables the customer to subscribe to different plans.
-    nullable: true
     example: null
     properties:
       periodAnchorInstruction:
@@ -279,11 +289,12 @@ properties:
       Date and time when the subscription starts.
       If this value is `null`, the current time is used.
       This value cannot be more than one service period in the past.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-sortable: true
     x-basic: true
     example: null
-    type: string
     format: date-time
   endTime:
     description: Date and time when the subscription ends.
@@ -362,12 +373,13 @@ properties:
         format: double
         example: 49.95
   paymentInstrumentId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       ID of the payment instrument to use for autopay.
       If this value is not provided, or if the payment instrument is inactive,
       the customer's default payment instrument is used.
-    nullable: true
     maxLength: 50
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
   canceledTime:

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -141,8 +141,9 @@ properties:
     description: |-
       URL where the end-user is redirected to when an offsite transaction is completed.
       The default value is the website URL.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   retryNumber:
     type: integer
@@ -154,8 +155,9 @@ properties:
     readOnly: true
     description: Specifies if a transaction is a retry.
   billingDescriptor:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     description: |-
       Billing descriptor that appears on the periodic billing statement.

--- a/openapi/components/schemas/StringCustomField.yaml
+++ b/openapi/components/schemas/StringCustomField.yaml
@@ -16,11 +16,13 @@ properties:
       - string
   description:
     description: Description of the custom field.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   additionalSchema:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Additional schema which adds additional values constrains.
     properties:
       allowedValues:

--- a/openapi/components/schemas/SubscriptionCancellation.yaml
+++ b/openapi/components/schemas/SubscriptionCancellation.yaml
@@ -15,15 +15,17 @@ properties:
     maxLength: 50
     example: ord_01GYJPRKHBD6ZYHH897QCJMBS4
   proratedInvoiceId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the invoice on which the cancellation proration is calculated.
     readOnly: true
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   appliedInvoiceId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the invoice on which the cancellation fees or credits are applied.
     readOnly: true
     maxLength: 50
@@ -82,8 +84,9 @@ properties:
     description: |-
       Date and time when a subscription is cancelled.
       By default, this occurs when `status` is `confirmed`, unless `draft` is specified.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   createdTime:

--- a/openapi/components/schemas/SubscriptionOrder.yaml
+++ b/openapi/components/schemas/SubscriptionOrder.yaml
@@ -119,12 +119,10 @@ properties:
       To use multiple plans in one subscription,
       all plans must have the same billing period,
       this property enables the customer to subscribe to different plans.
-    type:
-      - 'object'
-      - 'null'
     example: null
-    allOf:
+    oneOf:
       - $ref: ./InvoiceTimeShift.yaml
+      - type: 'null'
   recurringInterval:
     type: 
       - 'object'
@@ -304,18 +302,14 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   billingAddress:
     description: Billing address of the order.
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./ContactObject.yaml
+      - type: 'null'
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true

--- a/openapi/components/schemas/SubscriptionOrder.yaml
+++ b/openapi/components/schemas/SubscriptionOrder.yaml
@@ -23,36 +23,42 @@ properties:
     $ref: ./CustomerId.yaml
   renewalReminderTime:
     description: Date and time when the renewal reminder event triggers.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   renewalReminderNumber:
     description: Number of triggered renewal reminder events.
-    nullable: true
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   trialReminderTime:
     description: Date and time when the trial reminder event triggers.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   trialReminderNumber:
     description: Number of triggered trial reminder events.
-    nullable: true
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   abandonReminderTime:
     description: Date and time when the abandon order reminder event triggers.
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   abandonReminderNumber:
     description: Number of abandon order reminder events that are triggered.
-    nullable: true
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
   organizationId:
     readOnly: true
@@ -93,9 +99,10 @@ properties:
         description: |-
           Time and date when the trial ends.
           If a trial is enabled on this subscription, a value must be provided.
-        type: string
+        type:
+          - 'string'
+          - 'null'
         format: date-time
-        nullable: true
   isTrialOnly:
     description: |-
       Specifies if a subscription ends after a trial period.
@@ -112,20 +119,22 @@ properties:
       To use multiple plans in one subscription,
       all plans must have the same billing period,
       this property enables the customer to subscribe to different plans.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     example: null
     allOf:
       - $ref: ./InvoiceTimeShift.yaml
   recurringInterval:
-    type: object
+    type: 
+      - 'object'
+      - 'null'
     description: |-
       Recurring interval to override plan settings.
       To use plan settings, set this value to `null`.
 
       To use multiple plans in one subscription,
       all plans must have the same recurring period length.
-    nullable: true
     example: null
     properties:
       periodAnchorInstruction:
@@ -142,32 +151,36 @@ properties:
       Date and time when the subscription starts.
       If this value is `null`, the current time is used.
       This value cannot be more than one service period in the past.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     x-sortable: true
     x-basic: true
     example: null
-    type: string
     format: date-time
   endTime:
     description: Date and time when the subscription ends.
     x-sortable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   renewalTime:
     description: Date and time when the subscription renews.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     x-sortable: true
     x-basic: true
     format: date-time
-    nullable: true
   rebillNumber:
     description: Current billing period number.
-    type: integer
+    type:
+      - 'integer'
+      - 'null'
     readOnly: true
     x-sortable: true
-    nullable: true
   lineItems:
     description: Subscription line items which queue until the next renewal (or interim) invoice is issued for the subscription.
     readOnly: true
@@ -228,12 +241,13 @@ properties:
         format: double
         example: 49.95
   paymentInstrumentId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       ID of the payment instrument to use for autopay.
       If this value is not provided, or if the payment instrument is inactive,
       the customer's default payment instrument is used.
-    nullable: true
     maxLength: 50
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
   billingStatus:
@@ -267,8 +281,9 @@ properties:
   initialInvoiceId:
     description: ID of the initial invoice.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   recentInvoiceId:
@@ -276,8 +291,9 @@ properties:
       ID of the most recently issued invoice.
       The invoice might not be `paid` yet.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
@@ -288,40 +304,46 @@ properties:
       $ref: ./OrderItem.yaml
   deliveryAddress:
     description: Delivery address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   billingAddress:
     description: Billing address of the order.
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./ContactObject.yaml
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   voidTime:
     description: Date and time when the order is voided.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
   abandonTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: |-
       Date and time when the pending order is automatically abandoned.
       If this value is not passed during order creation,
       a [pending order TTL](https://all-rebilly.redoc.ly/tag/Organizations/operation/PatchOrganization/#!path=settings/billing/pendingOrderTtl&t=request) setting is used to calculate the value.
     format: date-time
-    nullable: true
   couponIds:
-    type: array
-    nullable: true
+    type:
+      - 'array'
+      - 'null'
     description: |-
       List of coupons to redeem on the customer and restrict to this order.
 
@@ -342,9 +364,10 @@ properties:
       description: ID of the coupon.
   poNumber:
     description: Purchase order number displayed on the issued invoices.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   shipping:
     $ref: ./Shipping.yaml
   notes:
@@ -352,9 +375,10 @@ properties:
     type: string
   canceledBy:
     description: Specifies who initiated the cancellation.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    nullable: true
     enum:
       - merchant
       - customer
@@ -362,8 +386,9 @@ properties:
       - null
   cancelCategory:
     description: Category of the cancellation.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     enum:
       - billing-failure
@@ -381,8 +406,9 @@ properties:
       - null
   cancelDescription:
     description: Description of the cancellation reason in free form.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     maxLength: 255
   revision:
@@ -394,8 +420,9 @@ properties:
     type: integer
     readOnly: true
   riskMetadata:
-    nullable: true
-    type: object
+    type:
+      - 'object'
+      - 'null'
     example: null
     description: |-
       Risk metadata.

--- a/openapi/components/schemas/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/SubscriptionOrderPlan.yaml
@@ -30,8 +30,9 @@ properties:
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   productOptions:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Name-value pairs that specify the product options.
     additionalProperties:
       type: string
@@ -47,8 +48,9 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Set up information of the plan.
     required:
       - price
@@ -83,8 +85,9 @@ properties:
     type: object
     properties:
       periodAnchorInstruction:
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
       unit:
         description: Unit of time.
         type: string
@@ -105,8 +108,9 @@ properties:
           Example: For a 1 year contract that is billed monthly,
           where the `periodUnit` is `month` and the `periodDuration` is `1`,
           set this field to `12`.
-        type: integer
-        nullable: true
+        type:
+          - 'integer'
+          - 'null'
         minimum: 1
         maximum: 65535
       billingTiming:
@@ -120,8 +124,9 @@ properties:
           - prepaid
           - postpaid
   trial:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: |-
       Trial configuration setting.
       If you do not want to offer a trial, set this value to `null`.
@@ -155,8 +160,9 @@ properties:
             type: integer
             minimum: 1
   meteredBilling:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     required:
       - strategy
     description: |-
@@ -174,15 +180,17 @@ properties:
           last: Last reported invoice item quantity usage.
       min:
         description: Minimum quantity that is charged at the end of a service period regardless of reported usage.
-        type: number
+        type:
+          - 'number'
+          - 'null'
         format: float
-        nullable: true
         minimum: 0.01
       max:
         description: Maximum quantity that is charged at the end of a service period regardless of reported usage.
-        type: number
+        type:
+          - 'number'
+          - 'null'
         format: float
-        nullable: true
         minimum: 0.01
   invoiceTimeShift:
     $ref: ./InvoiceTimeShift.yaml

--- a/openapi/components/schemas/SubscriptionPause.yaml
+++ b/openapi/components/schemas/SubscriptionPause.yaml
@@ -32,9 +32,10 @@ properties:
       - customer
   description:
     description: Description of the pause reason in free form.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
-    nullable: true
   effectiveTime:
     description: |-
       Date and time when the service period pauses.
@@ -43,9 +44,10 @@ properties:
       If this time is earlier then the current time, the current time is used.
 
       If this field is omitted, this value defaults to the current time.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   endTime:
     description: |-
       Date and time when the pause ends and the subscription resumes billing.
@@ -54,9 +56,10 @@ properties:
       use the current time or an earlier time.
       If `endTime` is earlier then the current time, the current time is used.
       If this field is empty, the subscription is indefinitely paused.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
-    nullable: true
   timeRemaining:
     description: |-
       Amount of time between the pause end time and the renewal time in ISO-8601 durations format.
@@ -71,9 +74,10 @@ properties:
       and the billing anchor is ignored for that period.
 
       For more information, see [Service period anchor, billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
-    type: string
+    type:
+      - 'string'
+      - 'null'
     example: P3600S
-    nullable: true
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/SubscriptionReactivation.yaml
+++ b/openapi/components/schemas/SubscriptionReactivation.yaml
@@ -21,8 +21,9 @@ properties:
     example: ord_cnl_0YVJ5XVQM9CDP8248ZQX0RDMKV
   description:
     description: Description of the reactivation reason in free form.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 255
   effectiveTime:
     description: |-
@@ -50,8 +51,9 @@ properties:
     description: |-
       ID of the payment instrument.
       If this field is omitted, the subscription payment instrument remains unchanged.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21
   createdTime:

--- a/openapi/components/schemas/SubscriptionsDataExport.yaml
+++ b/openapi/components/schemas/SubscriptionsDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/TagUntagRule.yaml
+++ b/openapi/components/schemas/TagUntagRule.yaml
@@ -75,8 +75,9 @@ properties:
 
       For more information,
       see [Using filters](https://api-reference.rebilly.com/#section/Using-filter-with-collections).
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   addTags:
     description: List of tags to add to the customer.
     type: array

--- a/openapi/components/schemas/TaxItem.yaml
+++ b/openapi/components/schemas/TaxItem.yaml
@@ -12,89 +12,103 @@ properties:
     description: Description of the tax.
   rate:
     description: Overall sales tax rate which includes state, county, city and district tax.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     readOnly: true
   stateAmount:
     description: Amount of sales tax to collect for the state.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.94
     readOnly: true
   countyAmount:
     description: Amount of sales tax to collect for the county.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.04
     readOnly: true
   cityAmount:
     description: Amount of sales tax to collect for the city.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0
     readOnly: true
   specialDistrictAmount:
     description: Amount of sales tax to collect for the special district.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     example: 0.38
     readOnly: true
   stateRate:
     description: State sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     readOnly: true
   countyRate:
     description: County sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     readOnly: true
   cityRate:
     description: City sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     readOnly: true
   specialDistrictRate:
     description: Special district sales tax rate for given location.
-    type: number
+    type:
+      - 'number'
+      - 'null'
     format: double
-    nullable: true
     readOnly: true
   jurisdictions:
     description: Jurisdiction names for the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       country:
         description: Two-letter ISO country code for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: US
         readOnly: true
       state:
         description: Postal abbreviated state name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: CA
         readOnly: true
       county:
         description: County name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: LOS ANGELES
         readOnly: true
       city:
         description: City name for the provided location.
-        type: string
-        nullable: true
+        type:
+          - 'string'
+          - 'null'
         example: LOS ANGELES
         readOnly: true

--- a/openapi/components/schemas/TaxJarCredential.yaml
+++ b/openapi/components/schemas/TaxJarCredential.yaml
@@ -32,8 +32,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/TaxNumber.yaml
+++ b/openapi/components/schemas/TaxNumber.yaml
@@ -19,8 +19,9 @@ properties:
     description: Determines if the tax number is selected as default to display on invoices.
     example: true
   isValid:
-    type: boolean
+    type:
+      - 'boolean'
+      - 'null'
     description: Determines if the tax number passed the EU official [VIES validation](https://ec.europa.eu/taxation_customs/vies/#/vat-validation).
-    nullable: true
     example: true
     readOnly: true

--- a/openapi/components/schemas/Transaction.yaml
+++ b/openapi/components/schemas/Transaction.yaml
@@ -497,11 +497,9 @@ properties:
     type: integer
     readOnly: true
   riskMetadata:
-    type:
-      - 'object'
-      - 'null'
-    allOf:
+    oneOf:
       - $ref: ./RiskMetadata.yaml
+      - type: 'null'
   notificationUrl:
     description: |-
       URL where a server-to-server POST notification is sent.

--- a/openapi/components/schemas/Transaction.yaml
+++ b/openapi/components/schemas/Transaction.yaml
@@ -101,8 +101,9 @@ properties:
       - $ref: ./CurrencyCode.yaml
   parentTransactionId:
     description: ID of the parent transaction.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     allOf:
       - $ref: ./TransactionId.yaml
   childTransactions:
@@ -200,8 +201,9 @@ properties:
     description: |-
       URL where the end-user is redirected to when an offsite transaction is completed.
       The default value is the website URL.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   retryNumber:
     type: integer
@@ -213,8 +215,9 @@ properties:
     readOnly: true
     description: Specifies if a transaction is a retry.
   billingDescriptor:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     description: |-
       Billing descriptor that appears on the periodic billing statement.
@@ -255,8 +258,9 @@ properties:
   updatedTime:
     $ref: ./UpdatedTime.yaml
   gatewayAccountId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the gateway account that processed the transaction.
     maxLength: 50
     example: gw_acc_0YVCXMF26DDNKAERE5NW727S34
@@ -264,8 +268,9 @@ properties:
   gatewayTransactionId:
     description: ID of the gateway transaction.
     readOnly: true
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: txn_0YVDTQJ8YWDGQACV2N2N5SPWQ0
   gateway:
@@ -279,64 +284,77 @@ properties:
         properties:
           code:
             description: Gateway response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           message:
             description: Gateway response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           type:
             description: Gateway response type.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw, unmapped gateway response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw, unmapped gateway response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
       avsResponse:
         description: Gateway Address Verification System (AVS) response.
         type: object
         properties:
           code:
             description: Response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           message:
             description: Response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
       cvvResponse:
         description: Gateway Card Verification Value (CVV) response.
         type: object
         properties:
           code:
             description: Response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           message:
             description: Response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw response code.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw response message.
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
   acquirerName:
     readOnly: true
     description: |-
@@ -365,18 +383,20 @@ properties:
     readOnly: true
   referenceData:
     description: Transaction reference data.
-    type: object
+    type:
+      - 'object'
+      - 'null'
     additionalProperties:
       type: string
     example:
       gatewayTransactionId: GAT123
     readOnly: true
-    nullable: true
   bin:
     description: Payment card Bank Identification Number (BIN).
     x-label: BIN
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: bin
     readOnly: true
   paymentInstrument:
@@ -395,8 +415,9 @@ properties:
     description: |-
       Detailed Dynamic currency conversion (DCC).
       If DCC is not applied to the transaction, this value is `null`.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       base:
@@ -428,8 +449,9 @@ properties:
     description: |-
       Bump offer information.
       If the transaction does not have an associated bump offer, this value is `null`.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     readOnly: true
     properties:
       order:
@@ -475,8 +497,9 @@ properties:
     type: integer
     readOnly: true
   riskMetadata:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     allOf:
       - $ref: ./RiskMetadata.yaml
   notificationUrl:
@@ -490,8 +513,9 @@ properties:
       when the result is confirmed, respond with a 2xx HTTP status code.
 
       The following placeholders are available to use in this URI: `{id}` and `{result}`.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: uri
   isDisputed:
     description: Specifies if a transaction is disputed.
@@ -501,16 +525,18 @@ properties:
     description: |-
       Date and time when the dispute is created.
       If the transaction is not disputed, this value is `null`.
-    type: string
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
-    nullable: true
     x-sortable: true
   disputeStatus:
     description: Status of the dispute.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
-    type: string
     enum:
       - null
       - response-needed
@@ -544,8 +570,9 @@ properties:
     x-sortable: true
   arn:
     x-label: ARN
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     readOnly: true
     description: Acquirer reference number.
     example: '74836950144358910018150'
@@ -562,18 +589,20 @@ properties:
     allOf:
       - $ref: ./CurrencyCode.yaml
   settlementTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Date and time when the transaction is settled by the banking institution.
     format: date-time
     readOnly: true
-    nullable: true
     x-sortable: true
   discrepancyTime:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: Date and time of the most recent discrepancy on the transaction.
     format: date-time
     readOnly: true
-    nullable: true
     x-sortable: true
   limits:
     $ref: ./TransactionLimitAmount.yaml

--- a/openapi/components/schemas/TransactionLimitAmount.yaml
+++ b/openapi/components/schemas/TransactionLimitAmount.yaml
@@ -1,7 +1,8 @@
-type: object
+type:
+  - 'object'
+  - 'null'
 title: LimitAmount
 description: Transaction amount limit information.
-nullable: true
 properties:
   amount:
     type: number

--- a/openapi/components/schemas/TransactionsDataExport.yaml
+++ b/openapi/components/schemas/TransactionsDataExport.yaml
@@ -64,10 +64,11 @@ properties:
     maxLength: 50
     example: usr_0YVCEENYJ3D7Q9EN6BN16HA0G4
   fileId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the data export file.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: file_0YV7HZ7KDCC5WBV9Q7WRKG1H6N
   recordCount:

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -30,8 +30,9 @@ properties:
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   productOptions:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Name-value pairs that specify the product options.
     additionalProperties:
       type: string
@@ -47,8 +48,9 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     description: Set up information of the plan.
     required:
       - price

--- a/openapi/components/schemas/UpcomingInvoice.yaml
+++ b/openapi/components/schemas/UpcomingInvoice.yaml
@@ -73,8 +73,9 @@ properties:
     $ref: ./Taxes.yaml
   organizationTaxIdNumber:
     description: Organization tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     required:
       - type
       - value
@@ -92,8 +93,9 @@ properties:
         example: GB980780684
   customerTaxIdNumber:
     description: Customer tax ID number that is displayed on the invoice.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
     required:
       - type
       - value
@@ -119,9 +121,10 @@ properties:
       - $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     example: PO123456
-    type: string
   notes:
     description: Notes for the customer that are displayed on the invoice.
     type: string

--- a/openapi/components/schemas/UpcomingInvoiceItem.yaml
+++ b/openapi/components/schemas/UpcomingInvoiceItem.yaml
@@ -25,14 +25,16 @@ properties:
     type: number
     format: double
   productId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the product.
     maxLength: 50
     example: prod_0YV7DES3WPC5J8JD8QTVNZBZNZ
   planId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the plan.
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X

--- a/openapi/components/schemas/Usage.yaml
+++ b/openapi/components/schemas/Usage.yaml
@@ -21,17 +21,19 @@ properties:
     maxLength: 50
     example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
   invoiceId:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     description: ID of the invoice to which usage is applied. This value is populated when the invoice is issued.
     readOnly: true
-    nullable: true
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   invoiceItemId:
     description: ID of the invoice item to which usage is applied. This value is populated when the invoice is issued.
     readOnly: true
-    nullable: true
-    type: string
+    type:
+      - 'string'
+      - 'null'
     maxLength: 50
     example: ii_0YVFDEQS2KCFTBN9HXWJFY55GV
   quantity:

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -23,12 +23,14 @@ properties:
     type: string
   businessPhone:
     description: User's business phone number.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   mobilePhone:
     description: User's mobile phone number.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
   permissions:
     description: |-
       Permissions that the user has within organizations.
@@ -46,8 +48,9 @@ properties:
     $ref: UpdatedTime.yaml
   loginTime:
     description: Date and time when the user last logged in.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   reportingCurrency:
@@ -79,8 +82,9 @@ properties:
     description: |-
       User preferences, such as: timezone, language, and more.
       This is an object with custom properties.
-    type: object
-    nullable: true
+    type:
+      - 'object'
+      - 'null'
   roleIds:
     type: array
     description: |-

--- a/openapi/components/schemas/WebhookCredential.yaml
+++ b/openapi/components/schemas/WebhookCredential.yaml
@@ -27,8 +27,9 @@ properties:
       deactivated: Credential is permanently deactivated and cannot be reactivated.
   deactivationTime:
     description: Date and time when the credential is deactivated.
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     format: date-time
     readOnly: true
   type:

--- a/openapi/components/schemas/Website.yaml
+++ b/openapi/components/schemas/Website.yaml
@@ -38,25 +38,29 @@ properties:
         properties:
           theme:
             description: Theme settings that are used in the deposit form.
-            type: object
-            nullable: true
+            type:
+              - 'object'
+              - 'null'
             properties:
               colorPrimary:
                 description: Primary color for the deposit form in hexadecimal format.
-                type: string
-                nullable: true
+                type:
+                  - 'string'
+                  - 'null'
                 maxLength: 6
                 example: '0044d4'
               colorSecondary:
                 description: Secondary color for the deposit form in hexadecimal format.
-                type: string
-                nullable: true
+                type:
+                  - 'string'
+                  - 'null'
                 maxLength: 6
                 example: 'ffffff'
               buttonTemplate:
                 description: Submit button template. `{{amount}}` can be used as a placeholder for amount and currency.
-                type: string
-                nullable: true
+                type:
+                  - 'string'
+                  - 'null'
                 maxLength: 100
                 example: Pay {{amount}}
       paymentForm:
@@ -65,39 +69,46 @@ properties:
         properties:
           css:
             description: Hosted payment form [CSS options](https://www.rebilly.com/docs/content/concepts-and-features/tutorial/customize-style-rebilly-instruments/#2-use-css-property-to-override-any-styles).
-            type: string
-            nullable: true
+            type:
+              - 'string'
+              - 'null'
           theme:
             description: Hosted payment form [theme options](https://www.rebilly.com/docs/content/concepts-and-features/tutorial/customize-style-rebilly-instruments/#adjust-the-default-style).
-            type: object
-            nullable: true
+            type:
+              - 'object'
+              - 'null'
             additionalProperties:
               type: string
             example:
               colorPrimary: '#504CCA'
           features:
             description: Hosted payment form features.
-            type: object
-            nullable: true
+            type:
+              - 'object'
+              - 'null'
             properties:
               showCoupons:
-                type: array
-                nullable: true
+                type:
+                  - 'array'
+                  - 'null'
                 items:
                   type: string
               fullPageRedirect:
-                type: boolean
+                type:
+                  - 'boolean'
+                  - 'null'
                 description: Specifies whether the hosted payment form uses a full page redirect, or the default iframe modal, for approval URL redirects.
-                nullable: true
                 default: false
               skipRedirectOnPaymentComplete:
-                type: boolean
+                type:
+                  - 'boolean'
+                  - 'null'
                 description: Specifies whether the hosted payment form skips the redirect to the website URL when the payment is completed.
-                nullable: true
                 default: false
   logoId:
-    type: string
-    nullable: true
+    type:
+      - 'string'
+      - 'null'
     description: ID of the linked file object.
     maxLength: 50
     example: 4f6cf35x-2c4y-483z-a0a9-158621f77a21

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: "latest"
   title: Rebilly API
@@ -1271,7 +1271,7 @@ paths:
   '/tags-rules/{id}':
     $ref: paths/tags-rules@{id}.yaml
 
-x-webhooks:
+webhooks:
   application-instance-disabled:
     post:
       $ref: ./webhooks/application-instance-disabled.yaml

--- a/openapi/paths/payout-requests@{id}@payment-instruments.yaml
+++ b/openapi/paths/payout-requests@{id}@payment-instruments.yaml
@@ -31,8 +31,9 @@ get:
                     This field is empty if the requested payment instrument has not been used yet.
                   x-label: Gateway account
                   x-basic: true
-                  type: string
-                  nullable: true
+                  type:
+                    - 'string'
+                    - 'null'
                   allOf:
                     - $ref: ../components/schemas/GatewayName.yaml
                 exposureAmount:

--- a/plugins/decorators.js
+++ b/plugins/decorators.js
@@ -2,6 +2,7 @@ const RemovePhpSamplePrefix = require('./decorators/remove-php-sample-prefix');
 const RemoveTagGroups = require('./decorators/remove-tag-groups');
 const ChangeTitle = require('./decorators/change-title');
 const RemoveUnusedTags = require('./decorators/remove-unused-tags');
+const BackportTo30 = require('./decorators/backport-to-30');
 const id = 'plugin';
 
 
@@ -12,6 +13,7 @@ const decorators = {
     'remove-php-sample-prefix': RemovePhpSamplePrefix,
     'remove-unused-tags': RemoveUnusedTags,
     'change-title': ChangeTitle,
+    'backport-to-30': BackportTo30,
   }
 };
 

--- a/plugins/decorators/backport-to-30.js
+++ b/plugins/decorators/backport-to-30.js
@@ -1,0 +1,53 @@
+module.exports = BackportTo30;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+
+function BackportTo30({ title }) {
+  return {
+    Root: {
+      enter(Root) {
+        Root['openapi'] = '3.0.3';
+      }
+    },
+    Schema: {
+      leave(Schema) {
+        if (Array.isArray(Schema.type) && Schema.type.length === 2 && Schema.type.includes('null')) {
+          Schema.type = Schema.type.filter(t => t !== 'null')[0];
+          Schema.nullable = true;
+        }
+        if (typeof Schema.oneOf !== 'undefined' && Schema.oneOf.length === 2) {
+          const nullIndex = Schema.oneOf.findIndex((subSchema) => {
+            const keys = Object.keys(subSchema);
+            if (keys.length === 1 && keys[0] === 'type') {
+              return subSchema.type === 'null';
+            }
+          });
+          if (nullIndex !== -1) {
+            Schema.oneOf.splice(nullIndex, 1);
+            // Workaround for ReadyToPay features
+            // TODO consider removing this workaround
+            if (typeof Schema.oneOf[0].$ref !== 'string' || !Schema.oneOf[0].$ref.includes('Feature') || Schema.oneOf[0].$ref.includes('PaymentCard')) {
+              Schema.allOf = Schema.oneOf;
+              delete Schema.oneOf;
+            }
+            Schema.type = 'object';
+            Schema.nullable = true;
+          }
+        }
+        if (typeof Schema.anyOf !== 'undefined') {
+          const nullIndex = Schema.anyOf.findIndex((subSchema) => {
+            const keys = Object.keys(subSchema);
+            if (keys.length === 1 && keys[0] === 'type') {
+              return subSchema.type === 'null';
+            }
+          });
+          if (nullIndex !== -1) {
+            Schema.anyOf.splice(nullIndex, 1);
+            Schema.type = 'object';
+            Schema.nullable = true;
+          }
+        }
+      },
+    }
+  }
+};

--- a/plugins/products-bundler/README.md
+++ b/plugins/products-bundler/README.md
@@ -3,7 +3,7 @@
 TODO: remove after spec permalinks are replaced.
 
 File `openapi/openapi.yaml` is a single entrypoint for every bundled API definition.
-It should include all paths, tags and x-webhooks. It is a job of the `products-bundler`
+It should include all paths, tags and webhooks. It is a job of the `products-bundler`
 plugin to bundle specific API definition file for a product.
 
 This plugin uses the `REBILLY_API_PRODUCT` env variable to read a config for the product

--- a/plugins/products-bundler/bundler.js
+++ b/plugins/products-bundler/bundler.js
@@ -49,9 +49,9 @@ const decorators = {
               definitionRoot['servers'] = productMapping['servers'];
             }
             definitionRoot['paths'] = getNewPaths(definitionRoot['paths'], ctx, tagsNamesToInclude, availableMethods, includedXProducts);
-            definitionRoot['x-webhooks'] = getNewPaths(definitionRoot['x-webhooks'], ctx, tagsNamesToInclude, ['post'], includedXProducts);
-            if (Object.keys(definitionRoot['x-webhooks']).length === 0) {
-              delete definitionRoot['x-webhooks'];
+            definitionRoot['webhooks'] = getNewPaths(definitionRoot['webhooks'], ctx, tagsNamesToInclude, ['post'], includedXProducts);
+            if (Object.keys(definitionRoot['webhooks']).length === 0) {
+              delete definitionRoot['webhooks'];
             }
             definitionRoot['components'] = getNewComponents(definitionRoot);
           }
@@ -172,8 +172,8 @@ function getNewComponents(definitionRoot) {
   }
 
   const sectionsToCheck = [definitionRoot['paths'], definitionRoot['info']];
-  if ('x-webhooks' in definitionRoot) {
-    sectionsToCheck.push(definitionRoot['x-webhooks']);
+  if ('webhooks' in definitionRoot) {
+    sectionsToCheck.push(definitionRoot['webhooks']);
   }
   let usedComponents = {};
   sectionsToCheck.forEach((element) => {

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -32,6 +32,16 @@ apis:
       plugin/remove-tag-groups: on
       plugin/change-title:
         title: All APIs
+  all@3.0:
+    root: openapi/openapi.yaml
+    output: catalog/all.yaml
+    metadata:
+      description: All Rebilly APIs.
+    decorators:
+      plugin/remove-tag-groups: on
+      plugin/change-title:
+        title: All APIs
+      plugin/backport-to-30: on
   storefront@latest:
     root: openapi/openapi.yaml
     output: catalog/storefront.yaml


### PR DESCRIPTION
## Summary

A separate bundle for SDK generation is a temporary solution that would be here until PHP SDK generator gets better OAS 3.1 support.

Changes:
- Replaced `nullable` with type arrays
- Replaced `x-webhooks` with `webhooks`
- Added decorator to build OpenAPI 3.0.3 version for SDK generation

<details>
<summary>Replace `nullable` with type arrays</summary>

Search:
```regex
^(?<space> *)(?:nullable: true(?<between1>(?:\n\k<space>[^\n]*)*?)\n\k<space>type: (?<type1>\w+)|type: (?<type2>\w+)(?<between2>(?:\n\k<space>[^\n]*)*?)\n\k<space>nullable: true)
```
Replace:
```regex
$<space>type:\n$<space>  - '$<type1>$<type2>'\n$<space>  - 'null'$<between1>$<between2>
```
VSCode friendly version: `$1type:\n$1  - '$3$4'\n$1  - 'null'$2$5`

</details>

## Links
https://github.com/Rebilly/rebilly/issues/5304

## Checklist

- [x] Writing style
- [x] API design standards
