### PR TITLE
Use FQCN in PHP SDK 3.x code samples

### DIFF
--- a/openapi/code_samples/PHP/histograms@transactions/get.php
+++ b/openapi/code_samples/PHP/histograms@transactions/get.php
@@ -3,8 +3,8 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $histogram = $service->histograms()->getTransactionHistogramReport(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     'website',
     'day',
     'sales',

--- a/openapi/code_samples/PHP/psalm.xml
+++ b/openapi/code_samples/PHP/psalm.xml
@@ -12,17 +12,12 @@
         <directory name="./" />
         <ignoreFiles>
             <directory name="vendor" />
+            <file name="data-exports/post.php"/> <!-- Class was renamed in unreleased version -->
+            <file name="data-exports@{id}/put.php"/> <!-- Class was renamed in unreleased version -->
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
         <UndefinedGlobalVariable errorLevel="suppress"/>
         <UnusedVariable errorLevel="suppress"/>
-
-        <UndefinedClass errorLevel="error">
-          <errorLevel type="suppress">
-            <file name="data-exports/post.php"/> <!-- Class was renamed in unreleased version -->
-            <file name="data-exports@{id}/put.php"/> <!-- Class was renamed in unreleased version -->
-          </errorLevel>
-        </UndefinedClass>
     </issueHandlers>
 </psalm>

--- a/openapi/code_samples/PHP/psalm.xml
+++ b/openapi/code_samples/PHP/psalm.xml
@@ -17,5 +17,12 @@
     <issueHandlers>
         <UndefinedGlobalVariable errorLevel="suppress"/>
         <UnusedVariable errorLevel="suppress"/>
+
+        <UndefinedClass errorLevel="error">
+          <errorLevel type="suppress">
+            <file name="data-exports/post.php"/> <!-- Class was renamed in unreleased version -->
+            <file name="data-exports@{id}/put.php"/> <!-- Class was renamed in unreleased version -->
+          </errorLevel>
+        </UndefinedClass>
     </issueHandlers>
 </psalm>

--- a/openapi/code_samples/PHP/reports@api-log-summary/get.php
+++ b/openapi/code_samples/PHP/reports@api-log-summary/get.php
@@ -3,7 +3,7 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getApiLogSummary(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@cumulative-subscriptions/get.php
+++ b/openapi/code_samples/PHP/reports@cumulative-subscriptions/get.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getCumulativeSubscriptions(
     'day',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@dashboard/get.php
+++ b/openapi/code_samples/PHP/reports@dashboard/get.php
@@ -3,7 +3,7 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $dashboard = $service->reports()->getDashboardMetrics(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     metrics: 'approvalRate,salesCount,salesValue,refundsValue',
 );

--- a/openapi/code_samples/PHP/reports@dcc-markup/get.php
+++ b/openapi/code_samples/PHP/reports@dcc-markup/get.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getDccMarkup(
     'day',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@events-triggered/get.php
+++ b/openapi/code_samples/PHP/reports@events-triggered/get.php
@@ -3,7 +3,7 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getEventsTriggeredSummary(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@events-triggered@{eventType}@rules/get.php
+++ b/openapi/code_samples/PHP/reports@events-triggered@{eventType}@rules/get.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getTriggeredEventRuleReport(
     'account-password-reset-requested',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@kyc-acceptance-summary/get.php
+++ b/openapi/code_samples/PHP/reports@kyc-acceptance-summary/get.php
@@ -3,6 +3,6 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getKycAcceptanceSummary(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
 );

--- a/openapi/code_samples/PHP/reports@kyc-rejection-summary/get.php
+++ b/openapi/code_samples/PHP/reports@kyc-rejection-summary/get.php
@@ -3,6 +3,6 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getKycRejectionSummary(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
 );

--- a/openapi/code_samples/PHP/reports@kyc-request-summary/get.php
+++ b/openapi/code_samples/PHP/reports@kyc-request-summary/get.php
@@ -3,6 +3,6 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getKycRequestSummary(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
 );

--- a/openapi/code_samples/PHP/reports@retention-percentage/get.php
+++ b/openapi/code_samples/PHP/reports@retention-percentage/get.php
@@ -5,7 +5,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 $report = $service->reports()->getRetentionPercentage(
     'day',
     'month',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@retention-value/get.php
+++ b/openapi/code_samples/PHP/reports@retention-value/get.php
@@ -5,7 +5,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 $report = $service->reports()->getRetentionValue(
     'month',
     'day',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@subscription-cancellation/get.php
+++ b/openapi/code_samples/PHP/reports@subscription-cancellation/get.php
@@ -3,8 +3,8 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getSubscriptionCancellation(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     'leadSource.source',
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@subscription-renewal/get.php
+++ b/openapi/code_samples/PHP/reports@subscription-renewal/get.php
@@ -3,7 +3,7 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getSubscriptionRenewal(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@time-series-transaction/get.php
+++ b/openapi/code_samples/PHP/reports@time-series-transaction/get.php
@@ -5,6 +5,6 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 $report = $service->reports()->getTimeSeriesTransaction(
     'approval-rate',
     'leads.sales-agent',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
 );

--- a/openapi/code_samples/PHP/reports@transactions-time-dispute/get.php
+++ b/openapi/code_samples/PHP/reports@transactions-time-dispute/get.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getTransactionsTimeDispute(
     'rebillNumber',
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     limit: 5,
 );

--- a/openapi/code_samples/PHP/reports@transactions/get.php
+++ b/openapi/code_samples/PHP/reports@transactions/get.php
@@ -3,8 +3,8 @@
 $service = new \Rebilly\Sdk\ReportsService($client);
 
 $report = $service->reports()->getTransactions(
-    new DateTimeImmutable('2022-01-01'),
-    new DateTimeImmutable('now'),
+    new \DateTimeImmutable('2022-01-01'),
+    new \DateTimeImmutable('now'),
     'leadSource.subAffiliate',
     limit: 5,
 );

--- a/openapi/code_samples/PHP/subscription-cancellations/post.php
+++ b/openapi/code_samples/PHP/subscription-cancellations/post.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\CoreService($client);
 
 $cancellation = new \Rebilly\Sdk\Model\SubscriptionCancellation([
     'subscriptionId' => 'subscriptionId',
-    'churnTime' => new DateTimeImmutable(),
+    'churnTime' => new \DateTimeImmutable(),
     'canceledBy' => \Rebilly\Sdk\Model\SubscriptionCancellation::CANCELED_BY_MERCHANT,
     'reason' => \Rebilly\Sdk\Model\SubscriptionCancellation::REASON_CONTRACT_EXPIRED,
 ]);

--- a/openapi/code_samples/PHP/subscription-cancellations@{id}/put.php
+++ b/openapi/code_samples/PHP/subscription-cancellations@{id}/put.php
@@ -4,7 +4,7 @@ $service = new \Rebilly\Sdk\CoreService($client);
 
 $cancellation = new \Rebilly\Sdk\Model\SubscriptionCancellation([
     'subscriptionId' => 'subscriptionId',
-    'churnTime' => new DateTimeImmutable(),
+    'churnTime' => new \DateTimeImmutable(),
     'canceledBy' => \Rebilly\Sdk\Model\SubscriptionCancellation::CANCELED_BY_MERCHANT,
     'reason' => \Rebilly\Sdk\Model\SubscriptionCancellation::REASON_CONTRACT_EXPIRED,
 ]);


### PR DESCRIPTION
## Summary
Use FQCN for DateTimeImmutable class in PHP SDK 3.x code samples
Suppress Psalm error because it runs checks using unreleased version of PHP SDK

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
