### PR TITLE
Add keepTrial to storefront PostSubscriptionItemsChange

### DIFF
--- a/openapi/components/requestBodies/storefront/PostSubscriptionItemsChange.yaml
+++ b/openapi/components/requestBodies/storefront/PostSubscriptionItemsChange.yaml
@@ -36,3 +36,8 @@ properties:
     type: boolean
     default: false
     example: true
+  keepTrial:
+    description: Specifies if the subscription must retain its active trial.
+    type: boolean
+    default: false
+    example: true


### PR DESCRIPTION
## Summary

Add `keepTrial` field to storefront `PostSubscriptionItemsChange`.

## Checklist

- [x] Writing style
- [x] API design standards
