### PR TITLE
Update description for authorize-and-void setup instruction

### DIFF
--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -363,7 +363,7 @@ properties:
         Creates an `authorize` transaction in the amount and currency of the request.
       authorize-and-void: |-
         Creates an `authorize` transaction followed by a `void`, if the `authorize` is approved.
-        If the request amount is $0, then a $1 authorize is created.  Otherwise the request amount is used.
+        If the request amount is $0, then a $1 authorize is created. Otherwise the request amount is used.
       sca: |-
         Uses Strong Customer Authentication (SCA) without an `authorize` transaction.
         SCA includes 3DS, and specific wallet behavior,

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -361,11 +361,9 @@ properties:
     x-enumDescriptions:
       authorize: |-
         Creates an `authorize` transaction in the amount and currency of the request.
-        This is used when a gateway account is configured for Strong Customer Authentication (SCA).
       authorize-and-void: |-
-        Creates an `authorize` transaction in the amount and currency of the request,
-        followed by a `void`, if the `authorize` is approved.
-        This is used when a gateway account is configured for Strong Customer Authentication (SCA).
+        Creates an `authorize` transaction followed by a `void`, if the `authorize` is approved.
+        If the request amount is $0, then a $1 authorize is created.  Otherwise the request amount is used.
       sca: |-
         Uses Strong Customer Authentication (SCA) without an `authorize` transaction.
         SCA includes 3DS, and specific wallet behavior,


### PR DESCRIPTION
## Summary

Do a $1 auth/void on a $0 setup transaction with "authorize-and-void" instruction. 

## Checklist

- [x] Writing style
- [x] API design standards
