### PR TITLE
fix: Remove illogical oneOf definitions

### DIFF
--- a/openapi/components/schemas/InvoiceTimeShift.yaml
+++ b/openapi/components/schemas/InvoiceTimeShift.yaml
@@ -14,6 +14,8 @@ description: |-
   - Bill at an interval of time after the service period starts.
   - Bill at an interval of time before the service period ends.
   - Bill at an interval of time after the service period ends.
+
+  A `null` value falls back to the plan or global settings.
 properties:
   issueTimeShift:
     type: object

--- a/openapi/components/schemas/StorefrontSubscription.yaml
+++ b/openapi/components/schemas/StorefrontSubscription.yaml
@@ -185,19 +185,7 @@ properties:
         type: boolean
         default: false
       invoiceTimeShift:
-        description: |-
-          Shifts issue time and due time of invoices for this subscription.
-
-          This setting overrides plan settings.
-          To use plan settings, set this value to `null`.
-
-          To use multiple plans in one subscription,
-          all plans must have the same billing period,
-          this property enables the customer to subscribe to different plans.
-        example: null
-        oneOf:
-          - $ref: ./InvoiceTimeShift.yaml
-          - type: 'null'
+        $ref: ./InvoiceTimeShift.yaml
       recurringInterval:
         type:
           - 'object'
@@ -245,19 +233,7 @@ properties:
     type: boolean
     default: false
   invoiceTimeShift:
-    description: |-
-      Shifts issue time and due time of invoices for this subscription.
-
-      This setting overrides plan settings.
-      To use plan settings, set this value to `null`.
-
-      To use multiple plans in one subscription,
-      all plans must have the same billing period,
-      this property enables the customer to subscribe to different plans.
-    example: null
-    oneOf:
-      - $ref: ./InvoiceTimeShift.yaml
-      - type: 'null'
+    $ref: ./InvoiceTimeShift.yaml
   recurringInterval:
     type:
       - 'object'

--- a/openapi/components/schemas/Subscription.yaml
+++ b/openapi/components/schemas/Subscription.yaml
@@ -117,19 +117,7 @@ properties:
     readOnly: true
     example: true
   invoiceTimeShift:
-    description: |-
-      Shifts issue time and due time of invoices for this subscription.
-
-      This setting overrides plan settings.
-      To use plan settings, set this value to `null`.
-
-      To use multiple plans in one subscription,
-      all plans must have the same billing period,
-      this property enables the customer to subscribe to different plans.
-    example: null
-    oneOf:
-      - $ref: ./InvoiceTimeShift.yaml
-      - type: 'null'
+    $ref: ./InvoiceTimeShift.yaml
   recurringInterval:
     type:
       - 'object'


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

```
invoiceTimeShift:
    description: |-
      Shifts issue time and due time of invoices for this subscription.

      This setting overrides plan settings.
      To use plan settings, set this value to `null`.

      To use multiple plans in one subscription,
      all plans must have the same billing period,
      this property enables the customer to subscribe to different plans.
    example: null
    oneOf:
      - $ref: ./InvoiceTimeShift.yaml
      - type: 'null'
```

Now, let's look at `InvoiceTimeShift.yaml` (only the first couple of lines):
```
type:
  - 'object'
  - 'null'
```

This makes the `oneOf` illogical for the `null` value (because it could match either the `null` part of the `oneOf` or the `InvoiceTimeShift` because that is also `null`. (A bit of a head 🤯 )

## Links
<!-- add any related links to other PRs or docs -->
- I'll probably write a blog post about it. 
- https://github.com/Redocly/redocly-cli/issues/1486

## Checklist

- [x] Writing style
- [x] API design standards
