### PR TITLE
Add meteredBilling field to StorefrontPlan

### DIFF
--- a/openapi/components/schemas/StorefrontPlan.yaml
+++ b/openapi/components/schemas/StorefrontPlan.yaml
@@ -112,6 +112,39 @@ properties:
             description: Length of time.
             type: integer
             minimum: 1
+  meteredBilling:
+    type:
+      - 'object'
+      - 'null'
+    required:
+      - strategy
+    description: |-
+      Use metered billing when an exact quantity is unknown.
+      Report usage during a service period and charge customers afterwards.
+      Metered billing plans must be postpaid.
+    properties:
+      strategy:
+        type: string
+        enum:
+          - sum
+          - last
+        x-enumDescriptions:
+          sum: Total amount of reported invoice item quantity usage.
+          last: Last reported invoice item quantity usage.
+      min:
+        description: Minimum quantity that is charged at the end of a service period regardless of reported usage.
+        type:
+          - 'number'
+          - 'null'
+        format: float
+        minimum: 0.01
+      max:
+        description: Maximum quantity that is charged at the end of a service period regardless of reported usage.
+        type:
+          - 'number'
+          - 'null'
+        format: float
+        minimum: 0.01
   createdTime:
     $ref: ./CreatedTime.yaml
   updatedTime:


### PR DESCRIPTION
## Summary

[Preview](https://rebilly-website--rem-git-rem-01hnb1ejh7zd3eqe72m-32321e.preview.redocly.app/catalog/all/Storefront-plans/StorefrontGetPlan/#!t=response&c=200&path=meteredBilling)

Add `meteredBilling`  field to `StorefrontPlan`.

## Checklist

- [x] Writing style
- [x] API design standards
