### PR TITLE
Add  `humanMessage` and `humanDescription` to StorefrontTransaction

### DIFF
--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -213,6 +213,16 @@ properties:
             type:
               - 'string'
               - 'null'
+          displayCode:
+            description: Gateway response code to display to the end-user.
+            type:
+              - 'string'
+              - 'null'
+          displayMessage:
+            description: Gateway response message to display to the end-user.
+            type:
+              - 'string'
+              - 'null'
       avsResponse:
         description: Gateway Address Verification System (AVS) response.
         type: object

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -213,12 +213,12 @@ properties:
             type:
               - 'string'
               - 'null'
-          displayMessage:
+          humanMessage:
             description: Gateway response message to display to the end-user.
             type:
               - 'string'
               - 'null'
-          displayDescription:
+          humanDescription:
             description: Gateway response description with more detailed information to display to the end-user.
             type:
               - 'string'

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -214,12 +214,12 @@ properties:
               - 'string'
               - 'null'
           humanMessage:
-            description: Gateway response message to display to the end-user.
+            description: Human-readable gateway response message.
             type:
               - 'string'
               - 'null'
           humanDescription:
-            description: Gateway response description with more detailed information to display to the end-user.
+            description: Human-readable gateway response description with more detailed information.
             type:
               - 'string'
               - 'null'

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -213,11 +213,6 @@ properties:
             type:
               - 'string'
               - 'null'
-          displayCode:
-            description: Gateway response code to display to the end-user.
-            type:
-              - 'string'
-              - 'null'
           displayMessage:
             description: Gateway response message to display to the end-user.
             type:

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -218,6 +218,11 @@ properties:
             type:
               - 'string'
               - 'null'
+          displayDescription:
+            description: Gateway response description with more detailed information to display to the end-user.
+            type:
+              - 'string'
+              - 'null'
       avsResponse:
         description: Gateway Address Verification System (AVS) response.
         type: object


### PR DESCRIPTION
## Summary
Add two new fields for the StorefrontTransaction gateway response object.

## Links

## Checklist

- [x] Writing style
- [x] API design standards
