### PR TITLE
Add expand parameter PostSubscriptionItemsChange

### DIFF
--- a/openapi/paths/subscriptions@{id}@change-items.yaml
+++ b/openapi/paths/subscriptions@{id}@change-items.yaml
@@ -8,6 +8,8 @@ post:
   summary: Change subscription order items
   operationId: PostSubscriptionItemsChange
   x-sdk-operation-name: changeItems
+  parameters:
+    - $ref: ../components/parameters/subscriptionExpand.yaml
   description: Changes subscription order items or quantities, and designates if or when pro-rata credits should be given.
   requestBody:
     content:


### PR DESCRIPTION
## Summary
Add expand parameter PostSubscriptionItemsChange so that expanding upcoming invoice can be used to replace deprecated subscription `lineItems` property.

## Links
Internal discussion

## Checklist

- [x] Writing style
- [x] API design standards
