### PR TITLE
Add pending status to Dispute

### DIFF
--- a/openapi/components/requestBodies/Dispute.yaml
+++ b/openapi/components/requestBodies/Dispute.yaml
@@ -225,6 +225,7 @@ content:
             - won
             - lost
             - unknown
+            - pending
         postedTime:
           description: Date and time when the dispute is posted.
           type: string

--- a/openapi/components/schemas/Dispute.yaml
+++ b/openapi/components/schemas/Dispute.yaml
@@ -83,6 +83,7 @@ properties:
       - won
       - lost
       - unknown
+      - pending
   postedTime:
     description: Date and time when the dispute is posted.
     type: string


### PR DESCRIPTION
## Summary
Add `pending` status as a Dispute status.

This accounts for Disputes (eg. Adyen disputes) where a dispute's first chargeback has been decided, but the window for a possible second chargeback is still open. When that window closes, another dispute update happens where the final outcome statusis decided (eg. won/lost).

## Links
N/A

## Checklist

- [x] Writing style
- [x] API design standards
