### PR TITLE
Add $1 auth/void setup instruction

### DIFF
--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -356,6 +356,7 @@ properties:
     enum:
       - authorize
       - authorize-and-void
+      - authorize-and-void-one-dollar
       - sca
       - do-nothing
     x-enumDescriptions:


### PR DESCRIPTION
## Summary

Support $0 setup transactions on gateway accounts that do not allow $0 authorize.  This would only apply for USD, CAD, EUR, GBP.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [ ] Writing style
- [ ] API design standards
