### PR TITLE
refactor: Use sibling $ref

### DIFF
--- a/openapi/components/requestBodies/CreditTransactionRequest.yaml
+++ b/openapi/components/requestBodies/CreditTransactionRequest.yaml
@@ -31,8 +31,7 @@ content:
             Payment instruction for the purchase.
             If this value is not supplied,
             the customer's default payment instrument is used.
-          allOf:
-            - $ref: ../schemas/PaymentInstruction.yaml
+          $ref: ../schemas/PaymentInstruction.yaml
         billingAddress:
           description: |-
             Billing address.

--- a/openapi/components/requestBodies/PatchCreditMemo.yaml
+++ b/openapi/components/requestBodies/PatchCreditMemo.yaml
@@ -18,8 +18,7 @@ properties:
           properties:
             transactionId:
               description: ID of the transaction to which the credit memo is allocated.
-              allOf:
-                - $ref: ../schemas/TransactionId.yaml
+              $ref: ../schemas/TransactionId.yaml
             amount:
               description: |-
                 Amount of credit that is allocated from the credit memo to the transaction.
@@ -30,8 +29,7 @@ properties:
               format: double
             currency:
               readOnly: true
-              allOf:
-                - $ref: ../schemas/CurrencyCode.yaml
+              $ref: ../schemas/CurrencyCode.yaml
             createdTime:
               $ref: ../schemas/CreatedTime.yaml
             updatedTime:
@@ -64,12 +62,10 @@ properties:
               format: double
             currency:
               readOnly: true
-              allOf:
-                - $ref: ../schemas/CurrencyCode.yaml
+              $ref: ../schemas/CurrencyCode.yaml
             createdTime:
               description: Date and time at which a credit memo is allocated.
-              allOf:
-                - $ref: ../schemas/ServerTimestamp.yaml
+              $ref: ../schemas/ServerTimestamp.yaml
             updatedTime:
               $ref: ../schemas/UpdatedTime.yaml
   items:

--- a/openapi/components/requestBodies/TransactionRequest.yaml
+++ b/openapi/components/requestBodies/TransactionRequest.yaml
@@ -60,8 +60,7 @@ content:
             Payment instruction for the purchase.
             If this value is not supplied,
             the customer's default payment instrument is used.
-          allOf:
-            - $ref: ../schemas/PaymentInstruction.yaml
+          $ref: ../schemas/PaymentInstruction.yaml
         billingAddress:
           description: |-
             Billing address.

--- a/openapi/components/requestBodies/storefront/StorefrontPatchPaymentInstrument.yaml
+++ b/openapi/components/requestBodies/storefront/StorefrontPatchPaymentInstrument.yaml
@@ -11,8 +11,7 @@ content:
             Billing address.
             If this field is supplied,
             it overrides the billing address obtained from the token.
-          allOf:
-            - $ref: ../../schemas/ContactObject.yaml
+          $ref: ../../schemas/ContactObject.yaml
         customFields:
           $ref: ../../schemas/ResourceCustomFields.yaml
 description: Payment instrument.

--- a/openapi/components/schemas/Acl.yaml
+++ b/openapi/components/schemas/Acl.yaml
@@ -8,11 +8,9 @@ items:
   properties:
     scope:
       description: Scope of the API key.
-      allOf:
-        - $ref: ./ApiKeyScope.yaml
+      $ref: ./ApiKeyScope.yaml
     permissions:
       description: |-
         If you are creating a restricted API key, use this field to specify individual permissions.
         Use the wildcard character `*` to provide full access.
-      allOf:
-        - $ref: ./AclPermissions.yaml
+      $ref: ./AclPermissions.yaml

--- a/openapi/components/schemas/AlternativeInstrument.yaml
+++ b/openapi/components/schemas/AlternativeInstrument.yaml
@@ -26,8 +26,7 @@ properties:
             - Khelocard
   billingAddress:
     description: Billing address of the user that is associated with the payment instrument.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   status:
     description: Payment instrument status.
     type: string

--- a/openapi/components/schemas/AlternativePaymentToken.yaml
+++ b/openapi/components/schemas/AlternativePaymentToken.yaml
@@ -21,13 +21,11 @@ properties:
             - Klarna
   billingAddress:
     description: Billing address object.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/AmlCheck.yaml
+++ b/openapi/components/schemas/AmlCheck.yaml
@@ -74,8 +74,7 @@ properties:
     properties:
       id:
         description: ID of the customer.
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       primaryAddress:
         type: object
         description: Customer's data at the time of the AML check.

--- a/openapi/components/schemas/AmlChecksDataExport.yaml
+++ b/openapi/components/schemas/AmlChecksDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/ApiKey.yaml
+++ b/openapi/components/schemas/ApiKey.yaml
@@ -23,8 +23,7 @@ properties:
     description: >-
       Specify access control list here if creating a restricted API key.
       Send all matching permission with an empty scope to allow all permissions.
-    allOf:
-      - $ref: ./Acl.yaml
+    $ref: ./Acl.yaml
   allowedIps:
     $ref: ./AllowedIps.yaml
   apiUser:

--- a/openapi/components/schemas/ApiKeyScope.yaml
+++ b/openapi/components/schemas/ApiKeyScope.yaml
@@ -4,8 +4,7 @@ properties:
     description: Array of account IDs.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   productId:
     description: Array of product IDs.
     type: array

--- a/openapi/components/schemas/AuthenticationTokenPasswordMode.yaml
+++ b/openapi/components/schemas/AuthenticationTokenPasswordMode.yaml
@@ -35,8 +35,7 @@ properties:
   credentialId:
     description: ID of the user associated with the authentication token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   expiredTime:
     description: Date and time when the token expired.
     type: string

--- a/openapi/components/schemas/AuthenticationTokenPasswordlessMode.yaml
+++ b/openapi/components/schemas/AuthenticationTokenPasswordlessMode.yaml
@@ -24,8 +24,7 @@ properties:
   credentialId:
     description: ID of the user associated with the authentication token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   expiredTime:
     description: Date and time when the token expired.
     type: string

--- a/openapi/components/schemas/AuthenticationTokenResponse.yaml
+++ b/openapi/components/schemas/AuthenticationTokenResponse.yaml
@@ -20,8 +20,7 @@ properties:
   credentialId:
     description: ID of the user associated with the authentication token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   expiredTime:
     description: Date and time when the token expired.
     type:

--- a/openapi/components/schemas/BBANType.yaml
+++ b/openapi/components/schemas/BBANType.yaml
@@ -52,8 +52,7 @@ allOf:
         type: string
       billingAddress:
         description: Customer's billing address.
-        allOf:
-          - $ref: ./ContactObject.yaml
+        $ref: ./ContactObject.yaml
       customFields:
         $ref: ./ResourceCustomFields.yaml
       riskMetadata:

--- a/openapi/components/schemas/BankAccount.yaml
+++ b/openapi/components/schemas/BankAccount.yaml
@@ -46,8 +46,7 @@ properties:
       - 'null'
   billingAddress:
     description: Customer's billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   fingerprint:
     description: |-
       Unique value which identifies the bank account.

--- a/openapi/components/schemas/BankAccountToken.yaml
+++ b/openapi/components/schemas/BankAccountToken.yaml
@@ -15,13 +15,11 @@ properties:
     $ref: ./BankAccountInstrument.yaml
   billingAddress:
     description: Billing address object.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/BankAccountUpdatePlain.yaml
+++ b/openapi/components/schemas/BankAccountUpdatePlain.yaml
@@ -12,8 +12,7 @@ properties:
       - other
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   stickyGatewayAccountId:
     description: |-
       ID of the sticky gateway account.
@@ -21,8 +20,7 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   useAsBackup:

--- a/openapi/components/schemas/Bind.yaml
+++ b/openapi/components/schemas/Bind.yaml
@@ -3,8 +3,7 @@ description: Rule information.
 properties:
   id:
     description: ID of the rule.
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   name:
     description: Name of the rule.
     type: string

--- a/openapi/components/schemas/BuyFeeTransaction.yaml
+++ b/openapi/components/schemas/BuyFeeTransaction.yaml
@@ -33,11 +33,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -50,8 +48,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/ChargeTransaction.yaml
+++ b/openapi/components/schemas/ChargeTransaction.yaml
@@ -27,11 +27,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -44,8 +42,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemo.yaml
@@ -31,8 +31,7 @@ properties:
           properties:
             transactionId:
               description: ID of the transaction to which the credit memo is allocated.
-              allOf:
-                - $ref: ./TransactionId.yaml
+              $ref: ./TransactionId.yaml
             amount:
               description: |-
                 Amount of credit that is allocated from the credit memo to the transaction.
@@ -43,8 +42,7 @@ properties:
               format: double
             currency:
               readOnly: true
-              allOf:
-                - $ref: ./CurrencyCode.yaml
+              $ref: ./CurrencyCode.yaml
             createdTime:
               $ref: ./CreatedTime.yaml
             updatedTime:
@@ -77,12 +75,10 @@ properties:
               format: double
             currency:
               readOnly: true
-              allOf:
-                - $ref: ./CurrencyCode.yaml
+              $ref: ./CurrencyCode.yaml
             createdTime:
               description: Date and time at which a credit memo is allocated.
-              allOf:
-                - $ref: ./ServerTimestamp.yaml
+              $ref: ./ServerTimestamp.yaml
             updatedTime:
               $ref: ./UpdatedTime.yaml
   items:

--- a/openapi/components/schemas/CreditMemoTimeline.yaml
+++ b/openapi/components/schemas/CreditMemoTimeline.yaml
@@ -31,7 +31,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/CustomerAverageValue.yaml
+++ b/openapi/components/schemas/CustomerAverageValue.yaml
@@ -4,8 +4,7 @@ description: Average customer value.
 properties:
   currency:
     description: Merchant's reporting currency.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     x-type: Money
     x-label: Average Value

--- a/openapi/components/schemas/CustomerLifetimeRevenue.yaml
+++ b/openapi/components/schemas/CustomerLifetimeRevenue.yaml
@@ -4,8 +4,7 @@ description: Customer's lifetime revenue.
 properties:
   currency:
     description: Merchant's reporting currency.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     x-type: Money
     x-label: Lifetime Revenue

--- a/openapi/components/schemas/CustomerTimeline.yaml
+++ b/openapi/components/schemas/CustomerTimeline.yaml
@@ -129,7 +129,6 @@ properties:
     $ref: ./TimelineExtraData.yaml
   occurredTime:
     description: Date and time when the timeline message occurred.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/CustomersDataExport.yaml
+++ b/openapi/components/schemas/CustomersDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/DigitalWalletCountry.yaml
+++ b/openapi/components/schemas/DigitalWalletCountry.yaml
@@ -3,5 +3,4 @@ description: |-
   This is often the location for settling the payment.
   Consult with your Payment Service Provider (PSP) to determine the
   appropriate country code.
-allOf:
-  - $ref: ./Country.yaml
+$ref: ./Country.yaml

--- a/openapi/components/schemas/DigitalWalletToken.yaml
+++ b/openapi/components/schemas/DigitalWalletToken.yaml
@@ -31,8 +31,7 @@ properties:
         format: double
       currency:
         description: Authorized for the digital wallet currency.
-        allOf:
-          - $ref: ./CurrencyCode.yaml
+        $ref: ./CurrencyCode.yaml
       descriptor:
         description: Descriptor for a payment.
         type: string
@@ -70,13 +69,11 @@ properties:
   billingAddress:
     readOnly: true
     description: Billing address object.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/DiscountFixed.yaml
+++ b/openapi/components/schemas/DiscountFixed.yaml
@@ -11,8 +11,7 @@ properties:
     format: double
     minimum: 0.01
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   type:
     type: string
     enum: ["fixed"]

--- a/openapi/components/schemas/Dispute.yaml
+++ b/openapi/components/schemas/Dispute.yaml
@@ -22,11 +22,9 @@ properties:
     example: cus_0YV7DDSDD1C8DA64KHH2W33CPF
   transactionId:
     description: ID of the disputed transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Dispute amount.
     type: number

--- a/openapi/components/schemas/EddTimeline.yaml
+++ b/openapi/components/schemas/EddTimeline.yaml
@@ -30,7 +30,6 @@ properties:
   occurredTime:
     description: Date and time when the customer timeline custom event occurs.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/FundsMatches.yaml
+++ b/openapi/components/schemas/FundsMatches.yaml
@@ -21,5 +21,4 @@ properties:
     type:
       - 'string'
       - 'null'
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml

--- a/openapi/components/schemas/GatewayAccountFinancialSettings.yaml
+++ b/openapi/components/schemas/GatewayAccountFinancialSettings.yaml
@@ -27,5 +27,4 @@ properties:
           $ref: ./Bips.yaml
         period:
           description: Instruction for calculating the reserve release time.
-          allOf:
-            - $ref: ./SchedulingMethodDateInterval.yaml
+          $ref: ./SchedulingMethodDateInterval.yaml

--- a/openapi/components/schemas/GatewayAccountLimit.yaml
+++ b/openapi/components/schemas/GatewayAccountLimit.yaml
@@ -6,8 +6,7 @@ properties:
   id:
     description: ID of the gateway account limit.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   status:
     description: Status of the gateway account limit.
     readOnly: true

--- a/openapi/components/schemas/GatewayAccountTimeline.yaml
+++ b/openapi/components/schemas/GatewayAccountTimeline.yaml
@@ -38,7 +38,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -95,7 +95,6 @@ properties:
     $ref: CreatedTime.yaml
   updatedTime:
     x-label: Last update time
-    allOf:
-      - $ref: UpdatedTime.yaml
+    $ref: UpdatedTime.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/GridSegment.yaml
+++ b/openapi/components/schemas/GridSegment.yaml
@@ -18,8 +18,7 @@ properties:
       id:
         description: User ID of the creator.
         type: string
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       name:
         description: First and last name of the creator.
         type: string
@@ -47,8 +46,7 @@ properties:
       This field is used when the `scope` field is set to `shared`.
     items:
       description: ID of the user.
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   users:
     type: array
     uniqueItems: true
@@ -61,8 +59,7 @@ properties:
         id:
           description: ID of the user.
           type: string
-          allOf:
-            - $ref: ./ResourceId.yaml
+          $ref: ./ResourceId.yaml
         name:
           description: First and last name.
           type: string

--- a/openapi/components/schemas/IBANType.yaml
+++ b/openapi/components/schemas/IBANType.yaml
@@ -38,8 +38,7 @@ allOf:
         type: string
       billingAddress:
         description: Customer's billing address.
-        allOf:
-          - $ref: ./ContactObject.yaml
+        $ref: ./ContactObject.yaml
       customFields:
         $ref: ./ResourceCustomFields.yaml
       riskMetadata:

--- a/openapi/components/schemas/Invoice.yaml
+++ b/openapi/components/schemas/Invoice.yaml
@@ -27,8 +27,7 @@ properties:
   currency:
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Amount of the invoice.
     type: number
@@ -102,12 +101,10 @@ properties:
         example: GB980780684
   billingAddress:
     description: Billing address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
     type:
@@ -140,8 +137,7 @@ properties:
           example: cpn_0YVCNKF81GD778N4YNVGDJK558
         redemptionId:
           description: ID of the redemption.
-          allOf:
-            - $ref: ./ResourceId.yaml
+          $ref: ./ResourceId.yaml
         amount:
           description: Total amount discounted by this coupon.
           type: number
@@ -227,8 +223,7 @@ properties:
     x-label: Date Issued
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/InvoiceItemsDataExport.yaml
+++ b/openapi/components/schemas/InvoiceItemsDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/InvoiceTimeline.yaml
+++ b/openapi/components/schemas/InvoiceTimeline.yaml
@@ -57,7 +57,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/InvoiceTransaction.yaml
+++ b/openapi/components/schemas/InvoiceTransaction.yaml
@@ -4,8 +4,7 @@ required:
 properties:
   transactionId:
     description: ID of the transaction to apply to the invoice.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   amount:
     description: |-
       Amount to be applied to the invoice. This value must not exceed the transaction amount.

--- a/openapi/components/schemas/InvoiceTransactionAllocation.yaml
+++ b/openapi/components/schemas/InvoiceTransactionAllocation.yaml
@@ -11,8 +11,7 @@ properties:
     type: number
     format: double
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/InvoicesDataExport.yaml
+++ b/openapi/components/schemas/InvoicesDataExport.yaml
@@ -78,8 +78,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/JournalAccount.yaml
+++ b/openapi/components/schemas/JournalAccount.yaml
@@ -18,8 +18,7 @@ properties:
       - 'null'
   createdTime:
     description: Date and time when the journal record is created.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   updatedTime:
     $ref: ./UpdatedTime.yaml
   _links:

--- a/openapi/components/schemas/JournalEntry.yaml
+++ b/openapi/components/schemas/JournalEntry.yaml
@@ -22,8 +22,7 @@ properties:
         example: 2022-09-30
   currency:
     description: Currency of the journal record revenue.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   description:
     type: string
   createdTime:

--- a/openapi/components/schemas/KhelocardCard.yaml
+++ b/openapi/components/schemas/KhelocardCard.yaml
@@ -36,8 +36,7 @@ properties:
     type: integer
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   status:
     description: Payment instrument status.
     type: string

--- a/openapi/components/schemas/KhelocardCardToken.yaml
+++ b/openapi/components/schemas/KhelocardCardToken.yaml
@@ -38,13 +38,11 @@ properties:
         type: integer
   billingAddress:
     description: Billing address object.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/KlarnaToken.yaml
+++ b/openapi/components/schemas/KlarnaToken.yaml
@@ -29,8 +29,7 @@ properties:
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/KycAddressMatches.yaml
+++ b/openapi/components/schemas/KycAddressMatches.yaml
@@ -77,8 +77,7 @@ properties:
     type:
       - 'string'
       - 'null'
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   isTampered:
     description: Specifies if an address proof document has been tampered with.
     type: boolean

--- a/openapi/components/schemas/KycIdentityMatches.yaml
+++ b/openapi/components/schemas/KycIdentityMatches.yaml
@@ -106,8 +106,7 @@ properties:
     type:
       - 'string'
       - 'null'
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   hasMatchingFaceProof:
     description: Specifies if an identity document has matching face proof.
     type: boolean

--- a/openapi/components/schemas/KycRequestDocument.yaml
+++ b/openapi/components/schemas/KycRequestDocument.yaml
@@ -4,8 +4,7 @@ required:
 properties:
   type:
     description: Type of document to request from the customer.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   subtypes:
     description: Permitted document subtype.
     type:

--- a/openapi/components/schemas/Membership.yaml
+++ b/openapi/components/schemas/Membership.yaml
@@ -11,8 +11,7 @@ properties:
       id:
         description: ID of the organization.
         type: string
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       name:
         description: Name of the organization.
         type: string
@@ -44,8 +43,7 @@ properties:
     description: |-
       Permissions that the user has within the organization.
       Use the wildcard character `*` for full access.
-    allOf:
-      - $ref: ./AclPermissions.yaml
+    $ref: ./AclPermissions.yaml
   isOwner:
     description: Specifies if the user is the owner of the organization.
     type: boolean

--- a/openapi/components/schemas/OneTimeOrder.yaml
+++ b/openapi/components/schemas/OneTimeOrder.yaml
@@ -61,8 +61,7 @@ properties:
   currency:
     description: Currency of the order.
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   initialInvoiceId:
     description: ID of the initial invoice (`null` for one-time orders).
     readOnly: true

--- a/openapi/components/schemas/OrderPreview.yaml
+++ b/openapi/components/schemas/OrderPreview.yaml
@@ -45,8 +45,7 @@ properties:
       type: string
   currency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   lineItems:
     type: array
     description: List of purchase items.

--- a/openapi/components/schemas/OrderTimeline.yaml
+++ b/openapi/components/schemas/OrderTimeline.yaml
@@ -68,7 +68,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/OriginalPlan.yaml
+++ b/openapi/components/schemas/OriginalPlan.yaml
@@ -5,5 +5,4 @@ required:
 properties:
   id:
     description: ID of the plan.
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml

--- a/openapi/components/schemas/PayPalAccount.yaml
+++ b/openapi/components/schemas/PayPalAccount.yaml
@@ -20,8 +20,7 @@ properties:
       - paypal
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   username:
     description: PayPal username.
     type: string

--- a/openapi/components/schemas/PayPalAccountAuthorization.yaml
+++ b/openapi/components/schemas/PayPalAccountAuthorization.yaml
@@ -6,8 +6,7 @@ properties:
   websiteId:
     $ref: ./WebsiteId.yaml
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Amount to authorize.
     type: number

--- a/openapi/components/schemas/PayPalToken.yaml
+++ b/openapi/components/schemas/PayPalToken.yaml
@@ -29,8 +29,7 @@ properties:
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/PaymentCard.yaml
+++ b/openapi/components/schemas/PaymentCard.yaml
@@ -80,8 +80,7 @@ properties:
     readOnly: true
   billingAddress:
     description: Contact's billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   useAsBackup:
     $ref: ./UseAsBackup.yaml
   billingPortalUrl:

--- a/openapi/components/schemas/PaymentCardCreatePlain.yaml
+++ b/openapi/components/schemas/PaymentCardCreatePlain.yaml
@@ -31,8 +31,7 @@ properties:
     writeOnly: true
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   riskMetadata:

--- a/openapi/components/schemas/PaymentCardToken.yaml
+++ b/openapi/components/schemas/PaymentCardToken.yaml
@@ -61,13 +61,11 @@ properties:
       Billing address object.
       This value is required to perform payments.
       For payment-card updates, `billingAddress` can be ignored.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token has been used.
     type: boolean

--- a/openapi/components/schemas/PaymentCardUpdatePlain.yaml
+++ b/openapi/components/schemas/PaymentCardUpdatePlain.yaml
@@ -11,8 +11,7 @@ properties:
     type: integer
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   stickyGatewayAccountId:
     description: |-
       ID of the sticky gateway account.
@@ -20,8 +19,7 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   useAsBackup:

--- a/openapi/components/schemas/PaymentInstrumentUpdateToken.yaml
+++ b/openapi/components/schemas/PaymentInstrumentUpdateToken.yaml
@@ -7,8 +7,7 @@ properties:
     description: |-
       Customer's billing address.
       If this value is supplied it overrides the billing address that is supplied with the token.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   stickyGatewayAccountId:
     description: |-
       ID of the sticky gateway account.
@@ -16,8 +15,7 @@ properties:
 
       For more information,
       see [Gateway routing](https://www.rebilly.com/docs/settings/intelligent-payment-routing/#sticky-gateway-accounts).
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   useAsBackup:

--- a/openapi/components/schemas/PayoutRequest.yaml
+++ b/openapi/components/schemas/PayoutRequest.yaml
@@ -15,8 +15,7 @@ properties:
     $ref: ./WebsiteId.yaml
   customerId:
     description: ID of the customer who is requesting a payout.
-    allOf:
-      - $ref: ./CustomerId.yaml
+    $ref: ./CustomerId.yaml
   paymentInstrumentId:
     type:
       - 'string'
@@ -26,8 +25,7 @@ properties:
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
   currency:
     description: Currency of the payout.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Amount of the payout.
     type: number
@@ -72,8 +70,7 @@ properties:
       properties:
         transactionId:
           description: ID of the transaction to which the payout request is allocated.
-          allOf:
-            - $ref: ./TransactionId.yaml
+          $ref: ./TransactionId.yaml
         transactionResult:
           description: Result of a transaction.
           type: string
@@ -89,8 +86,7 @@ properties:
           description: Name of the payment gateway that processed, or is selected to process, the transaction.
           x-label: Gateway account
           x-basic: true
-          allOf:
-            - $ref: ./GatewayName.yaml
+          $ref: ./GatewayName.yaml
         paymentInstrumentId:
           type: string
           description: ID of the selected payment instrument for the transaction.
@@ -102,8 +98,7 @@ properties:
           format: double
         createdTime:
           description: Date and time when a payout request is allocated.
-          allOf:
-            - $ref: ./ServerTimestamp.yaml
+          $ref: ./ServerTimestamp.yaml
         updatedTime:
           $ref: ./UpdatedTime.yaml
   selectedPaymentInstrumentRedirectUrl:
@@ -115,12 +110,10 @@ properties:
     example: https://example.com/payout-request-success?id={{id}}
   createdTime:
     description: Date and time when the payout request is created.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   updatedTime:
     description: Date and time when the payout request is updated.
-    allOf:
-      - $ref: ./UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/PlaidAccountToken.yaml
+++ b/openapi/components/schemas/PlaidAccountToken.yaml
@@ -29,13 +29,11 @@ properties:
         description: ID of the Plaid account.
   billingAddress:
     description: Billing address object.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   id:
     description: ID of the token.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   isUsed:
     description: Specifies if the token is already used.
     type: boolean

--- a/openapi/components/schemas/PriceBasedShippingRate.yaml
+++ b/openapi/components/schemas/PriceBasedShippingRate.yaml
@@ -24,7 +24,6 @@ properties:
     type: number
     format: double
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/Profile.yaml
+++ b/openapi/components/schemas/Profile.yaml
@@ -3,8 +3,7 @@ properties:
   id:
     description: ID of the user.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   email:
     description: Email address of the user.
     readOnly: true

--- a/openapi/components/schemas/ProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfAddressKycDocument.yaml
@@ -27,12 +27,10 @@ properties:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/ProofOfCreditFileKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfCreditFileKycDocument.yaml
@@ -27,12 +27,10 @@ properties:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/ProofOfFundsKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfFundsKycDocument.yaml
@@ -27,12 +27,10 @@ properties:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfIdentityKycDocument.yaml
@@ -27,12 +27,10 @@ properties:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/ProofOfPurchaseKycDocument.yaml
+++ b/openapi/components/schemas/ProofOfPurchaseKycDocument.yaml
@@ -27,12 +27,10 @@ properties:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/PurchaseBumpOffer.yaml
+++ b/openapi/components/schemas/PurchaseBumpOffer.yaml
@@ -16,8 +16,7 @@ properties:
     example: bonus
   bumpAmount:
     description: Amount of the bump offer.
-    allOf:
-      - $ref: ./MoneyAmount.yaml
+    $ref: ./MoneyAmount.yaml
   bumpAmountInUsd:
     description: Amount of the bump offer in USD.
     readOnly: true

--- a/openapi/components/schemas/PurchaseMatches.yaml
+++ b/openapi/components/schemas/PurchaseMatches.yaml
@@ -29,5 +29,4 @@ properties:
     type:
       - 'string'
       - 'null'
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml

--- a/openapi/components/schemas/Quote.yaml
+++ b/openapi/components/schemas/Quote.yaml
@@ -113,8 +113,7 @@ properties:
     properties:
       currency:
         description: Currency of the invoice.
-        allOf:
-          - $ref: ./CurrencyCode.yaml
+        $ref: ./CurrencyCode.yaml
       initialAmounts:
         type: object
         description: Total amounts of the initial invoice.

--- a/openapi/components/schemas/QuoteTimeline.yaml
+++ b/openapi/components/schemas/QuoteTimeline.yaml
@@ -36,7 +36,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/ReadyToPayAmount.yaml
+++ b/openapi/components/schemas/ReadyToPayAmount.yaml
@@ -17,7 +17,6 @@ properties:
   billingAddress:
     description: Billing address.
     writeOnly: true
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   riskMetadata:
     $ref: ./RiskMetadata.yaml

--- a/openapi/components/schemas/ReadyToPayItems.yaml
+++ b/openapi/components/schemas/ReadyToPayItems.yaml
@@ -27,7 +27,6 @@ properties:
   billingAddress:
     description: Billing address.
     writeOnly: true
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   riskMetadata:
     $ref: ./RiskMetadata.yaml

--- a/openapi/components/schemas/RefundTransaction.yaml
+++ b/openapi/components/schemas/RefundTransaction.yaml
@@ -27,11 +27,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -44,8 +42,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/RevenueAuditDataExport.yaml
+++ b/openapi/components/schemas/RevenueAuditDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/ReverseTransaction.yaml
+++ b/openapi/components/schemas/ReverseTransaction.yaml
@@ -25,11 +25,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -42,8 +40,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/RiskReserveReleaseTransaction.yaml
+++ b/openapi/components/schemas/RiskReserveReleaseTransaction.yaml
@@ -25,11 +25,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -42,8 +40,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/RiskReserveTransaction.yaml
+++ b/openapi/components/schemas/RiskReserveTransaction.yaml
@@ -35,11 +35,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -52,8 +50,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/RiskScoreBlocklist.yaml
+++ b/openapi/components/schemas/RiskScoreBlocklist.yaml
@@ -3,45 +3,35 @@ description: Risk score blocklist configuration.
 properties:
   address:
     description: House number and ZIP code of the customer's address.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   bank-account:
     description: Bank account being charged.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   bin:
     description: Bank Identification Number (BIN) of the payment card being charged.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   country:
     description: Country where the customer is making the purchase, and of the payment card billing address.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   customer-id:
     description: Rebilly `customerId` of the customer making the purchase.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   email:
     description: Email address of the customer making the purchase.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   email-domain:
     description: Email address domain of the customer making the purchase.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   fingerprint:
     description: |-
       Fingerprint of the user's device.
       A device fingerprint is a unique token that is used to identify the user.
       The device fingerprint is generated based on device attributes,
       such as: hardware, software, IP address, language, browser, and more.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   ip-address:
     description: IP address of the customer making the purchase.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml
   payment-card:
     description: Payment card number being charged.
-    allOf:
-      - $ref: ./RiskScoreBlocklistType.yaml
+    $ref: ./RiskScoreBlocklistType.yaml

--- a/openapi/components/schemas/RiskScoreRules.yaml
+++ b/openapi/components/schemas/RiskScoreRules.yaml
@@ -20,65 +20,49 @@ required:
 properties:
   isProxy:
     description: Specifies whether the customer's IP address is related to a proxy.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   isVpn:
     description: Specifies whether the customer's IP address is related to a VPN.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   isTor:
     description: Specifies whether the customer's IP address is related to TOR.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   isHosting:
     description: Specifies whether the customer's IP address is related to hosting.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   hasMismatchedBillingAddressCountry:
     description: Specifies whether the customer's billing address country and geo-IP address are not the same.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   hasMismatchedBankCountry:
     description: Specifies whether the customer's bank country and geo-IP address are not the same.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   hasMismatchedTimeZone:
     description: Specifies whether the customer's browser time zone and the IP address associated time zone are not the same.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   hasMismatchedHolderName:
     description: Specifies whether the customer's billing address name and primary address name are not the same.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   hasFakeName:
     description: Specifies whether the holder name seems fake.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   isHighRiskCountry:
     description: Specifies whether the geo-IP country, or the customer's billing country, is considered a high risk country.
-    allOf:
-      - $ref: ./RiskScoreBoolean.yaml
+    $ref: ./RiskScoreBoolean.yaml
   paymentInstrumentVelocity:
     description: Number of transactions for this payment instrument, based on fingerprint, in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml
   declinedPaymentInstrumentVelocity:
     description: Number of declined transactions for this payment instrument fingerprint in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml
   deviceVelocity:
     description: Number of transactions for this device, based on fingerprint, in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml
   ipVelocity:
     description:  Number of transactions for this IP address in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml
   emailVelocity:
     description: Number of transactions for this email address in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml
   billingAddressVelocity:
     description: Number of transactions for this billing address in the last 24 hours.
-    allOf:
-      - $ref: ./RiskScoreBracket.yaml
+    $ref: ./RiskScoreBracket.yaml

--- a/openapi/components/schemas/RuleSetDraft.yaml
+++ b/openapi/components/schemas/RuleSetDraft.yaml
@@ -38,8 +38,7 @@ properties:
       id:
         description: Author's user ID.
         type: string
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       name:
         description: Author's first and last name.
         type: string

--- a/openapi/components/schemas/RulesEngineTimeline.yaml
+++ b/openapi/components/schemas/RulesEngineTimeline.yaml
@@ -30,7 +30,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/SellFeeTransaction.yaml
+++ b/openapi/components/schemas/SellFeeTransaction.yaml
@@ -33,11 +33,9 @@ properties:
     example: btxn_0YVCNJYRXTDDQ9QF2Z60ZA05WP
   transactionId:
     description: ID of the related transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   settlementCurrency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementAmount:
     x-type: Money
     x-currency-field: settlementCurrency
@@ -50,8 +48,7 @@ properties:
     format: double
   settlementTime:
     description: Date and time of the expected settlement.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   settlementRate:
     description: |-
       If the settlement currency does not match the transaction currency.

--- a/openapi/components/schemas/Session.yaml
+++ b/openapi/components/schemas/Session.yaml
@@ -16,8 +16,7 @@ properties:
       Permissions of the session.
       See the format in example.
       Use wildcard `*` for full access.
-    allOf:
-      - $ref: ./AclPermissions.yaml
+    $ref: ./AclPermissions.yaml
   userId:
     type: string
     description: ID of the user.

--- a/openapi/components/schemas/SettlementSettings.yaml
+++ b/openapi/components/schemas/SettlementSettings.yaml
@@ -8,12 +8,10 @@ required:
 properties:
   settlementCurrency:
     description: Default settlement currency for all transactions.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementPeriod:
     description: Default settlement period for all transactions.
-    allOf:
-      - $ref: SettlementPeriod.yaml
+    $ref: SettlementPeriod.yaml
   advancedSettings:
     description: |-
       Advanced settlement settings.

--- a/openapi/components/schemas/ShippingOption.yaml
+++ b/openapi/components/schemas/ShippingOption.yaml
@@ -25,5 +25,4 @@ properties:
     type: number
     format: double
   currency:
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml

--- a/openapi/components/schemas/Status.yaml
+++ b/openapi/components/schemas/Status.yaml
@@ -10,5 +10,4 @@ properties:
       - ok
   time:
     description: Current date and time.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml

--- a/openapi/components/schemas/StorefrontAccount.yaml
+++ b/openapi/components/schemas/StorefrontAccount.yaml
@@ -3,8 +3,7 @@ properties:
   id:
     description: ID of the account.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   websiteId:
     readOnly: true
     allOf:

--- a/openapi/components/schemas/StorefrontAlternativeInstrument.yaml
+++ b/openapi/components/schemas/StorefrontAlternativeInstrument.yaml
@@ -4,8 +4,7 @@ properties:
   id:
     description: ID of the payment instrument.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   method:
     description: Payment method of the payment instrument.
     allOf:
@@ -19,8 +18,7 @@ properties:
             - Khelocard
   billingAddress:
     description: Billing address of the user that is associated with the payment instrument.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   status:
     description: Payment instrument status.
     type: string

--- a/openapi/components/schemas/StorefrontBankAccount.yaml
+++ b/openapi/components/schemas/StorefrontBankAccount.yaml
@@ -4,8 +4,7 @@ properties:
   id:
     description: ID of the payment instrument.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   method:
     description: Method of payment instrument.
     type: string
@@ -39,8 +38,7 @@ properties:
     type: string
   billingAddress:
     description: Customer's billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   fingerprint:
     description: |-
       Unique value which identifies the bank account.

--- a/openapi/components/schemas/StorefrontBillingPortal.yaml
+++ b/openapi/components/schemas/StorefrontBillingPortal.yaml
@@ -56,8 +56,7 @@ properties:
     properties:
       logoId:
         description: ID of the linked file object.
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       colors:
         description: Various colors used in the billing portal.
         type: object

--- a/openapi/components/schemas/StorefrontCheckoutForm.yaml
+++ b/openapi/components/schemas/StorefrontCheckoutForm.yaml
@@ -83,8 +83,7 @@ properties:
     properties:
       logoId:
         description: ID of the linked file object.
-        allOf:
-          - $ref: ./ResourceId.yaml
+        $ref: ./ResourceId.yaml
       summary:
         description: Summary text.
         type: string

--- a/openapi/components/schemas/StorefrontInvoice.yaml
+++ b/openapi/components/schemas/StorefrontInvoice.yaml
@@ -23,8 +23,7 @@ properties:
   currency:
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Amount of the invoice.
     type: number
@@ -58,12 +57,10 @@ properties:
     $ref: ./Taxes.yaml
   billingAddress:
     description: Billing address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
     type:
@@ -94,8 +91,7 @@ properties:
           example: cpn_0YVCNKF81GD778N4YNVGDJK558
         redemptionId:
           description: ID of the redemption.
-          allOf:
-            - $ref: ./ResourceId.yaml
+          $ref: ./ResourceId.yaml
         amount:
           description: Total amount discounted by this coupon.
           type: number
@@ -147,20 +143,17 @@ properties:
   abandonedTime:
     description: Date and time when the invoice is abandoned.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   voidedTime:
     description: Date and time when the invoice is voided.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   paidTime:
     x-label: Payment Date
     x-sortable: true
     x-basic: true
     description: Date and time when the invoice is paid.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   dueTime:
     description: Date and time when the invoice is due for payment.
     type: string
@@ -171,8 +164,7 @@ properties:
     x-label: Date Issued
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/StorefrontKhelocardCard.yaml
+++ b/openapi/components/schemas/StorefrontKhelocardCard.yaml
@@ -3,8 +3,7 @@ title: Khelocard card
 properties:
   id:
     description: ID of the payment instrument.
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   method:
     description: Method of payment instrument.
     type: string
@@ -30,8 +29,7 @@ properties:
     type: integer
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   status:
     description: Payment instrument status.
     type: string

--- a/openapi/components/schemas/StorefrontOneTimeOrder.yaml
+++ b/openapi/components/schemas/StorefrontOneTimeOrder.yaml
@@ -41,8 +41,7 @@ properties:
   currency:
     description: Currency of the order.
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   initialInvoiceId:
     type: string
     description: ID of the initial invoice.
@@ -76,12 +75,10 @@ properties:
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   voidTime:
     description: Date and time when the order is voided.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   abandonTime:
     type:
       - 'string'

--- a/openapi/components/schemas/StorefrontOrderPreview.yaml
+++ b/openapi/components/schemas/StorefrontOrderPreview.yaml
@@ -45,8 +45,7 @@ properties:
       type: string
   currency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   lineItems:
     type: array
     description: List of purchase items.
@@ -155,5 +154,4 @@ properties:
       ID of the shipping rate.
       If unset the cheapest applicable shipping rate is chosen.
     writeOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml

--- a/openapi/components/schemas/StorefrontPayPalAccount.yaml
+++ b/openapi/components/schemas/StorefrontPayPalAccount.yaml
@@ -4,8 +4,7 @@ properties:
   id:
     description: ID of the payment instrument.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   method:
     description: Method of payment instrument.
     type: string
@@ -13,8 +12,7 @@ properties:
       - paypal
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   username:
     description: PayPal username.
     type: string

--- a/openapi/components/schemas/StorefrontPaymentCard.yaml
+++ b/openapi/components/schemas/StorefrontPaymentCard.yaml
@@ -5,8 +5,7 @@ properties:
   id:
     description: ID of the payment instrument.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   method:
     description: Method of payment instrument.
     type: string
@@ -73,8 +72,7 @@ properties:
     readOnly: true
   billingAddress:
     description: Contact's billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   useAsBackup:
     $ref: ./UseAsBackup.yaml
   billingPortalUrl:

--- a/openapi/components/schemas/StorefrontPayoutRequest.yaml
+++ b/openapi/components/schemas/StorefrontPayoutRequest.yaml
@@ -15,8 +15,7 @@ properties:
     example: inst_0YVB8KPKNXCBR9EDX7JHSED75N
   currency:
     description: Currency of the payout.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   amount:
     description: Amount of the payout.
     type: number
@@ -35,12 +34,10 @@ properties:
       fulfilled: Request is fully paid out when `availableAmount` reaches zero.
   createdTime:
     description: Date and time when the payout request is created.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   updatedTime:
     description: Date and time when the payout request is updated.
-    allOf:
-      - $ref: ./UpdatedTime.yaml
+    $ref: ./UpdatedTime.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/StorefrontProofOfAddressKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfAddressKycDocument.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   fileIds:
     description: |-
       IDs of linked file objects.
@@ -15,18 +14,15 @@ properties:
       `['kyc', 'id-front']`, `['kyc', 'id-back']`, `['kyc', 'face-proof']`.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   documentType:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/StorefrontProofOfCreditFileKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfCreditFileKycDocument.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   fileIds:
     description: |-
       IDs of linked file objects.
@@ -15,18 +14,15 @@ properties:
       `['kyc', 'id-front']`, `['kyc', 'id-back']`, `['kyc', 'face-proof']`.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   documentType:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/StorefrontProofOfFundsKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfFundsKycDocument.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   fileIds:
     description: |-
       IDs of linked file objects.
@@ -15,18 +14,15 @@ properties:
       `['kyc', 'id-front']`, `['kyc', 'id-back']`, `['kyc', 'face-proof']`.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   documentType:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/StorefrontProofOfIdentityKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfIdentityKycDocument.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   fileIds:
     description: |-
       IDs of linked file objects.
@@ -15,18 +14,15 @@ properties:
       `['kyc', 'id-front']`, `['kyc', 'id-back']`, `['kyc', 'face-proof']`.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   documentType:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/StorefrontProofOfPurchaseKycDocument.yaml
+++ b/openapi/components/schemas/StorefrontProofOfPurchaseKycDocument.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   fileIds:
     description: |-
       IDs of linked file objects.
@@ -15,18 +14,15 @@ properties:
       `['kyc', 'id-front']`, `['kyc', 'id-back']`, `['kyc', 'face-proof']`.
     type: array
     items:
-      allOf:
-        - $ref: ./ResourceId.yaml
+      $ref: ./ResourceId.yaml
   documentType:
     description: |-
       Document type submitted for validation.
       Only the `identity-proof` and `address-proof` types are analyzed automatically.
-    allOf:
-      - $ref: ./KycDocumentTypes.yaml
+    $ref: ./KycDocumentTypes.yaml
   documentSubtype:
     description: Document subtype submitted for validation.
-    allOf:
-      - $ref: ./KycDocumentSubtypes.yaml
+    $ref: ./KycDocumentSubtypes.yaml
   status:
     description: Status of the validation.
     type: string

--- a/openapi/components/schemas/StorefrontPurchase.yaml
+++ b/openapi/components/schemas/StorefrontPurchase.yaml
@@ -7,8 +7,7 @@ properties:
   orderId:
     description: ID of the order.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   invoice:
     description: Initial invoice.
     readOnly: true
@@ -63,8 +62,7 @@ properties:
       ID of the shipping rate. If this value is not set,
       the cheapest applicable shipping rate is chosen.
     writeOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   paymentInstruction:
     description: Payment instruction for the purchase.
     writeOnly: true

--- a/openapi/components/schemas/StorefrontQuote.yaml
+++ b/openapi/components/schemas/StorefrontQuote.yaml
@@ -98,8 +98,7 @@ properties:
     properties:
       currency:
         description: Currency of the invoice.
-        allOf:
-          - $ref: ./CurrencyCode.yaml
+        $ref: ./CurrencyCode.yaml
       initialAmounts:
         type: object
         description: Total amounts of the initial invoice.

--- a/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
+++ b/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
@@ -41,8 +41,7 @@ properties:
   currency:
     description: Currency of the order.
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   initialInvoiceId:
     type: string
     description: ID of the initial invoice.
@@ -76,12 +75,10 @@ properties:
   activationTime:
     description: Date and time when the order is activated.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   voidTime:
     description: Date and time when the order is voided.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   abandonTime:
     type:
       - 'string'

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -3,8 +3,7 @@ description: Transaction information.
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   websiteId:
     readOnly: true
     allOf:
@@ -64,8 +63,7 @@ properties:
     readOnly: true
   currency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   purchaseAmount:
     description: |-
       Amount by which the purchase is completed.
@@ -78,8 +76,7 @@ properties:
     readOnly: true
   purchaseCurrency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   requestAmount:
     description: |-
       Amount of the payment request.
@@ -92,12 +89,10 @@ properties:
     readOnly: true
   requestCurrency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   parentTransactionId:
     description: ID of the parent transaction.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   childTransactions:
     description: IDs of child transactions.
     readOnly: true
@@ -135,8 +130,7 @@ properties:
     x-sortable: true
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   redirectUrl:
     description: |-
       URL where the end-user is redirected to when an offsite transaction is completed.
@@ -191,8 +185,7 @@ properties:
     description: Date and time when the transaction is processed.
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/SubscriptionInvoice.yaml
+++ b/openapi/components/schemas/SubscriptionInvoice.yaml
@@ -4,5 +4,4 @@ properties:
     description: >-
       If present, applies a payment to the invoice created.
       If the payment is for the invoice total, it would be marked as paid.
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml

--- a/openapi/components/schemas/SubscriptionOrder.yaml
+++ b/openapi/components/schemas/SubscriptionOrder.yaml
@@ -274,8 +274,7 @@ properties:
   currency:
     description: Currency of the order.
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   initialInvoiceId:
     description: ID of the initial invoice.
     readOnly: true

--- a/openapi/components/schemas/SubscriptionsDataExport.yaml
+++ b/openapi/components/schemas/SubscriptionsDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/Tag.yaml
+++ b/openapi/components/schemas/Tag.yaml
@@ -9,8 +9,7 @@ properties:
   id:
     description: ID of the tag.
     readOnly: true
-    allOf:
-      - $ref: ./ResourceId.yaml
+    $ref: ./ResourceId.yaml
   name:
     description: |-
       Unique name for the tag.

--- a/openapi/components/schemas/TaxTracking.yaml
+++ b/openapi/components/schemas/TaxTracking.yaml
@@ -15,8 +15,7 @@ properties:
   initiatedTime:
     description: Date and time the HTTP request is initiated.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   url:
     type: string
     x-sortable: true

--- a/openapi/components/schemas/Transaction.yaml
+++ b/openapi/components/schemas/Transaction.yaml
@@ -3,8 +3,7 @@ description: Transaction information.
 properties:
   id:
     readOnly: true
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   websiteId:
     readOnly: true
     allOf:
@@ -69,8 +68,7 @@ properties:
     readOnly: true
   currency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   purchaseAmount:
     description: |-
       Amount by which the purchase is completed.
@@ -83,8 +81,7 @@ properties:
     readOnly: true
   purchaseCurrency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   requestAmount:
     description: |-
       Amount of the payment request.
@@ -97,15 +94,13 @@ properties:
     readOnly: true
   requestCurrency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   parentTransactionId:
     description: ID of the parent transaction.
     type:
       - 'string'
       - 'null'
-    allOf:
-      - $ref: ./TransactionId.yaml
+    $ref: ./TransactionId.yaml
   childTransactions:
     description: IDs of child transactions.
     readOnly: true
@@ -143,8 +138,7 @@ properties:
     x-sortable: true
   billingAddress:
     description: Billing address.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   has3ds:
     description: Specifies if the transaction uses 3D Secure.
     type: boolean
@@ -251,8 +245,7 @@ properties:
     description: Date and time when the transaction is processed.
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:
@@ -422,16 +415,13 @@ properties:
     properties:
       base:
         description: Initial amount and currency to convert from.
-        allOf:
-          - $ref: ./Money.yaml
+        $ref: ./Money.yaml
       quote:
         description: Suggested amount and currency to convert to.
-        allOf:
-          - $ref: ./Money.yaml
+        $ref: ./Money.yaml
       usdMarkup:
         description: Markup amount converted to USD.
-        allOf:
-          - $ref: ./MoneyAmount.yaml
+        $ref: ./MoneyAmount.yaml
       outcome:
         type: string
         description: Dynamic currency conversion outcome.
@@ -456,8 +446,7 @@ properties:
     properties:
       order:
         description: Initial amount and currency.
-        allOf:
-          - $ref: ./Money.yaml
+        $ref: ./Money.yaml
       version:
         type: string
         description: |-
@@ -467,8 +456,7 @@ properties:
         description: |-
           Language in which the bump offer displays to the user.
           This field in useful to find translation issues.
-        allOf:
-          - $ref: ./LanguageIsoCode.yaml
+        $ref: ./LanguageIsoCode.yaml
       outcome:
         type: string
         readOnly: true
@@ -584,8 +572,7 @@ properties:
     readOnly: true
   reportCurrency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   settlementTime:
     type:
       - 'string'

--- a/openapi/components/schemas/TransactionQuery.yaml
+++ b/openapi/components/schemas/TransactionQuery.yaml
@@ -40,5 +40,4 @@ properties:
     readOnly: true
   currency:
     readOnly: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml

--- a/openapi/components/schemas/TransactionTimeline.yaml
+++ b/openapi/components/schemas/TransactionTimeline.yaml
@@ -77,7 +77,6 @@ properties:
   occurredTime:
     description: Date and time when the timeline message occurred.
     readOnly: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   _links:
     $ref: ./SelfLink.yaml

--- a/openapi/components/schemas/TransactionUpdate.yaml
+++ b/openapi/components/schemas/TransactionUpdate.yaml
@@ -17,5 +17,4 @@ properties:
     format: double
   currency:
     description: Currency of the transaction.
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml

--- a/openapi/components/schemas/TransactionsDataExport.yaml
+++ b/openapi/components/schemas/TransactionsDataExport.yaml
@@ -77,8 +77,7 @@ properties:
     type: integer
   scheduledTime:
     description: Date and time when the data export is scheduled to generate a file.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -117,8 +117,7 @@ properties:
       For example, rent must be paid in advance,
       so the invoice must be in advance of the billing date.
       For more information, see [Service period anchor, and billing timing, and invoice time shift](https://www.rebilly.com/docs/dev-docs/concepts/#service-period-anchor-and-billing-timing-and-invoice-time-shift).
-    allOf:
-      - $ref: ./InvoiceTimeShift.yaml
+    $ref: ./InvoiceTimeShift.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/UpcomingInvoice.yaml
+++ b/openapi/components/schemas/UpcomingInvoice.yaml
@@ -18,8 +18,7 @@ properties:
   currency:
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./CurrencyCode.yaml
+    $ref: ./CurrencyCode.yaml
   customerId:
     x-basic: true
     allOf:
@@ -113,12 +112,10 @@ properties:
         example: GB980780684
   billingAddress:
     description: Billing address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   deliveryAddress:
     description: Delivery address of the invoice.
-    allOf:
-      - $ref: ./ContactObject.yaml
+    $ref: ./ContactObject.yaml
   poNumber:
     description: Purchase order number that is displayed on the invoice.
     type:
@@ -143,8 +140,7 @@ properties:
           example: cpn_0YVCNKF81GD778N4YNVGDJK558
         redemptionId:
           description: ID of the redemption.
-          allOf:
-            - $ref: ./ResourceId.yaml
+          $ref: ./ResourceId.yaml
         amount:
           description: Total amount discounted by this coupon.
           type: number
@@ -164,8 +160,7 @@ properties:
     x-label: Date Issued
     x-sortable: true
     x-basic: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:

--- a/openapi/components/schemas/UpcomingInvoiceItem.yaml
+++ b/openapi/components/schemas/UpcomingInvoiceItem.yaml
@@ -67,8 +67,7 @@ properties:
     $ref: ./UpdatedTime.yaml
   tax:
     description: Invoice item tax.
-    allOf:
-      - $ref: ./TaxItem.yaml
+    $ref: ./TaxItem.yaml
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -35,8 +35,7 @@ properties:
     description: |-
       Permissions that the user has within organizations.
       Use the wildcard character `*` for full access.
-    allOf:
-      - $ref: ./AclPermissions.yaml
+    $ref: ./AclPermissions.yaml
   computedPermissions:
     description: All user permissions and roles. Use these permissions to emulate the user.
     readOnly: true

--- a/openapi/components/schemas/WebhookTracking.yaml
+++ b/openapi/components/schemas/WebhookTracking.yaml
@@ -18,8 +18,7 @@ properties:
   initiatedTime:
     description: Date and time when the webhook is initiated.
     x-sortable: true
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   url:
     type: string
     x-sortable: true
@@ -65,8 +64,7 @@ properties:
   sentTime:
     x-sortable: true
     description: Date and time when the webhook is sent.
-    allOf:
-      - $ref: ./ServerTimestamp.yaml
+    $ref: ./ServerTimestamp.yaml
   createdTime:
     x-sortable: true
     $ref: ./CreatedTime.yaml

--- a/openapi/paths/permissions-emulation.yaml
+++ b/openapi/paths/permissions-emulation.yaml
@@ -23,8 +23,7 @@ post:
           properties:
             permissions:
               description: List of permissions to be emulated.
-              allOf:
-                - $ref: ../components/schemas/AclPermissions.yaml
+              $ref: ../components/schemas/AclPermissions.yaml
     required: true
   responses:
     '201':

--- a/openapi/paths/previews@rule-actions@send-email.yaml
+++ b/openapi/paths/previews@rule-actions@send-email.yaml
@@ -12,8 +12,7 @@ post:
       application/json:
         schema:
           description: Send a test email.
-          allOf:
-            - $ref: ../components/schemas/RulesEmailNotification.yaml
+          $ref: ../components/schemas/RulesEmailNotification.yaml
     description: Test email resource.
     required: true
   responses:
@@ -23,8 +22,7 @@ post:
         application/json:
           schema:
             description: Send a test email.
-            allOf:
-              - $ref: ../components/schemas/RulesEmailNotification.yaml
+            $ref: ../components/schemas/RulesEmailNotification.yaml
     '401':
       $ref: ../components/responses/Unauthorized.yaml
     '403':

--- a/plugins/custom-rules.js
+++ b/plugins/custom-rules.js
@@ -1,10 +1,12 @@
 const NoUnusedTags = require('./rules/no-unused-tags');
+const SiblingRef = require('./rules/sibling-ref');
 const id = 'custom-rules';
 
 /** @type {import('@redocly/openapi-cli').CustomRulesConfig} */
 const rules = {
     oas3: {
         'no-unused-tags': NoUnusedTags,
+        'sibling-ref': SiblingRef,
     },
 };
 

--- a/plugins/rules/sibling-ref.js
+++ b/plugins/rules/sibling-ref.js
@@ -1,0 +1,30 @@
+module.exports = SiblingRef;
+
+const refSiblings = ['allOf', 'description', 'summary'];
+
+function SiblingRef() {
+    return {
+        Schema(schema, {report, location, resolve}) {
+            if (!('allOf' in schema) || schema.allOf.length !== 1 || Object.keys(schema).length === 1) {
+                return;
+            }
+
+            for (const siblingKey in schema) {
+                if (!refSiblings.includes(siblingKey)) {
+                    return;
+                }
+            }
+
+            // Discriminator schemas use allOf to define the parent schema
+            const resolvedSchema = resolve(schema.allOf[0]);
+            if ('discriminator' in resolvedSchema.node) {
+                return false;
+            }
+
+            report({
+                message: 'Schema allOf should be converted to sibling $ref',
+                location: location,
+            });
+        },
+    };
+}

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -34,7 +34,7 @@ apis:
         title: All APIs
   all@3.0:
     root: openapi/openapi.yaml
-    output: catalog/all.yaml
+    output: catalog/all-3.0.yaml
     metadata:
       description: All Rebilly APIs.
     decorators:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -217,6 +217,7 @@ rules:
       - api
       - upcoming-invoice
   custom-rules/no-unused-tags: error
+  custom-rules/sibling-ref: error
   response-contains-header:
     severity: error
     names:


### PR DESCRIPTION
## Summary

- Removed `allOf` in favor of `$ref` with siblings
- Added custom rule to prevent further appearances redundant `allOf` 

## Links

See [Reference object](https://swagger.io/specification/#:~:text=%3A%20Pets%20operations-,Reference%20Object,-A%20simple%20object) specification

Closes https://github.com/Rebilly/api-definitions/issues/1688

## Checklist

- [x] Writing style
- [x] API design standards
