### PR TITLE
Rename Storefront tags

### DIFF
--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -377,7 +377,7 @@ properties:
     type: string
     default: none
     description: |-
-      Defines the mode of gateway payout behaviour for the [Ready to payout](https://all-rebilly.redoc.ly/tag/Purchases/operation/StorefrontPostReadyToPayout) operation.
+      Defines the mode of gateway payout behaviour for the [Ready to payout](https://all-rebilly.redoc.ly/tag/Storefront-purchases/operation/StorefrontPostReadyToPayout) operation.
     enum:
       - all
       - covered-payout

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -519,13 +519,49 @@ tags:
     description: |-
       Use this operation to check the status of the Rebilly API.
       No authentication is required.
+  - name: Storefront account
+    description: |-
+      Use these operations to access Storefront account.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront billing portals
+    description: |-
+      Use these operations to access Storefront billing portals.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront checkout forms
+    description: |-
+      Use these operations to access Storefront checkout forms.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront custom fields
+    description: |-
+      Use these operations to access Storefront custom fields.
+      APIs intended to be used directly from an untrusted browser.
   - name: Storefront invoices
     description: |-
       Use these operations to access Storefront invoices.
       APIs intended to be used directly from an untrusted browser.
+  - name: Storefront KYC documents
+    description: |-
+      Use these operations to access Storefront KYC documents.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront payment instruments
+    description: |-
+      Use these operations to access Storefront payment instruments.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront plans
+    description: |-
+      Use these operations to access Storefront plans.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront purchases
+    description: |-
+      Use these operations to access Storefront purchases.
+      APIs intended to be used directly from an untrusted browser.
   - name: Storefront products
     description: |-
       Use these operations to access Storefront products.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront quotes
+    description: |-
+      Use these operations to access Storefront quotes.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront transactions
     description: |-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -519,6 +519,7 @@ tags:
     description: |-
       Use this operation to check the status of the Rebilly API.
       No authentication is required.
+  - name: Storefront products
   - name: Tags
     description: Use tags to organize and categorize customers or KYC documents based on keywords.
   - name: Tracking

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -535,6 +535,10 @@ tags:
     description: |-
       Use these operations to access Storefront custom fields.
       APIs intended to be used directly from an untrusted browser.
+  - name: Storefront deposits
+    description: |-
+      Use these operations to access Storefront deposits.
+      APIs intended to be used directly from an untrusted browser.
   - name: Storefront invoices
     description: |-
       Use these operations to access Storefront invoices.
@@ -542,6 +546,10 @@ tags:
   - name: Storefront KYC documents
     description: |-
       Use these operations to access Storefront KYC documents.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront orders
+    description: |-
+      Use these operations to access Storefront orders.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront payment instruments
     description: |-
@@ -551,13 +559,13 @@ tags:
     description: |-
       Use these operations to access Storefront plans.
       APIs intended to be used directly from an untrusted browser.
-  - name: Storefront purchases
-    description: |-
-      Use these operations to access Storefront purchases.
-      APIs intended to be used directly from an untrusted browser.
   - name: Storefront products
     description: |-
       Use these operations to access Storefront products.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront purchases
+    description: |-
+      Use these operations to access Storefront purchases.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront quotes
     description: |-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1299,106 +1299,106 @@ paths:
     $ref: ./paths/reports@transactions.yaml
   '/experimental/subscriptions/{subscriptionId}/summary-metrics':
     $ref: ./paths/subscriptions@{subscriptionId}@summary-metrics.yaml
-  '/Storefront/account':
-    $ref: ./paths/Storefront/account.yaml
-  '/Storefront/account/forgot-password':
-    $ref: paths/Storefront/account@forgot-password.yaml
-  '/Storefront/account/password':
-    $ref: paths/Storefront/account@password.yaml
-  '/Storefront/account/resend-verification':
-    $ref: paths/Storefront/account@resend-verification.yaml
-  '/Storefront/account/reset-password/{token}':
-    $ref: paths/Storefront/account@reset-password@{token}.yaml
-  '/Storefront/account/verification/{token}':
-    $ref: paths/Storefront/account@verification@{token}.yaml
-  '/Storefront/billing-portals/{slug}':
-    $ref: paths/Storefront/billing-portals@{slug}.yaml
-  '/Storefront/deposit-strategies/{id}':
-    $ref: paths/Storefront/deposit-strategies@{id}.yaml
-  '/Storefront/deposit-requests/{id}':
-    $ref: paths/Storefront/deposit-requests@{id}.yaml
-  '/Storefront/deposit':
-    $ref: paths/Storefront/deposit.yaml
-  '/Storefront/checkout-forms/{id}':
-    $ref: paths/Storefront/checkout-forms@{id}.yaml
-  '/Storefront/custom-fields/{resource}':
-    $ref: paths/Storefront/custom-fields@{resource}.yaml
-  '/Storefront/invoices':
-    $ref: paths/Storefront/invoices.yaml
-  '/Storefront/invoices/{id}':
-    $ref: paths/Storefront/invoices@{id}.yaml
-  '/Storefront/kyc-documents':
-    $ref: paths/Storefront/kyc-documents.yaml
-  '/Storefront/kyc-documents/{id}':
-    $ref: paths/Storefront/kyc-documents@{id}.yaml
-  '/Storefront/kyc-requests/{id}':
-    $ref: paths/Storefront/kyc-requests@{id}.yaml
-  '/Storefront/kyc-liveness-sessions':
-    $ref: paths/Storefront/kyc-liveness-sessions.yaml
-  '/Storefront/kyc-liveness-sessions/{id}':
-    $ref: paths/Storefront/kyc-liveness-sessions@{id}.yaml
-  '/Storefront/kyc-liveness-sessions/{id}/finish':
-    $ref: paths/Storefront/kyc-liveness-sessions@{id}@finish.yaml
-  '/Storefront/login':
-    $ref: paths/Storefront/login.yaml
-  '/Storefront/logout':
-    $ref: paths/Storefront/logout.yaml
-  '/Storefront/orders':
-    $ref: paths/Storefront/orders.yaml
-  '/Storefront/orders/{id}':
-    $ref: paths/Storefront/orders@{id}.yaml
-  '/Storefront/orders/{id}/cancellation':
-    $ref: paths/Storefront/orders@{id}@cancellation.yaml
-  '/Storefront/orders/{id}/pause':
-    $ref: paths/Storefront/orders@{id}@pause.yaml
-  '/Storefront/payment':
-    $ref: paths/Storefront/payment.yaml
-  '/Storefront/payment-instruments':
-    $ref: paths/Storefront/payment-instruments.yaml
-  '/Storefront/payment-instruments/{id}':
-    $ref: paths/Storefront/payment-instruments@{id}.yaml
-  '/Storefront/payment-instruments/{id}/deactivation':
-    $ref: paths/Storefront/payment-instruments@{id}@deactivation.yaml
-  '/Storefront/payment-instruments/{id}/setup':
-    $ref: paths/Storefront/payment-instruments@{id}@setup.yaml
-  '/Storefront/payout-requests':
-    $ref: ./paths/Storefront/payout-requests.yaml
-  '/Storefront/payout-requests/{id}':
-    $ref: paths/Storefront/payout-requests@{id}.yaml
-  '/Storefront/plans':
-    $ref: paths/Storefront/plans.yaml
-  '/Storefront/plans/{id}':
-    $ref: paths/Storefront/plans@{id}.yaml
-  '/Storefront/products':
-    $ref: paths/Storefront/products.yaml
-  '/Storefront/products/{id}':
-    $ref: paths/Storefront/products@{id}.yaml
-  '/Storefront/purchase':
-    $ref: paths/Storefront/purchase.yaml
-  '/Storefront/preview-purchase':
-    $ref: paths/Storefront/preview-purchase.yaml
-  '/Storefront/quotes/{id}':
-    $ref: paths/Storefront/quotes@{id}.yaml
-  '/Storefront/quotes/{id}/accept':
-    $ref: paths/Storefront/quotes@{id}@accept.yaml
-  '/Storefront/quotes/{id}/reject':
-    $ref: paths/Storefront/quotes@{id}@reject.yaml
-  '/Storefront/ready-to-pay':
-    $ref: paths/Storefront/ready-to-pay.yaml
-  '/Storefront/ready-to-payout':
-    $ref: paths/Storefront/ready-to-payout.yaml
-  '/Storefront/register':
-    $ref: paths/Storefront/register.yaml
-  '/Storefront/transactions':
-    $ref: paths/Storefront/transactions.yaml
-  '/Storefront/transactions/{id}':
-    $ref: paths/Storefront/transactions@{id}.yaml
-  '/Storefront/transactions/{id}/{token}/continue':
-    $ref: paths/Storefront/transactions@{id}@{token}@continue.yaml
-  '/Storefront/transactions/{id}/{token}/bypass':
-    $ref: paths/Storefront/transactions@{id}@{token}@bypass.yaml
-  '/Storefront/websites/{id}':
-    $ref: paths/Storefront/websites@{id}.yaml
+  '/storefront/account':
+    $ref: ./paths/storefront/account.yaml
+  '/storefront/account/forgot-password':
+    $ref: paths/storefront/account@forgot-password.yaml
+  '/storefront/account/password':
+    $ref: paths/storefront/account@password.yaml
+  '/storefront/account/resend-verification':
+    $ref: paths/storefront/account@resend-verification.yaml
+  '/storefront/account/reset-password/{token}':
+    $ref: paths/storefront/account@reset-password@{token}.yaml
+  '/storefront/account/verification/{token}':
+    $ref: paths/storefront/account@verification@{token}.yaml
+  '/storefront/billing-portals/{slug}':
+    $ref: paths/storefront/billing-portals@{slug}.yaml
+  '/storefront/deposit-strategies/{id}':
+    $ref: paths/storefront/deposit-strategies@{id}.yaml
+  '/storefront/deposit-requests/{id}':
+    $ref: paths/storefront/deposit-requests@{id}.yaml
+  '/storefront/deposit':
+    $ref: paths/storefront/deposit.yaml
+  '/storefront/checkout-forms/{id}':
+    $ref: paths/storefront/checkout-forms@{id}.yaml
+  '/storefront/custom-fields/{resource}':
+    $ref: paths/storefront/custom-fields@{resource}.yaml
+  '/storefront/invoices':
+    $ref: paths/storefront/invoices.yaml
+  '/storefront/invoices/{id}':
+    $ref: paths/storefront/invoices@{id}.yaml
+  '/storefront/kyc-documents':
+    $ref: paths/storefront/kyc-documents.yaml
+  '/storefront/kyc-documents/{id}':
+    $ref: paths/storefront/kyc-documents@{id}.yaml
+  '/storefront/kyc-requests/{id}':
+    $ref: paths/storefront/kyc-requests@{id}.yaml
+  '/storefront/kyc-liveness-sessions':
+    $ref: paths/storefront/kyc-liveness-sessions.yaml
+  '/storefront/kyc-liveness-sessions/{id}':
+    $ref: paths/storefront/kyc-liveness-sessions@{id}.yaml
+  '/storefront/kyc-liveness-sessions/{id}/finish':
+    $ref: paths/storefront/kyc-liveness-sessions@{id}@finish.yaml
+  '/storefront/login':
+    $ref: paths/storefront/login.yaml
+  '/storefront/logout':
+    $ref: paths/storefront/logout.yaml
+  '/storefront/orders':
+    $ref: paths/storefront/orders.yaml
+  '/storefront/orders/{id}':
+    $ref: paths/storefront/orders@{id}.yaml
+  '/storefront/orders/{id}/cancellation':
+    $ref: paths/storefront/orders@{id}@cancellation.yaml
+  '/storefront/orders/{id}/pause':
+    $ref: paths/storefront/orders@{id}@pause.yaml
+  '/storefront/payment':
+    $ref: paths/storefront/payment.yaml
+  '/storefront/payment-instruments':
+    $ref: paths/storefront/payment-instruments.yaml
+  '/storefront/payment-instruments/{id}':
+    $ref: paths/storefront/payment-instruments@{id}.yaml
+  '/storefront/payment-instruments/{id}/deactivation':
+    $ref: paths/storefront/payment-instruments@{id}@deactivation.yaml
+  '/storefront/payment-instruments/{id}/setup':
+    $ref: paths/storefront/payment-instruments@{id}@setup.yaml
+  '/storefront/payout-requests':
+    $ref: ./paths/storefront/payout-requests.yaml
+  '/storefront/payout-requests/{id}':
+    $ref: paths/storefront/payout-requests@{id}.yaml
+  '/storefront/plans':
+    $ref: paths/storefront/plans.yaml
+  '/storefront/plans/{id}':
+    $ref: paths/storefront/plans@{id}.yaml
+  '/storefront/products':
+    $ref: paths/storefront/products.yaml
+  '/storefront/products/{id}':
+    $ref: paths/storefront/products@{id}.yaml
+  '/storefront/purchase':
+    $ref: paths/storefront/purchase.yaml
+  '/storefront/preview-purchase':
+    $ref: paths/storefront/preview-purchase.yaml
+  '/storefront/quotes/{id}':
+    $ref: paths/storefront/quotes@{id}.yaml
+  '/storefront/quotes/{id}/accept':
+    $ref: paths/storefront/quotes@{id}@accept.yaml
+  '/storefront/quotes/{id}/reject':
+    $ref: paths/storefront/quotes@{id}@reject.yaml
+  '/storefront/ready-to-pay':
+    $ref: paths/storefront/ready-to-pay.yaml
+  '/storefront/ready-to-payout':
+    $ref: paths/storefront/ready-to-payout.yaml
+  '/storefront/register':
+    $ref: paths/storefront/register.yaml
+  '/storefront/transactions':
+    $ref: paths/storefront/transactions.yaml
+  '/storefront/transactions/{id}':
+    $ref: paths/storefront/transactions@{id}.yaml
+  '/storefront/transactions/{id}/{token}/continue':
+    $ref: paths/storefront/transactions@{id}@{token}@continue.yaml
+  '/storefront/transactions/{id}/{token}/bypass':
+    $ref: paths/storefront/transactions@{id}@{token}@bypass.yaml
+  '/storefront/websites/{id}':
+    $ref: paths/storefront/websites@{id}.yaml
   '/customers/{id}/edd-score':
     $ref: paths/customers@{id}@edd-score.yaml
   '/customers/{id}/edd-timeline':

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -520,6 +520,9 @@ tags:
       Use this operation to check the status of the Rebilly API.
       No authentication is required.
   - name: Storefront products
+    description: |-
+      Use these operations to access Storefront products.
+      APIs intended to be used directly from an untrusted browser.
   - name: Tags
     description: Use tags to organize and categorize customers or KYC documents based on keywords.
   - name: Tracking

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -505,7 +505,7 @@ tags:
       No authentication is required.
   - name: Storefront account
     description: |-
-      Use these operations to manage Rebilly Storefront accounts.
+      Use these operations to manage Storefront accounts.
       An account in which you are subscribed to in order to use the Rebilly product.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront billing portals

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -507,158 +507,158 @@ tags:
     description: |-
       Use these operations to manage Storefront accounts.
       A Storefront account is an account that the customer is subscribed to in order to use the Rebilly product.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use Storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
       For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
 
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront billing portals
     description: |-
-      Use these operations to access storefront billing portals.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront billing portals.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront checkout forms
     description: |-
-      Use these operations to access storefront checkout forms.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront checkout forms.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront custom fields
     description: |-
-      Use these operations to access storefront custom fields.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront custom fields.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront deposits
     description: |-
-      Use these operations to access storefront deposits.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront deposits.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront invoices
     description: |-
-      Use these operations to access storefront invoices.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront invoices.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront KYC documents
     description: |-
-      Use these operations to access storefront KYC documents.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront KYC documents.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront orders
     description: |-
-      Use these operations to access storefront orders.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront orders.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront payment instruments
     description: |-
-      Use these operations to access storefront payment instruments.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront payment instruments.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront plans
     description: |-
-      Use these operations to access storefront plans.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront plans.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront products
     description: |-
-      Use these operations to access storefront products.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, 
-      see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront products.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information,
+      see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront purchases
     description: |-
-      Use these operations to manage storefront purchases.
+      Use these operations to manage Storefront purchases.
       Purchases are transactions that have been executed related to the purchase of goods or services.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront quotes
     description: |-
-      Use these operations to access storefront quotes.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront quotes.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront transactions
     description: |-
       Use these operations to access Storefront transactions.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront websites
     description: |-
-      Use these operations to access storefront websites.
-      
-      Storefront operations interact directly with the customer, 
-      and provide the customer with access to their own data. 
-      
-      To use storefront operations, 
-      the customer must be issued a JWT with limited permissions. 
-      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Use these operations to access Storefront websites.
+
+      Storefront operations interact directly with the customer,
+      and provide the customer with access to their own data.
+
+      To use Storefront operations,
+      the customer must be issued a JWT with limited permissions.
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
       Storefront operations are intended to be used directly from an untrusted browser.
   - name: Tags
     description: Use tags to organize and categorize customers or KYC documents based on keywords.
@@ -1299,106 +1299,106 @@ paths:
     $ref: ./paths/reports@transactions.yaml
   '/experimental/subscriptions/{subscriptionId}/summary-metrics':
     $ref: ./paths/subscriptions@{subscriptionId}@summary-metrics.yaml
-  '/storefront/account':
-    $ref: ./paths/storefront/account.yaml
-  '/storefront/account/forgot-password':
-    $ref: paths/storefront/account@forgot-password.yaml
-  '/storefront/account/password':
-    $ref: paths/storefront/account@password.yaml
-  '/storefront/account/resend-verification':
-    $ref: paths/storefront/account@resend-verification.yaml
-  '/storefront/account/reset-password/{token}':
-    $ref: paths/storefront/account@reset-password@{token}.yaml
-  '/storefront/account/verification/{token}':
-    $ref: paths/storefront/account@verification@{token}.yaml
-  '/storefront/billing-portals/{slug}':
-    $ref: paths/storefront/billing-portals@{slug}.yaml
-  '/storefront/deposit-strategies/{id}':
-    $ref: paths/storefront/deposit-strategies@{id}.yaml
-  '/storefront/deposit-requests/{id}':
-    $ref: paths/storefront/deposit-requests@{id}.yaml
-  '/storefront/deposit':
-    $ref: paths/storefront/deposit.yaml
-  '/storefront/checkout-forms/{id}':
-    $ref: paths/storefront/checkout-forms@{id}.yaml
-  '/storefront/custom-fields/{resource}':
-    $ref: paths/storefront/custom-fields@{resource}.yaml
-  '/storefront/invoices':
-    $ref: paths/storefront/invoices.yaml
-  '/storefront/invoices/{id}':
-    $ref: paths/storefront/invoices@{id}.yaml
-  '/storefront/kyc-documents':
-    $ref: paths/storefront/kyc-documents.yaml
-  '/storefront/kyc-documents/{id}':
-    $ref: paths/storefront/kyc-documents@{id}.yaml
-  '/storefront/kyc-requests/{id}':
-    $ref: paths/storefront/kyc-requests@{id}.yaml
-  '/storefront/kyc-liveness-sessions':
-    $ref: paths/storefront/kyc-liveness-sessions.yaml
-  '/storefront/kyc-liveness-sessions/{id}':
-    $ref: paths/storefront/kyc-liveness-sessions@{id}.yaml
-  '/storefront/kyc-liveness-sessions/{id}/finish':
-    $ref: paths/storefront/kyc-liveness-sessions@{id}@finish.yaml
-  '/storefront/login':
-    $ref: paths/storefront/login.yaml
-  '/storefront/logout':
-    $ref: paths/storefront/logout.yaml
-  '/storefront/orders':
-    $ref: paths/storefront/orders.yaml
-  '/storefront/orders/{id}':
-    $ref: paths/storefront/orders@{id}.yaml
-  '/storefront/orders/{id}/cancellation':
-    $ref: paths/storefront/orders@{id}@cancellation.yaml
-  '/storefront/orders/{id}/pause':
-    $ref: paths/storefront/orders@{id}@pause.yaml
-  '/storefront/payment':
-    $ref: paths/storefront/payment.yaml
-  '/storefront/payment-instruments':
-    $ref: paths/storefront/payment-instruments.yaml
-  '/storefront/payment-instruments/{id}':
-    $ref: paths/storefront/payment-instruments@{id}.yaml
-  '/storefront/payment-instruments/{id}/deactivation':
-    $ref: paths/storefront/payment-instruments@{id}@deactivation.yaml
-  '/storefront/payment-instruments/{id}/setup':
-    $ref: paths/storefront/payment-instruments@{id}@setup.yaml
-  '/storefront/payout-requests':
-    $ref: ./paths/storefront/payout-requests.yaml
-  '/storefront/payout-requests/{id}':
-    $ref: paths/storefront/payout-requests@{id}.yaml
-  '/storefront/plans':
-    $ref: paths/storefront/plans.yaml
-  '/storefront/plans/{id}':
-    $ref: paths/storefront/plans@{id}.yaml
-  '/storefront/products':
-    $ref: paths/storefront/products.yaml
-  '/storefront/products/{id}':
-    $ref: paths/storefront/products@{id}.yaml
-  '/storefront/purchase':
-    $ref: paths/storefront/purchase.yaml
-  '/storefront/preview-purchase':
-    $ref: paths/storefront/preview-purchase.yaml
-  '/storefront/quotes/{id}':
-    $ref: paths/storefront/quotes@{id}.yaml
-  '/storefront/quotes/{id}/accept':
-    $ref: paths/storefront/quotes@{id}@accept.yaml
-  '/storefront/quotes/{id}/reject':
-    $ref: paths/storefront/quotes@{id}@reject.yaml
-  '/storefront/ready-to-pay':
-    $ref: paths/storefront/ready-to-pay.yaml
-  '/storefront/ready-to-payout':
-    $ref: paths/storefront/ready-to-payout.yaml
-  '/storefront/register':
-    $ref: paths/storefront/register.yaml
-  '/storefront/transactions':
-    $ref: paths/storefront/transactions.yaml
-  '/storefront/transactions/{id}':
-    $ref: paths/storefront/transactions@{id}.yaml
-  '/storefront/transactions/{id}/{token}/continue':
-    $ref: paths/storefront/transactions@{id}@{token}@continue.yaml
-  '/storefront/transactions/{id}/{token}/bypass':
-    $ref: paths/storefront/transactions@{id}@{token}@bypass.yaml
-  '/storefront/websites/{id}':
-    $ref: paths/storefront/websites@{id}.yaml
+  '/Storefront/account':
+    $ref: ./paths/Storefront/account.yaml
+  '/Storefront/account/forgot-password':
+    $ref: paths/Storefront/account@forgot-password.yaml
+  '/Storefront/account/password':
+    $ref: paths/Storefront/account@password.yaml
+  '/Storefront/account/resend-verification':
+    $ref: paths/Storefront/account@resend-verification.yaml
+  '/Storefront/account/reset-password/{token}':
+    $ref: paths/Storefront/account@reset-password@{token}.yaml
+  '/Storefront/account/verification/{token}':
+    $ref: paths/Storefront/account@verification@{token}.yaml
+  '/Storefront/billing-portals/{slug}':
+    $ref: paths/Storefront/billing-portals@{slug}.yaml
+  '/Storefront/deposit-strategies/{id}':
+    $ref: paths/Storefront/deposit-strategies@{id}.yaml
+  '/Storefront/deposit-requests/{id}':
+    $ref: paths/Storefront/deposit-requests@{id}.yaml
+  '/Storefront/deposit':
+    $ref: paths/Storefront/deposit.yaml
+  '/Storefront/checkout-forms/{id}':
+    $ref: paths/Storefront/checkout-forms@{id}.yaml
+  '/Storefront/custom-fields/{resource}':
+    $ref: paths/Storefront/custom-fields@{resource}.yaml
+  '/Storefront/invoices':
+    $ref: paths/Storefront/invoices.yaml
+  '/Storefront/invoices/{id}':
+    $ref: paths/Storefront/invoices@{id}.yaml
+  '/Storefront/kyc-documents':
+    $ref: paths/Storefront/kyc-documents.yaml
+  '/Storefront/kyc-documents/{id}':
+    $ref: paths/Storefront/kyc-documents@{id}.yaml
+  '/Storefront/kyc-requests/{id}':
+    $ref: paths/Storefront/kyc-requests@{id}.yaml
+  '/Storefront/kyc-liveness-sessions':
+    $ref: paths/Storefront/kyc-liveness-sessions.yaml
+  '/Storefront/kyc-liveness-sessions/{id}':
+    $ref: paths/Storefront/kyc-liveness-sessions@{id}.yaml
+  '/Storefront/kyc-liveness-sessions/{id}/finish':
+    $ref: paths/Storefront/kyc-liveness-sessions@{id}@finish.yaml
+  '/Storefront/login':
+    $ref: paths/Storefront/login.yaml
+  '/Storefront/logout':
+    $ref: paths/Storefront/logout.yaml
+  '/Storefront/orders':
+    $ref: paths/Storefront/orders.yaml
+  '/Storefront/orders/{id}':
+    $ref: paths/Storefront/orders@{id}.yaml
+  '/Storefront/orders/{id}/cancellation':
+    $ref: paths/Storefront/orders@{id}@cancellation.yaml
+  '/Storefront/orders/{id}/pause':
+    $ref: paths/Storefront/orders@{id}@pause.yaml
+  '/Storefront/payment':
+    $ref: paths/Storefront/payment.yaml
+  '/Storefront/payment-instruments':
+    $ref: paths/Storefront/payment-instruments.yaml
+  '/Storefront/payment-instruments/{id}':
+    $ref: paths/Storefront/payment-instruments@{id}.yaml
+  '/Storefront/payment-instruments/{id}/deactivation':
+    $ref: paths/Storefront/payment-instruments@{id}@deactivation.yaml
+  '/Storefront/payment-instruments/{id}/setup':
+    $ref: paths/Storefront/payment-instruments@{id}@setup.yaml
+  '/Storefront/payout-requests':
+    $ref: ./paths/Storefront/payout-requests.yaml
+  '/Storefront/payout-requests/{id}':
+    $ref: paths/Storefront/payout-requests@{id}.yaml
+  '/Storefront/plans':
+    $ref: paths/Storefront/plans.yaml
+  '/Storefront/plans/{id}':
+    $ref: paths/Storefront/plans@{id}.yaml
+  '/Storefront/products':
+    $ref: paths/Storefront/products.yaml
+  '/Storefront/products/{id}':
+    $ref: paths/Storefront/products@{id}.yaml
+  '/Storefront/purchase':
+    $ref: paths/Storefront/purchase.yaml
+  '/Storefront/preview-purchase':
+    $ref: paths/Storefront/preview-purchase.yaml
+  '/Storefront/quotes/{id}':
+    $ref: paths/Storefront/quotes@{id}.yaml
+  '/Storefront/quotes/{id}/accept':
+    $ref: paths/Storefront/quotes@{id}@accept.yaml
+  '/Storefront/quotes/{id}/reject':
+    $ref: paths/Storefront/quotes@{id}@reject.yaml
+  '/Storefront/ready-to-pay':
+    $ref: paths/Storefront/ready-to-pay.yaml
+  '/Storefront/ready-to-payout':
+    $ref: paths/Storefront/ready-to-payout.yaml
+  '/Storefront/register':
+    $ref: paths/Storefront/register.yaml
+  '/Storefront/transactions':
+    $ref: paths/Storefront/transactions.yaml
+  '/Storefront/transactions/{id}':
+    $ref: paths/Storefront/transactions@{id}.yaml
+  '/Storefront/transactions/{id}/{token}/continue':
+    $ref: paths/Storefront/transactions@{id}@{token}@continue.yaml
+  '/Storefront/transactions/{id}/{token}/bypass':
+    $ref: paths/Storefront/transactions@{id}@{token}@bypass.yaml
+  '/Storefront/websites/{id}':
+    $ref: paths/Storefront/websites@{id}.yaml
   '/customers/{id}/edd-score':
     $ref: paths/customers@{id}@edd-score.yaml
   '/customers/{id}/edd-timeline':

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -519,9 +519,21 @@ tags:
     description: |-
       Use this operation to check the status of the Rebilly API.
       No authentication is required.
+  - name: Storefront invoices
+    description: |-
+      Use these operations to access Storefront invoices.
+      APIs intended to be used directly from an untrusted browser.
   - name: Storefront products
     description: |-
       Use these operations to access Storefront products.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront transactions
+    description: |-
+      Use these operations to access Storefront transactions.
+      APIs intended to be used directly from an untrusted browser.
+  - name: Storefront websites
+    description: |-
+      Use these operations to access Storefront websites.
       APIs intended to be used directly from an untrusted browser.
   - name: Tags
     description: Use tags to organize and categorize customers or KYC documents based on keywords.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -506,65 +506,160 @@ tags:
   - name: Storefront account
     description: |-
       Use these operations to manage Storefront accounts.
-      An account in which you are subscribed to in order to use the Rebilly product.
-      APIs intended to be used directly from an untrusted browser.
+      A Storefront account is an account that the customer is subscribed to in order to use the Rebilly product.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use Storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Create a session with username and password](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront billing portals
     description: |-
-      Use these operations to access Storefront billing portals.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront billing portals.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront checkout forms
     description: |-
-      Use these operations to access Storefront checkout forms.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront checkout forms.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront custom fields
     description: |-
-      Use these operations to access Storefront custom fields.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront custom fields.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront deposits
     description: |-
-      Use these operations to access Storefront deposits.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront deposits.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront invoices
     description: |-
-      Use these operations to access Storefront invoices.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront invoices.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront KYC documents
     description: |-
-      Use these operations to access Storefront KYC documents.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront KYC documents.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront orders
     description: |-
-      Use these operations to access Storefront orders.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront orders.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront payment instruments
     description: |-
-      Use these operations to access Storefront payment instruments.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront payment instruments.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront plans
     description: |-
-      Use these operations to access Storefront plans.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront plans.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront products
     description: |-
-      Use these operations to access Storefront products.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront products.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, 
+      see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront purchases
     description: |-
-      Use these operations to manage Storefront purchases.
+      Use these operations to manage storefront purchases.
       Purchases are transactions that have been executed related to the purchase of goods or services.
-      APIs intended to be used directly from an untrusted browser.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront quotes
     description: |-
-      Use these operations to access Storefront quotes.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront quotes.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, the customer must be issued a JWT with limited permissions. For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront transactions
     description: |-
       Use these operations to access Storefront transactions.
-      APIs intended to be used directly from an untrusted browser.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Storefront websites
     description: |-
-      Use these operations to access Storefront websites.
-      APIs intended to be used directly from an untrusted browser.
+      Use these operations to access storefront websites.
+      
+      Storefront operations interact directly with the customer, 
+      and provide the customer with access to their own data. 
+      
+      To use storefront operations, 
+      the customer must be issued a JWT with limited permissions. 
+      For more information, see [Customer authentication](https://www.rebilly.com/catalog/all/Storefront-account/StorefrontPostLogin) and [Exchange an authentication token](https://www.rebilly.com/catalog/all/Customer-authentication/PostAuthenticationTokenExchange).
+      Storefront operations are intended to be used directly from an untrusted browser.
   - name: Tags
     description: Use tags to organize and categorize customers or KYC documents based on keywords.
   - name: Tracking

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -405,8 +405,6 @@ tags:
       For more information, see [My organizations and websites](https://www.rebilly.com/docs/settings/organizations-and-websites/).
 
       Note: No data, including organizations, is shared between the live and sandbox environments.
-  - name: Password reset
-    description: Use these operations to manage password resets for a user or organization.
   - name: Payment instruments
     description: |-
       Use these operations to manage payment instruments.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -83,7 +83,7 @@ components:
     CustomerJWT:
       description: |-
         To create a JSON Web Token (JWT) using Storefront authentication,
-        see [Create a session with username and password](https://all-rebilly.redoc.ly/tag/Authentication/operation/StorefrontPostLogin).
+        see [Create a session with username and password](https://all-rebilly.redoc.ly/tag/Storefront-account/operation/StorefrontPostLogin).
 
         Usage format: `Bearer <JWT>`.
       type: http

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -91,10 +91,6 @@ components:
       bearerFormat: JWT
 
 tags:
-  - name: Account
-    description: |-
-      Use these operations to manage Rebilly accounts.
-      An account in which you are subscribed to in order to use the Rebilly product.
   - name: Allowlists
     description: |-
       Use allowlists to exclude specific customer attribute data from risk score checks.
@@ -126,8 +122,6 @@ tags:
       Use these operations to install or uninstall apps from the Rebilly App Store to your Rebilly account, and to manage application instances.
       An application user is a person or organization that uses an app that is installed from the Rebilly App Store.
       For more information, see [Install or uninstall an app](https://www.rebilly.com/docs/dev-docs/install-an-app/).
-  - name: Authentication
-    description: Use these operations to manage the process of confirming the identity of users that are attempting to access resources.
   - name: Balance transactions
     description: |-
       Use these operations to view and manage balance transactions.
@@ -286,10 +280,6 @@ tags:
 
       Email notifications can also be used to notify teammates about new customers, blocklist matches, risk score changes, and more.
       For more information, see [Email notifications](https://www.rebilly.com/docs/automations/email-notifications/).
-  - name: Email verification
-    description: |-
-      Use these operations to manage email verification.
-      Email verification is the process of confirming that an email address exists and is associated with an individual.
   - name: External identifiers
     description: |-
       Use external identifier operations to associate entities such as customers,
@@ -460,10 +450,6 @@ tags:
     description: |-
       Use these operations to manage user profiles.
       A profile represents the person that is signed in to Rebilly.
-  - name: Purchases
-    description: |-
-      Use these operations to manage purchases.
-      Purchases are transactions that have been executed related to the purchase of goods or services.
   - name: Quotes
     description: |-
       Use quote operations to create and manage quotations.
@@ -521,7 +507,8 @@ tags:
       No authentication is required.
   - name: Storefront account
     description: |-
-      Use these operations to access Storefront account.
+      Use these operations to manage Rebilly Storefront accounts.
+      An account in which you are subscribed to in order to use the Rebilly product.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront billing portals
     description: |-
@@ -565,7 +552,8 @@ tags:
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront purchases
     description: |-
-      Use these operations to access Storefront purchases.
+      Use these operations to manage Storefront purchases.
+      Purchases are transactions that have been executed related to the purchase of goods or services.
       APIs intended to be used directly from an untrusted browser.
   - name: Storefront quotes
     description: |-

--- a/openapi/paths/storefront/account.yaml
+++ b/openapi/paths/storefront/account.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Account
+    - Storefront account
   summary: Retrieve Account
   operationId: StorefrontGetAccount
   x-sdk-operation-name: get
@@ -26,7 +26,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Account
+    - Storefront account
   summary: Update Account
   operationId: StorefrontPatchAccount
   x-sdk-operation-name: update
@@ -39,7 +39,6 @@ patch:
         schema:
           allOf:
             - $ref: ../../components/schemas/StorefrontAccount.yaml
-
   responses:
     200:
       description: Account updated.

--- a/openapi/paths/storefront/account@forgot-password.yaml
+++ b/openapi/paths/storefront/account@forgot-password.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Password reset
+    - Storefront account
   summary: Request a password reset
   operationId: StorefrontPostForgotPassword
   x-sdk-operation-name: requestPasswordReset

--- a/openapi/paths/storefront/account@password.yaml
+++ b/openapi/paths/storefront/account@password.yaml
@@ -2,7 +2,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Account
+    - Storefront account
   summary: Change an account password
   operationId: StorefrontPatchAccountPassword
   x-sdk-operation-name: changePassword

--- a/openapi/paths/storefront/account@resend-verification.yaml
+++ b/openapi/paths/storefront/account@resend-verification.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Email verification
+    - Storefront account
   summary: Resend email verification
   operationId: StorefrontPostAccountResendVerification
   x-sdk-operation-name: resendEmailVerification

--- a/openapi/paths/storefront/account@reset-password@{token}.yaml
+++ b/openapi/paths/storefront/account@reset-password@{token}.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Password reset
+    - Storefront account
   summary: Finish password reset
   operationId: StorefrontPostResetPassword
   x-sdk-operation-name: confirmPasswordReset

--- a/openapi/paths/storefront/account@verification@{token}.yaml
+++ b/openapi/paths/storefront/account@verification@{token}.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Email verification
+    - Storefront account
   summary: Verify an account email
   operationId: StorefrontPostAccountVerification
   x-sdk-operation-name: verifyEmail

--- a/openapi/paths/storefront/billing-portals@{slug}.yaml
+++ b/openapi/paths/storefront/billing-portals@{slug}.yaml
@@ -11,7 +11,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Billing portals
+    - Storefront billing portals
   summary: Retrieve a billing portal
   operationId: StorefrontGetBillingPortal
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/checkout-forms@{id}.yaml
+++ b/openapi/paths/storefront/checkout-forms@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Checkout forms
+    - Storefront checkout forms
   summary: Retrieve a checkout form
   operationId: StorefrontGetCheckoutForm
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/custom-fields@{resource}.yaml
+++ b/openapi/paths/storefront/custom-fields@{resource}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Custom fields
+    - Storefront custom fields
   summary: Retrieve custom fields
   operationId: StorefrontGetCustomFieldCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/deposit-requests@{id}.yaml
+++ b/openapi/paths/storefront/deposit-requests@{id}.yaml
@@ -5,7 +5,7 @@ get:
     - Storefront
   x-badge: Experimental
   tags:
-    - Deposits
+    - Storefront deposits
   summary: Retrieve a deposit request
   operationId: StorefrontGetDepositRequest
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/deposit-strategies@{id}.yaml
+++ b/openapi/paths/storefront/deposit-strategies@{id}.yaml
@@ -5,7 +5,7 @@ get:
     - Storefront
   x-badge: Experimental
   tags:
-    - Deposits
+    - Storefront deposits
   summary: Retrieve a deposit strategy
   operationId: StorefrontGetDepositStrategy
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/deposit.yaml
+++ b/openapi/paths/storefront/deposit.yaml
@@ -3,7 +3,7 @@ post:
     - Storefront
   x-badge: Experimental
   tags:
-    - Deposits
+    - Storefront deposits
   summary: Create a deposit
   operationId: StorefrontPostDeposit
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/invoices.yaml
+++ b/openapi/paths/storefront/invoices.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Invoices
+    - Storefront invoices
   summary: Retrieve invoices
   operationId: StorefrontGetInvoiceCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/invoices@{id}.yaml
+++ b/openapi/paths/storefront/invoices@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Invoices
+    - Storefront invoices
   summary: Retrieve a Invoice
   operationId: StorefrontGetInvoice
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/kyc-documents.yaml
+++ b/openapi/paths/storefront/kyc-documents.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Retrieve KYC documents
   operationId: StorefrontGetKycDocumentCollection
   x-sdk-operation-name: getAll
@@ -36,7 +36,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Create a KYC document
   operationId: StorefrontPostKycDocument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/kyc-documents@{id}.yaml
+++ b/openapi/paths/storefront/kyc-documents@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Retrieve a KYC Document
   operationId: StorefrontGetKycDocument
   x-sdk-operation-name: get
@@ -28,7 +28,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Update a KYC document
   operationId: StorefrontPatchKycDocument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/kyc-liveness-sessions.yaml
+++ b/openapi/paths/storefront/kyc-liveness-sessions.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Create a KYC liveness session
   operationId: StorefrontPostKycLivenessSession
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/kyc-liveness-sessions@{id}.yaml
+++ b/openapi/paths/storefront/kyc-liveness-sessions@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Retrieve a KYC liveness session
   operationId: StorefrontGetKycLivenessSession
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/kyc-liveness-sessions@{id}@finish.yaml
+++ b/openapi/paths/storefront/kyc-liveness-sessions@{id}@finish.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Finish KYC liveness session
   operationId: StorefrontPostKycLivenessSessionFinish
   x-sdk-operation-name: finish

--- a/openapi/paths/storefront/kyc-requests@{id}.yaml
+++ b/openapi/paths/storefront/kyc-requests@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - KYC documents
+    - Storefront KYC documents
   summary: Retrieve a KYC request
   operationId: StorefrontGetKycRequest
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/login.yaml
+++ b/openapi/paths/storefront/login.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Authentication
+    - Storefront account
   summary: Create a session with username and password
   operationId: StorefrontPostLogin
   x-sdk-operation-name: login

--- a/openapi/paths/storefront/logout.yaml
+++ b/openapi/paths/storefront/logout.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Authentication
+    - Storefront account
   summary: Destroys the user's current session
   operationId: StorefrontPostLogout
   x-sdk-operation-name: logout

--- a/openapi/paths/storefront/orders.yaml
+++ b/openapi/paths/storefront/orders.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Orders
+    - Storefront orders
   summary: Retrieve orders
   operationId: StorefrontGetOrderCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/orders@{id}.yaml
+++ b/openapi/paths/storefront/orders@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Orders
+    - Storefront orders
   summary: Retrieve an order
   operationId: StorefrontGetOrder
   x-sdk-operation-name: get
@@ -28,7 +28,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Orders
+    - Storefront orders
   summary: Update an order
   operationId: StorefrontPatchOrder
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/orders@{id}@cancellation.yaml
+++ b/openapi/paths/storefront/orders@{id}@cancellation.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Orders
+    - Storefront orders
   summary: Cancel an order
   operationId: StorefrontPostOrderCancellation
   x-sdk-operation-name: cancel

--- a/openapi/paths/storefront/orders@{id}@pause.yaml
+++ b/openapi/paths/storefront/orders@{id}@pause.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Orders
+    - Storefront orders
   summary: Pause a subscription order
   operationId: StorefrontPostOrderPause
   x-sdk-operation-name: pause

--- a/openapi/paths/storefront/payment-instruments.yaml
+++ b/openapi/paths/storefront/payment-instruments.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Retrieve payment instruments
   operationId: StorefrontGetPaymentInstrumentCollection
   x-sdk-operation-name: getAll
@@ -39,7 +39,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Create a payment instrument
   operationId: StorefrontPostPaymentInstrument
   x-sdk-operation-name: create

--- a/openapi/paths/storefront/payment-instruments@{id}.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Retrieve a payment instrument
   operationId: StorefrontGetPaymentInstrument
   x-sdk-operation-name: get
@@ -38,7 +38,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Update payment instrument
   operationId: StorefrontPatchPaymentInstrument
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@deactivation.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Deactivate a payment instrument
   operationId: StorefrontPostPaymentInstrumentDeactivation
   x-sdk-operation-name: deactivate

--- a/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
+++ b/openapi/paths/storefront/payment-instruments@{id}@setup.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Retrieve a payment instrument setup transaction
   operationId: StorefrontGetPaymentInstrumentSetup
   x-sdk-operation-name: getSetupTransaction
@@ -31,7 +31,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Payment instruments
+    - Storefront payment instruments
   summary: Create a setup payment instrument transaction
   operationId: StorefrontPostPaymentInstrumentSetup
   x-sdk-operation-name: setup

--- a/openapi/paths/storefront/payment.yaml
+++ b/openapi/paths/storefront/payment.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Purchases
+    - Storefront purchases
   summary: Perform a payment
   operationId: StorefrontPostPayment
   x-sdk-operation-name: payment

--- a/openapi/paths/storefront/payout-requests.yaml
+++ b/openapi/paths/storefront/payout-requests.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Retrieve payout requests
   operationId: StorefrontGetPayoutRequestCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/payout-requests@{id}.yaml
+++ b/openapi/paths/storefront/payout-requests@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Retrieve a payout request
   operationId: StorefrontGetPayoutRequest
   x-sdk-operation-name: get
@@ -28,7 +28,7 @@ patch:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Update a payout request
   operationId: StorefrontPatchPayoutRequest
   x-sdk-operation-name: update

--- a/openapi/paths/storefront/plans.yaml
+++ b/openapi/paths/storefront/plans.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Plans
+    - Storefront plans
   summary: Retrieve a list of plans
   operationId: StorefrontGetPlanCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/plans@{id}.yaml
+++ b/openapi/paths/storefront/plans@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Plans
+    - Storefront plans
   summary: Retrieve a plan
   operationId: StorefrontGetPlan
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/preview-purchase.yaml
+++ b/openapi/paths/storefront/preview-purchase.yaml
@@ -3,7 +3,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Purchases
+    - Storefront purchases
   summary: Preview a purchase
   operationId: StorefrontPostPreviewPurchase
   x-sdk-operation-name: preview

--- a/openapi/paths/storefront/products.yaml
+++ b/openapi/paths/storefront/products.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Products
+    - Storefront products
   summary: Retrieve products
   operationId: StorefrontGetProductCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/products@{id}.yaml
+++ b/openapi/paths/storefront/products@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Products
+    - Storefront products
   summary: Retrieve a product
   operationId: StorefrontGetProduct
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/purchase.yaml
+++ b/openapi/paths/storefront/purchase.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Purchases
+    - Storefront purchases
   summary: Make a purchase
   operationId: StorefrontPostPurchase
   x-sdk-operation-name: purchase

--- a/openapi/paths/storefront/quotes@{id}.yaml
+++ b/openapi/paths/storefront/quotes@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Quotes
+    - Storefront quotes
   summary: Retrieve a quote
   operationId: StorefrontGetQuote
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/quotes@{id}@accept.yaml
+++ b/openapi/paths/storefront/quotes@{id}@accept.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Quotes
+    - Storefront quotes
   summary: Accept a quote
   operationId: StorefrontPostQuoteAcceptance
   x-sdk-operation-name: accept

--- a/openapi/paths/storefront/quotes@{id}@reject.yaml
+++ b/openapi/paths/storefront/quotes@{id}@reject.yaml
@@ -4,7 +4,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Quotes
+    - Storefront quotes
   summary: Reject a quote
   operationId: StorefrontPostQuoteRejection
   x-sdk-operation-name: reject

--- a/openapi/paths/storefront/ready-to-pay.yaml
+++ b/openapi/paths/storefront/ready-to-pay.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Purchases
+    - Storefront purchases
   summary: Ready to pay
   operationId: StorefrontPostReadyToPay
   x-sdk-operation-name: readyToPay

--- a/openapi/paths/storefront/ready-to-payout.yaml
+++ b/openapi/paths/storefront/ready-to-payout.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Purchases
+    - Storefront purchases
   summary: Ready to payout
   operationId: StorefrontPostReadyToPayout
   x-sdk-operation-name: readyToPayout

--- a/openapi/paths/storefront/register.yaml
+++ b/openapi/paths/storefront/register.yaml
@@ -2,7 +2,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Account
+    - Storefront account
   summary: Register Account
   operationId: StorefrontPostRegister
   x-sdk-operation-name: register

--- a/openapi/paths/storefront/transactions.yaml
+++ b/openapi/paths/storefront/transactions.yaml
@@ -2,7 +2,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Retrieve transactions
   operationId: StorefrontGetTransactionCollection
   x-sdk-operation-name: getAll

--- a/openapi/paths/storefront/transactions@{id}.yaml
+++ b/openapi/paths/storefront/transactions@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Retrieve a transaction
   operationId: StorefrontGetTransaction
   x-sdk-operation-name: get

--- a/openapi/paths/storefront/transactions@{id}@{token}@bypass.yaml
+++ b/openapi/paths/storefront/transactions@{id}@{token}@bypass.yaml
@@ -5,7 +5,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Skip a transaction KYC verification
   operationId: StorefrontPostKycRequestBypass
   x-sdk-operation-name: skipKyc

--- a/openapi/paths/storefront/transactions@{id}@{token}@continue.yaml
+++ b/openapi/paths/storefront/transactions@{id}@{token}@continue.yaml
@@ -5,7 +5,7 @@ post:
   x-products:
     - Storefront
   tags:
-    - Transactions
+    - Storefront transactions
   summary: Finish a transaction KYC verification
   operationId: StorefrontPostKycRequestContinue
   x-sdk-operation-name: finishKyc

--- a/openapi/paths/storefront/websites@{id}.yaml
+++ b/openapi/paths/storefront/websites@{id}.yaml
@@ -4,7 +4,7 @@ get:
   x-products:
     - Storefront
   tags:
-    - Websites
+    - Storefront websites
   summary: Retrieve a website
   operationId: StorefrontGetWebsite
   x-sdk-operation-name: get


### PR DESCRIPTION
## Summary
Rename Storefront tags so Core API and Storefront operations with same name are not confused with each other.

Combined operations with Account, Authentication, Email verification, Password reset tags into `Storefront account` tag

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
