### PR TITLE
Flatten plan related schemas

### DIFF
--- a/openapi/components/schemas/OneTimeSalePlan.yaml
+++ b/openapi/components/schemas/OneTimeSalePlan.yaml
@@ -48,20 +48,7 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type:
-      - 'object'
-      - 'null'
-    description: Set up information of the plan.
-    required:
-      - price
-    properties:
-      price:
-        description: |-
-          Price of setting up the plan.
-          If your service charges a set up fee, specify it here.
-          To charge no set up fee, set this value to `0`.
-        type: number
-        format: double
+    $ref: ./PlanSetup.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   isActive:

--- a/openapi/components/schemas/PlanSetup.yaml
+++ b/openapi/components/schemas/PlanSetup.yaml
@@ -1,0 +1,14 @@
+type:
+  - 'object'
+  - 'null'
+description: Set up information of the plan.
+required:
+  - price
+properties:
+  price:
+    description: |-
+      Price of setting up the plan.
+      If your service charges a set up fee, specify it here.
+      To charge no set up fee, set this value to `0`.
+    type: number
+    format: double

--- a/openapi/components/schemas/PlanTrial.yaml
+++ b/openapi/components/schemas/PlanTrial.yaml
@@ -1,0 +1,32 @@
+type:
+  - 'object'
+required:
+  - price
+  - period
+properties:
+  price:
+    description: |-
+      Price of setting up a trial.
+      If your service charges a fee for a trial, specify it here.
+      To charge no trial fee, set this value to `0`.
+    type: number
+    format: double
+  period:
+    type: object
+    description: Period information.
+    required:
+      - unit
+      - length
+    properties:
+      unit:
+        description: Unit of time.
+        type: string
+        enum:
+          - day
+          - week
+          - month
+          - year
+      length:
+        description: Length of time.
+        type: integer
+        minimum: 1

--- a/openapi/components/schemas/StorefrontPlan.yaml
+++ b/openapi/components/schemas/StorefrontPlan.yaml
@@ -50,20 +50,7 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type:
-      - 'object'
-      - 'null'
-    description: Set up information of the plan.
-    required:
-      - price
-    properties:
-      price:
-        description: |-
-          Price of setting up the plan.
-          If your service charges a set up fee, specify it here.
-          To charge no set up fee, set this value to `0`.
-        type: number
-        format: double
+    $ref: ./PlanSetup.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   isActive:

--- a/openapi/components/schemas/SubscriptionPlan.yaml
+++ b/openapi/components/schemas/SubscriptionPlan.yaml
@@ -49,20 +49,7 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type:
-      - 'object'
-      - 'null'
-    description: Set up information of the plan.
-    required:
-      - price
-    properties:
-      price:
-        description: |-
-          Price of setting up the plan.
-          If your service charges a set up fee, specify it here.
-          To charge no set up fee, set this value to `0`.
-        type: number
-        format: double
+    $ref: ./PlanSetup.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   isActive:
@@ -123,41 +110,12 @@ properties:
           - prepaid
           - postpaid
   trial:
-    type:
-      - 'object'
-      - 'null'
     description: |-
       Trial configuration setting.
       If you do not want to offer a trial, set this value to `null`.
-    required:
-      - price
-      - period
-    properties:
-      price:
-        description: |-
-          Price of the trial.
-          For a free trial, set this value to `0`.
-        type: number
-        format: double
-      period:
-        type: object
-        description: Period information.
-        required:
-          - unit
-          - length
-        properties:
-          unit:
-            description: Unit of time.
-            type: string
-            enum:
-              - day
-              - week
-              - month
-              - year
-          length:
-            description: Length of time.
-            type: integer
-            minimum: 1
+    oneOf: 
+      - $ref: ./PlanTrial.yaml
+      - type: 'null'
   meteredBilling:
     type:
       - 'object'

--- a/openapi/components/schemas/TrialOnlyPlan.yaml
+++ b/openapi/components/schemas/TrialOnlyPlan.yaml
@@ -52,20 +52,7 @@ properties:
   pricing:
     $ref: ./PlanPriceFormula.yaml
   setup:
-    type:
-      - 'object'
-      - 'null'
-    description: Set up information of the plan.
-    required:
-      - price
-    properties:
-      price:
-        description: |-
-          Price of setting up the plan.
-          If your service charges a set up fee, specify it here.
-          To charge no set up fee, set this value to `0`.
-        type: number
-        format: double
+    $ref: ./PlanSetup.yaml
   customFields:
     $ref: ./ResourceCustomFields.yaml
   isActive:
@@ -83,38 +70,8 @@ properties:
     description: Specifies if a plan is a trial that does not have recurring instructions.
     readOnly: true
   trial:
-    type: object
     description: Trial configuration settings.
-    required:
-      - price
-      - period
-    properties:
-      price:
-        description: |-
-          Price of setting up a trial.
-          If your service charges a fee for a trial, specify it here.
-          To charge no trial fee, set this value to `0`.
-        type: number
-        format: double
-      period:
-        type: object
-        description: Period information.
-        required:
-          - unit
-          - length
-        properties:
-          unit:
-            description: Unit of time.
-            type: string
-            enum:
-              - day
-              - week
-              - month
-              - year
-          length:
-            description: Length of time.
-            type: integer
-            minimum: 1
+    $ref: ./PlanTrial.yaml
   invoiceTimeShift:
     description: |-
       Use invoice time shift to adjust the invoice issue and due date when billing must occur before the service period changes.


### PR DESCRIPTION
## Summary

Simplifies reading deeply nested schemas by flattening them down a bit (extracted `PlanTrial.yaml` and `PlanSetup.yaml`).

## Checklist

- [x] Writing style
- [x] API design standards
