### PR TITLE
fix: Make WebhookCredential type readonly

### DIFF
--- a/openapi/components/schemas/WebhookCredential.yaml
+++ b/openapi/components/schemas/WebhookCredential.yaml
@@ -35,6 +35,7 @@ properties:
   type:
     description: Type of credential.
     type: string
+    readOnly: true
     enum:
       - webhook
   host:


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
