### PR TITLE
Add missing required field to sample

### DIFF
--- a/openapi/code_samples/JavaScript/transactions/post.js
+++ b/openapi/code_samples/JavaScript/transactions/post.js
@@ -1,6 +1,7 @@
 // first set the properties for the new transaction
 const data = {
     customerId: 'foobar-0001',
+    type: 'sale',
     websiteId: 'my-main-website',
     paymentInstrument: {
         method: 'payment-card',


### PR DESCRIPTION
## Summary

This pull request adds a missing field that is required for a JavaScript example, to the [Create a transaction](https://www.rebilly.com/catalog/all/Transactions/PostTransaction/) API operation.

## Checklist

- [X] Writing style
- [X] API design standards
