### PR TITLE
fix: Make _links of plan schemas read only

### DIFF
--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -85,6 +85,7 @@ properties:
   _links:
     type: array
     description: Related links.
+    readOnly: true
     items:
       type: object
       properties:

--- a/openapi/components/schemas/SubscriptionOrderPlan.yaml
+++ b/openapi/components/schemas/SubscriptionOrderPlan.yaml
@@ -202,6 +202,7 @@ properties:
   _links:
     type: array
     description: Related links.
+    readOnly: true
     items:
       type: object
       properties:

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -129,6 +129,7 @@ properties:
   _links:
     type: array
     description: Related links.
+    readOnly: true
     items:
       type: object
       properties:


### PR DESCRIPTION
## Summary
Make _links of plan schemas read only

## Checklist

- [x] Writing style
- [x] API design standards
