### PR TITLE
Add parameters to GetEventCollection

### DIFF
--- a/openapi/paths/events.yaml
+++ b/openapi/paths/events.yaml
@@ -7,6 +7,10 @@ get:
   operationId: GetEventCollection
   x-sdk-operation-name: getAll
   description: Retrieves a list of system events.
+  parameters:
+    - $ref: ../components/parameters/collectionLimit.yaml
+    - $ref: ../components/parameters/collectionOffset.yaml
+    - $ref: ../components/parameters/collectionFilter.yaml
   responses:
     '200':
       description: List of system events retrieved.


### PR DESCRIPTION
## Summary
GetEventCollection is missing parameters - this PR adds it in.

## Links
N/A

## Checklist

- [x] Writing style
- [x] API design standards
