### PR TITLE
Extract multiple times duplicated data export recurring value object

### DIFF
--- a/openapi/components/schemas/AmlChecksDataExport.yaml
+++ b/openapi/components/schemas/AmlChecksDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/CustomersDataExport.yaml
+++ b/openapi/components/schemas/CustomersDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/DataExportRecurring.yaml
+++ b/openapi/components/schemas/DataExportRecurring.yaml
@@ -1,0 +1,14 @@
+description: Recurring export schedule.
+type: object
+required:
+  - instruction
+properties:
+  instruction:
+    type: string
+    description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
+  start:
+    type: string
+    format: date-time
+    description: |-
+      Date and time when the first scheduled recurring export occurs.
+      The default value is now.

--- a/openapi/components/schemas/InvoiceItemsDataExport.yaml
+++ b/openapi/components/schemas/InvoiceItemsDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/InvoicesDataExport.yaml
+++ b/openapi/components/schemas/InvoicesDataExport.yaml
@@ -44,20 +44,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/RevenueAuditDataExport.yaml
+++ b/openapi/components/schemas/RevenueAuditDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/SubscriptionsDataExport.yaml
+++ b/openapi/components/schemas/SubscriptionsDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true

--- a/openapi/components/schemas/TransactionsDataExport.yaml
+++ b/openapi/components/schemas/TransactionsDataExport.yaml
@@ -43,20 +43,7 @@ properties:
     items:
       type: string
   recurring:
-    description: Recurring export schedule.
-    type: object
-    required:
-      - instruction
-    properties:
-      instruction:
-        type: string
-        description: Schedule instruction in [Recurrence Rule RFC 5545](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) format.
-      start:
-        type: string
-        format: date-time
-        description: |-
-          Date and time when the first scheduled recurring export occurs.
-          The default value is now.
+    $ref: ./DataExportRecurring.yaml
   userId:
     description: ID of the user who requested the data export.
     readOnly: true


### PR DESCRIPTION
## Summary

Previously, this object was duplicated across 7 files with the exact same structure. This extracts it to a separate reusable schema, same as `DataExportDateRange`.

## Checklist

- [x] Writing style
- [x] API design standards
