### PR TITLE
Remove Worldpay enableStoredCredentials in favour of enforceStoredCredentials

### DIFF
--- a/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
+++ b/openapi/components/schemas/GatewayAccountConfig/Worldpay.yaml
@@ -63,10 +63,6 @@ allOf:
             description: Automatic capture delay in hours.
             minimum: 0
             default: 0
-          enableStoredCredentials:
-            type: boolean
-            description: Specifies whether to enable stored credentials.
-            default: false
           enforceStoredCredentials:
             type: string
             description: |-


### PR DESCRIPTION
No merchants are using enableStoredCredentials