### PR TITLE
Fix GatewayAccount PUT SDK operation name

### DIFF
--- a/openapi/paths/gateway-accounts@{id}.yaml
+++ b/openapi/paths/gateway-accounts@{id}.yaml
@@ -40,7 +40,7 @@ put:
     - Gateway accounts
   summary: Upsert a gateway account
   operationId: PutGatewayAccount
-  x-sdk-operation-name: update
+  x-sdk-operation-name: upsert
   description: Creates or updates (upserts) a gateway account with a specified ID.
   requestBody:
     $ref: ../components/requestBodies/GatewayAccount.yaml


### PR DESCRIPTION
## Summary

This was a mistake, as `update` is already used for `PATCH`.

## Checklist

- [x] Writing style
- [x] API design standards
