### PR TITLE
Fix billing portal plan definition

### DIFF
--- a/openapi/components/schemas/BillingPortal.yaml
+++ b/openapi/components/schemas/BillingPortal.yaml
@@ -125,7 +125,9 @@ properties:
       type: object
       properties:
         plan:
-          $ref: ./FlexiblePlan.yaml
+          anyOf:
+            - $ref: ./OriginalPlan.yaml
+            - $ref: ./FlexiblePlan.yaml
         status:
           type: string
           description: |-
@@ -145,7 +147,9 @@ properties:
       description: Add-on plan details.
       properties:
         plan:
-          $ref: ./FlexiblePlan.yaml
+          anyOf:
+            - $ref: ./OriginalPlan.yaml
+            - $ref: ./FlexiblePlan.yaml
         status:
           type: string
           description: |-

--- a/openapi/components/schemas/FlexiblePlan.yaml
+++ b/openapi/components/schemas/FlexiblePlan.yaml
@@ -1,7 +1,7 @@
 allOf:
   - type: object
     description: |-
-      Customize an existing plan for the current order.
+      Customize an existing plan.
 
       To create a new plan, see [Create a plan](https://www.rebilly.com/catalog/all/Plans/PostPlan).
     required:

--- a/openapi/components/schemas/OriginalPlan.yaml
+++ b/openapi/components/schemas/OriginalPlan.yaml
@@ -1,6 +1,6 @@
 type: object
 description: |-
-  Use an existing plan without changes for the current order.
+  Use an existing plan without changes.
 
   To create a new plan, see [Create a plan](https://www.rebilly.com/catalog/all/Plans/PostPlan).
 required:


### PR DESCRIPTION
## Summary

This PR fixes Billing Portal plans definitions  - allows to send plan `id` only

## Checklist

- [x] Writing style
- [x] API design standards
