### PR TITLE
Add subscription-items-changed event

### DIFF
--- a/openapi/components/requestBodies/Webhooks/SubscriptionWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/SubscriptionWebhook.yaml
@@ -26,6 +26,7 @@ content:
             - subscription-trial-ended
             - subscription-upgraded
             - order-delinquency-reached
+            - subscription-items-changed
         _embedded:
           type: object
           description: Embedded objects.

--- a/openapi/components/schemas/EventType.yaml
+++ b/openapi/components/schemas/EventType.yaml
@@ -65,6 +65,7 @@ enum:
   - subscription-churned
   - subscription-created
   - subscription-downgraded
+  - subscription-items-changed
   - subscription-modified
   - subscription-pause-created
   - subscription-pause-modified

--- a/openapi/components/schemas/GlobalEventType.yaml
+++ b/openapi/components/schemas/GlobalEventType.yaml
@@ -78,6 +78,7 @@ enum:
   - subscription-canceled
   - subscription-churned
   - subscription-downgraded
+  - subscription-items-changed
   - subscription-modified
   - subscription-pause-created
   - subscription-pause-modified

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1653,6 +1653,9 @@ webhooks:
   subscription-downgraded:
     post:
       $ref: ./webhooks/subscription-downgraded.yaml
+  subscription-items-changed:
+    post:
+      $ref: ./webhooks/subscription-items-changed.yaml
   subscription-modified:
     post:
       $ref: ./webhooks/subscription-modified.yaml

--- a/openapi/webhooks/subscription-items-changed.yaml
+++ b/openapi/webhooks/subscription-items-changed.yaml
@@ -1,4 +1,4 @@
-summary: Subscription items changed.
+summary: Subscription items changed
 operationId: subscription-items-changed
 x-products:
   - Core

--- a/openapi/webhooks/subscription-items-changed.yaml
+++ b/openapi/webhooks/subscription-items-changed.yaml
@@ -1,0 +1,11 @@
+summary: Subscription items changed.
+operationId: subscription-items-changed
+x-products:
+  - Core
+tags:
+  - Orders
+requestBody:
+  $ref: ../components/requestBodies/Webhooks/SubscriptionWebhook.yaml
+responses:
+  '2xx':
+    description: Returns any 2xx status to indicate that data is received.


### PR DESCRIPTION
## Summary

This PR adds subscription-items-changed event and adds it to webhooks

## Checklist

- [x] Writing style
- [x] API design standards
