### PR TITLE
Rename risk metadata vpnServiceName to hostingName

### DIFF
--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -114,8 +114,8 @@ properties:
     description: Specifies if the customer's IP address is related to hosting.
     type: boolean
     readOnly: true
-  vpnServiceName:
-    description: VPN service name, if available.
+  dch:
+    description: Name of the data center or hosting provider, if available.
     type:
       - 'string'
       - 'null'

--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -114,7 +114,7 @@ properties:
     description: Specifies if the customer's IP address is related to hosting.
     type: boolean
     readOnly: true
-  dch:
+  hostingName:
     description: Name of the data center or hosting provider, if available.
     type:
       - 'string'


### PR DESCRIPTION
## Summary
Rename risk metadata vpnServiceName to hostingName because `isHosting` related to that field

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
