### PR TITLE
Add readyToPayoutInstruction property

### DIFF
--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -370,13 +370,10 @@ properties:
         Does nothing except return an approved `setup` transaction.
         This is the default behavior.
   readyToPayoutInstruction:
-    type:
-      - 'string'
-      - 'null'
+    type: string
     default: none
     description: |-
       Defines the mode of gateway payout behaviour for the [Ready to payout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout) operation.
-      If this value is `null`, payouts are not supported by the gateway.
     enum:
       - all
       - covered-payout
@@ -386,15 +383,15 @@ properties:
       all: |-
         Payout any amount from this gateway.
       covered-payout: |-
-        Payout from this gateway if it previously processed a payment for the same, 
+        Payout from this gateway if it previously processed a payment for the same,
         or a greater, amount.
       approved-payment: |-
-        Payout any amount from this gateway if it processed an earlier payment. 
-        The customer must have a previously approved transaction, 
+        Payout any amount from this gateway if it processed an earlier payment.
+        The customer must have a previously approved transaction,
         in the same currency, on this gateway.
       none:
-        Do not allow any payouts with this gateway. 
-        This is the default value, 
+        Do not allow any payouts with this gateway.
+        This is the default value,
         merchants must opt into payouts.
   customFields:
     $ref: ./ResourceCustomFields.yaml

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -375,7 +375,7 @@ properties:
       - 'null'
     default: none
     description: |-
-      Defines a mode of gateway payout behaviour for [StorefrontReadyToPayout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout).
+      Defines the mode of gateway payout behaviour for the [Ready to payout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout) operation.
       If this value is `null`, payouts are not supported by the gateway.
     enum:
       - all
@@ -384,14 +384,18 @@ properties:
       - none
     x-enumDescriptions:
       all: |-
-        Allow any amount to payout through gateway.
+        Payout any amount from this gateway.
       covered-payout: |-
-        Only payout amount of gateway what has been paid into gateway.
+        Payout from this gateway if it previously processed a payment for the same, 
+        or a greater, amount.
       approved-payment: |-
-        Payout any amount as long as there was a previously approved transaction for this customer and currency.
-        via this gateway
+        Payout any amount from this gateway if it processed an earlier payment. 
+        The customer must have a previously approved transaction, 
+        in the same currency, on this gateway.
       none:
-        Gateway not allowed for payout. This will be the default value, merchant will need to opt into payouts.
+        Do not allow any payouts with this gateway. 
+        This is the default value, 
+        merchants must opt into payouts.
   customFields:
     $ref: ./ResourceCustomFields.yaml
   createdTime:

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -375,7 +375,7 @@ properties:
       - 'null'
     default: none
     description: |-
-      Defines a mode of gateway payout behaviour.
+      Defines a mode of gateway payout behaviour for [StorefrontReadyToPayout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout).
       If a `null`, a gateway does not support payout operation.
     enum:
       - all

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -376,7 +376,7 @@ properties:
     default: none
     description: |-
       Defines a mode of gateway payout behaviour for [StorefrontReadyToPayout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout).
-      If a `null`, a gateway does not support payout operation.
+      If this value is `null`, payouts are not supported by the gateway.
     enum:
       - all
       - covered-payout

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -370,10 +370,13 @@ properties:
         Does nothing except return an approved `setup` transaction.
         This is the default behavior.
   readyToPayoutInstruction:
-    type: string
+    type:
+      - 'string'
+      - 'null'
     default: none
     description: |-
       Defines a mode of gateway payout behaviour.
+      If a `null`, a gateway does not support payout operation.
     enum:
       - all
       - covered-payout

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -369,6 +369,26 @@ properties:
       do-nothing: |-
         Does nothing except return an approved `setup` transaction.
         This is the default behavior.
+  readyToPayoutInstruction:
+    type: string
+    default: none
+    description: |-
+      Defines a mode of gateway payout behaviour.
+    enum:
+      - all
+      - covered-payout
+      - approved-payment
+      - none
+    x-enumDescriptions:
+      all: |-
+        Allow any amount to payout through gateway.
+      covered-payout: |-
+        Only payout amount of gateway what has been paid into gateway.
+      approved-payment: |-
+        Payout any amount as long as there was a previously approved transaction for this customer and currency.
+        via this gateway
+      none:
+        Gateway not allowed for payout. This will be the default value, merchant will need to opt into payouts.
   customFields:
     $ref: ./ResourceCustomFields.yaml
   createdTime:


### PR DESCRIPTION
## Summary
In this PR added `readyToPayoutInstruction ` to manage payout behaviour of payment gateway

## Checklist

- [x] Writing style
- [x] API design standards
