### PR TITLE
Add detail to 'Create order' fields

### DIFF
--- a/openapi/components/schemas/FlexiblePlan.yaml
+++ b/openapi/components/schemas/FlexiblePlan.yaml
@@ -1,5 +1,9 @@
 allOf:
   - type: object
+    description: |-
+      Customize an existing plan for the current order.
+
+      To create a new plan, see [Create a plan](https://all-rebilly.redoc.ly/tag/Plans/operation/PostPlan).
     required:
       - id
     properties:

--- a/openapi/components/schemas/OneTimeOrder.yaml
+++ b/openapi/components/schemas/OneTimeOrder.yaml
@@ -81,7 +81,7 @@ properties:
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
-    description: Item details.
+    description: Details of items in the order.
     type: array
     minItems: 1
     items:

--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -1,4 +1,5 @@
 type: object
+description: Details of the one-time sale plan. Use this plan for non-recurring, one-time, sales.
 required:
   - name
   - currency

--- a/openapi/components/schemas/OrderItem.yaml
+++ b/openapi/components/schemas/OrderItem.yaml
@@ -19,7 +19,7 @@ properties:
     description: Number of product units in the specified plan.
     type: integer
   plan:
-    description: Plan details.
+    description: Details of the plan.
     anyOf:
       - $ref: ./OriginalPlan.yaml
       - $ref: ./FlexiblePlan.yaml

--- a/openapi/components/schemas/OriginalPlan.yaml
+++ b/openapi/components/schemas/OriginalPlan.yaml
@@ -1,5 +1,8 @@
 type: object
-description: Plan without changes.
+description: |-
+  Use an existing plan without changes for the current order.
+
+  To create a new plan, see [Create a plan](https://all-rebilly.redoc.ly/tag/Plans/operation/PostPlan).
 required:
   - id
 properties:

--- a/openapi/components/schemas/PlanFormulaFixedFee.yaml
+++ b/openapi/components/schemas/PlanFormulaFixedFee.yaml
@@ -1,3 +1,10 @@
+title: Fixed-fee
+description: |-
+  Fixed-fee pricing details.
+  Use this formula for subscriptions that involve the same price,
+  number of units, and reoccur over a fixed period of time.
+
+  For more information, see [Fixed-fee per period](https://www.rebilly.com/docs/settings/pricing-formulas/#fixed-fee-per-period).
 type: object
 required:
   - price

--- a/openapi/components/schemas/PlanFormulaFlatRate.yaml
+++ b/openapi/components/schemas/PlanFormulaFlatRate.yaml
@@ -1,3 +1,10 @@
+title: Flat rate
+description: |-
+  Flat rate pricing details.
+  Use this formula to charge a flat fee per unit.
+  For example, $0.10 per transaction or $4 per unit.
+
+  For more information, see [Flat rate pricing](https://www.rebilly.com/docs/billing/pricing-formulas/#flat-rate-pricing).
 type: object
 required:
   - price

--- a/openapi/components/schemas/PlanFormulaStairstep.yaml
+++ b/openapi/components/schemas/PlanFormulaStairstep.yaml
@@ -1,3 +1,9 @@
+title: Stair-step
+description: |-
+  Stair-step pricing details.
+  Use this formula to charge for units that are sold in specific quantities.
+
+  For more information, see [Stair-step](https://www.rebilly.com/docs/billing/pricing-formulas/#stair-step).
 type: object
 required:
   - brackets

--- a/openapi/components/schemas/PlanFormulaTiered.yaml
+++ b/openapi/components/schemas/PlanFormulaTiered.yaml
@@ -1,3 +1,9 @@
+title: Tiered
+description: |-
+  Tiered pricing details.
+  Use this formula to charge for units that are sold within defined quantity ranges, or tiers.
+
+  For more information, see [Tiered](https://www.rebilly.com/docs/settings/pricing-formulas/#tiered).
 type: object
 required:
   - brackets

--- a/openapi/components/schemas/PlanFormulaVolume.yaml
+++ b/openapi/components/schemas/PlanFormulaVolume.yaml
@@ -1,3 +1,11 @@
+title: Volume
+description: |-
+  Volume pricing details.
+  Use this formula to charge for units that are sold in bulk,
+  or volume ranges. In general,
+  this formula means that a customer pays less per unit when they buy a large volume of units.
+
+  For more information, see [Volume](https://www.rebilly.com/docs/settings/pricing-formulas/#volume).
 type: object
 required:
   - brackets

--- a/openapi/components/schemas/PlanPriceFormula.yaml
+++ b/openapi/components/schemas/PlanPriceFormula.yaml
@@ -1,5 +1,5 @@
+description: Pricing details.
 type: object
-description: Pricing information.
 discriminator:
   propertyName: formula
   mapping:

--- a/openapi/components/schemas/StorefrontOneTimeOrder.yaml
+++ b/openapi/components/schemas/StorefrontOneTimeOrder.yaml
@@ -57,7 +57,7 @@ properties:
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
-    description: Item details.
+    description: Details of items in the order.
     type: array
     minItems: 1
     items:

--- a/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
+++ b/openapi/components/schemas/StorefrontSubscriptionOrder.yaml
@@ -57,7 +57,7 @@ properties:
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
-    description: Item details.
+    description: Details of items in the order.
     type: array
     minItems: 1
     items:
@@ -191,7 +191,7 @@ properties:
           - $ref: ./InvoiceTimeShift.yaml
           - type: 'null'
       recurringInterval:
-        type: 
+        type:
           - 'object'
           - 'null'
         description: |-
@@ -252,7 +252,7 @@ properties:
       - $ref: ./InvoiceTimeShift.yaml
       - type: 'null'
   recurringInterval:
-    type: 
+    type:
       - 'object'
       - 'null'
     description: |-

--- a/openapi/components/schemas/SubscriptionChange.yaml
+++ b/openapi/components/schemas/SubscriptionChange.yaml
@@ -5,7 +5,7 @@ required:
   - prorated
 properties:
   items:
-    description: Item details.
+    description: Details of items in the order.
     type: array
     minItems: 1
     items:

--- a/openapi/components/schemas/SubscriptionOrder.yaml
+++ b/openapi/components/schemas/SubscriptionOrder.yaml
@@ -124,7 +124,7 @@ properties:
       - $ref: ./InvoiceTimeShift.yaml
       - type: 'null'
   recurringInterval:
-    type: 
+    type:
       - 'object'
       - 'null'
     description: |-
@@ -294,7 +294,7 @@ properties:
     maxLength: 50
     example: in_0YVF9605RKC62BP14NE2R7V2XT
   items:
-    description: Item details.
+    description: Details of items in the order.
     type: array
     minItems: 1
     items:

--- a/openapi/components/schemas/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/SubscriptionOrderPlan.yaml
@@ -1,3 +1,4 @@
+description: Details of the subscription order plan. Use this plan for subscriptions or sales that reoccur over a period of time.
 type: object
 required:
   - name

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -1,3 +1,7 @@
+description: |-
+  Details of the trial-only plan.
+  Use this plan for limited-time product trials.
+  Trials may have a reduced fee, or may be free.
 type: object
 required:
   - name


### PR DESCRIPTION
## Summary
This pull request adds detail to fields related to the 'Create an order' operation.

In particular, pricing formulas were not rendering well in the generated docs.

### Before

<img width="380" alt="Screenshot 2023-11-24 at 18 21 23" src="https://github.com/Rebilly/api-definitions/assets/85164331/c6a1c8c9-1f32-4123-a999-73401a1015e2">

### After

<img width="380" alt="Screenshot 2023-11-24 at 18 25 42" src="https://github.com/Rebilly/api-definitions/assets/85164331/4b4b2d4f-21a8-4dae-8a4e-dd5098ba40b3">

## Checklist

- [x] Writing style
- [x] API design standards
