### PR TITLE
docs(js): Update outdated subscription code examples

### DIFF
--- a/openapi/code_samples/JavaScript/subscriptions/post.js
+++ b/openapi/code_samples/JavaScript/subscriptions/post.js
@@ -3,7 +3,7 @@ const data = {
     customerId: 'foobar-0001',
     websiteId: 'my-main-website',
     items: [
-        { planId: 'my-plan-id', quantity: '1' },
+        { plan: { id: 'my-plan-id' }, quantity: 1 },
     ],
     // you can append this subscription to
     // an existing invoice by passing its ID
@@ -26,7 +26,6 @@ const data = {
             primary: true
         }],
     },
-    quantity: 1,
     customFields: {}
 };
 

--- a/openapi/code_samples/JavaScript/subscriptions@{id}/put.js
+++ b/openapi/code_samples/JavaScript/subscriptions@{id}/put.js
@@ -2,7 +2,9 @@
 const data = {
     customerId: 'foobar-0001',
     websiteId: 'my-main-website',
-    planId: 'my-plan-id',
+    items: [
+        { plan: { id: 'my-plan-id' }, quantity: 1 },
+    ],
     // you can append this subscription to
     // an existing invoice by passing its ID
     initialInvoiceId: 'my-existing-invoice-id',
@@ -24,7 +26,6 @@ const data = {
             primary: true
         }],
     },
-    quantity: 1,
     customFields: {}
 };
 


### PR DESCRIPTION
## Summary
The JS code samples for the subscription entity is out of date and does not match the current `js-sdk` types.

## Checklist

- [x] Writing style
- [x] API design standards
