### PR TITLE
Add PatchPayoutRequest to update payout request status

### DIFF
--- a/openapi/components/requestBodies/PatchPayoutRequest.yaml
+++ b/openapi/components/requestBodies/PatchPayoutRequest.yaml
@@ -4,7 +4,6 @@ properties:
   status:
     description: Status of the request.
     type: string
-    readOnly: true
     enum:
       - rejected
       - canceled

--- a/openapi/components/requestBodies/PatchPayoutRequest.yaml
+++ b/openapi/components/requestBodies/PatchPayoutRequest.yaml
@@ -1,0 +1,13 @@
+type: object
+description: Payout request.
+properties:
+  status:
+    description: Status of the request.
+    type: string
+    readOnly: true
+    enum:
+      - rejected
+      - canceled
+    x-enumDescriptions:
+      rejected: Request is rejected by merchant.
+      canceled: Request is canceled by customer.

--- a/openapi/components/schemas/PayoutRequest.yaml
+++ b/openapi/components/schemas/PayoutRequest.yaml
@@ -51,11 +51,15 @@ properties:
       - instrument-selected
       - partially-fulfilled
       - fulfilled
+      - rejected
+      - canceled
     x-enumDescriptions:
       pending: Request is awaiting customer's selection of the payment instrument or fulfillment.
       instrument-selected: Request has a selected payment instrument and is awaiting fulfillment.
       partially-fulfilled: Request is partially paid out when `availableAmount` is less than `amount`.
       fulfilled: Request is fully paid out when `availableAmount` reaches zero.
+      rejected: Request is rejected by merchant.
+      canceled: Request is canceled by customer.
   selectPaymentInstrumentUrl:
     readOnly: true
     type: string

--- a/openapi/paths/payout-requests@{id}.yaml
+++ b/openapi/paths/payout-requests@{id}.yaml
@@ -60,3 +60,35 @@ put:
       $ref: ../components/responses/NotFound.yaml
     '422':
       $ref: ../components/responses/ValidationError.yaml
+patch:
+  x-products:
+    - Core
+  tags:
+    - Transactions
+  summary: Update a payout request
+  operationId: PatchPayoutRequest
+  x-sdk-operation-name: patch
+  description: Updates a payout request with a specified ID.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/requestBodies/PatchPayoutRequest.yaml
+  responses:
+    '200':
+      description: Payout request updated.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/PayoutRequest.yaml
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../components/responses/Forbidden.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+    '409':
+      $ref: ../components/responses/Conflict.yaml
+    '422':
+      $ref: ../components/responses/ValidationError.yaml


### PR DESCRIPTION
## Summary
Add PatchPayoutRequest to update payout request status to `rejected` or `canceled`

## Links
Alternative to https://github.com/Rebilly/api-definitions/pull/1798

## Checklist

- [x] Writing style
- [x] API design standards
