### PR TITLE
Add autopay to quotes

### DIFF
--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -382,8 +382,10 @@ properties:
     type:
       - 'boolean'
       - 'null'
-    default: null
-    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
+    description: |-
+      Specifies if payment attempts for the related subscription are made automatically.
+      If autopay is enabled, the payment is retrieved from the customer on the renewal date using the payment instrument that is set at `paymentInstrumentId`,
+      or the default payment instrument on the subscription.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -378,6 +378,12 @@ properties:
                 - 'number'
                 - 'null'
               format: double
+  autopay:
+    type:
+      - 'boolean'
+      - 'null'
+    default: null
+    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -364,6 +364,12 @@ properties:
                 - 'number'
                 - 'null'
               format: double
+  autopay:
+    type:
+      - 'boolean'
+      - 'null'
+    default: false
+    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -365,9 +365,7 @@ properties:
                 - 'null'
               format: double
   autopay:
-    type:
-      - 'boolean'
-      - 'null'
+    type: boolean
     default: false
     description: |-
       Specifies if payment attempts for the related subscription are made automatically.

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -369,7 +369,10 @@ properties:
       - 'boolean'
       - 'null'
     default: false
-    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
+    description: |-
+      Specifies if payment attempts for the related subscription are made automatically.
+      If autopay is enabled, the payment is retrieved from the customer on the renewal date using the payment instrument that is set at `paymentInstrumentId`,
+      or the default payment instrument on the subscription.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -384,6 +384,12 @@ properties:
                 - 'number'
                 - 'null'
               format: double
+  autopay:
+    type:
+      - 'boolean'
+      - 'null'
+    default: null
+    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -388,8 +388,10 @@ properties:
     type:
       - 'boolean'
       - 'null'
-    default: null
-    description: Specifies whether to automatically pay the related invoice when the quote is accepted.
+    description: |-
+      Specifies if payment attempts for the related subscription are made automatically.
+      If autopay is enabled, the payment is retrieved from the customer on the renewal date using the payment instrument that is set at `paymentInstrumentId`,
+      or the default payment instrument on the subscription.
   paymentTerms:
     description: Payment terms for the customer which are displayed on the quote.
     type: string


### PR DESCRIPTION
## Summary
This PR adds autopay option to quotes, to be used when creating, or modifying related subscription.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
