### PR TITLE
fix: Rename Subscription endTime to churnTime

### DIFF
--- a/openapi/components/schemas/StorefrontSubscription.yaml
+++ b/openapi/components/schemas/StorefrontSubscription.yaml
@@ -292,8 +292,8 @@ properties:
     x-basic: true
     example: null
     format: date-time
-  endTime:
-    description: Date and time when the subscription ends.
+  churnTime:
+    description: Date and time when the subscription is deactivated.
     x-sortable: true
     type: string
     format: date-time

--- a/openapi/components/schemas/Subscription.yaml
+++ b/openapi/components/schemas/Subscription.yaml
@@ -163,8 +163,8 @@ properties:
     x-basic: true
     example: null
     format: date-time
-  endTime:
-    description: Date and time when the subscription ends.
+  churnTime:
+    description: Date and time when the subscription is deactivated.
     x-sortable: true
     type:
       - 'string'


### PR DESCRIPTION
## Summary
Rename Subscription endTime to churnTime to avoid confusion

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
