### PR TITLE
Add detail to default instrument description

### DIFF
--- a/openapi/components/schemas/AlternativePaymentInstrument.yaml
+++ b/openapi/components/schemas/AlternativePaymentInstrument.yaml
@@ -2,9 +2,9 @@ title: Alternative instrument
 description: |-
         Alternative payment method instrument.
 
-        If chosen as the default payment instrument,
-        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
-        The default payment instrument takes precedence over the customer's primary payment instrument.
+        To use this payment instrument for automatic subscription renewals,
+        and for transactions when no specific payment instrument is provided by the user,
+        set this as the default payment instrument.
 
 type: object
 required:

--- a/openapi/components/schemas/AlternativePaymentInstrument.yaml
+++ b/openapi/components/schemas/AlternativePaymentInstrument.yaml
@@ -1,5 +1,11 @@
-description: Alternative payment method instrument.
 title: Alternative instrument
+description: |-
+        Alternative payment method instrument.
+
+        If chosen as the default payment instrument,
+        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
+        The default payment instrument takes precedence over the customer's primary payment instrument.
+
 type: object
 required:
   - method

--- a/openapi/components/schemas/AlternativePaymentInstrument.yaml
+++ b/openapi/components/schemas/AlternativePaymentInstrument.yaml
@@ -5,7 +5,6 @@ description: |-
         To use this payment instrument for automatic subscription renewals,
         and for transactions when no specific payment instrument is provided by the user,
         set this as the default payment instrument.
-
 type: object
 required:
   - method

--- a/openapi/components/schemas/CashInstrument.yaml
+++ b/openapi/components/schemas/CashInstrument.yaml
@@ -2,9 +2,9 @@ title: Cash
 description: |-
         Cash payment instrument object.
 
-        If chosen as the default payment instrument,
-        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
-        The default payment instrument takes precedence over the customer's primary payment instrument.
+        To use this payment instrument for automatic subscription renewals,
+        and for transactions when no specific payment instrument is provided by the user,
+        set this as the default payment instrument.
 type: object
 required:
   - method

--- a/openapi/components/schemas/CashInstrument.yaml
+++ b/openapi/components/schemas/CashInstrument.yaml
@@ -1,5 +1,10 @@
-description: Cash payment instrument object.
 title: Cash
+description: |-
+        Cash payment instrument object.
+
+        If chosen as the default payment instrument,
+        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
+        The default payment instrument takes precedence over the customer's primary payment instrument.
 type: object
 required:
   - method

--- a/openapi/components/schemas/CheckInstrument.yaml
+++ b/openapi/components/schemas/CheckInstrument.yaml
@@ -2,9 +2,9 @@ title: Check
 description: |-
         Check payment instrument object.
 
-        If chosen as the default payment instrument,
-        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
-        The default payment instrument takes precedence over the customer's primary payment instrument.
+        To use this payment instrument for automatic subscription renewals,
+        and for transactions when no specific payment instrument is provided by the user,
+        set this as the default payment instrument.
 type: object
 required:
   - method

--- a/openapi/components/schemas/CheckInstrument.yaml
+++ b/openapi/components/schemas/CheckInstrument.yaml
@@ -1,5 +1,10 @@
-description: Check payment instrument object.
 title: Check
+description: |-
+        Check payment instrument object.
+
+        If chosen as the default payment instrument,
+        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
+        The default payment instrument takes precedence over the customer's primary payment instrument.
 type: object
 required:
   - method

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -45,11 +45,6 @@ properties:
       The token expires after first use.
 # TODO Check if it's valid. Might require a oneOf instead.
   defaultPaymentInstrument:
-    description: |-
-      Default payment instrument.
-      The default payment instrument is used to automatically pay subscription renewals,
-      and for transaction requests where a specific payment instrument is not provided.
-      The default payment instrument takes precedence over the customer's primary payment instrument.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
       - $ref: ./AlternativePaymentInstrument.yaml

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -49,7 +49,7 @@ properties:
       Default payment instrument.
       The default payment instrument is used to automatically pay subscription renewals,
       and for transaction requests where a specific payment instrument is not provided.
-      The default payment instruments takes precedence over the customer's primary payment instrument.
+      The default payment instrument takes precedence over the customer's primary payment instrument.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
       - $ref: ./AlternativePaymentInstrument.yaml

--- a/openapi/components/schemas/Customer.yaml
+++ b/openapi/components/schemas/Customer.yaml
@@ -45,7 +45,11 @@ properties:
       The token expires after first use.
 # TODO Check if it's valid. Might require a oneOf instead.
   defaultPaymentInstrument:
-    description: Default payment instrument information.
+    description: |-
+      Default payment instrument.
+      The default payment instrument is used to automatically pay subscription renewals,
+      and for transaction requests where a specific payment instrument is not provided.
+      The default payment instruments takes precedence over the customer's primary payment instrument.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
       - $ref: ./AlternativePaymentInstrument.yaml

--- a/openapi/components/schemas/FlexiblePlan.yaml
+++ b/openapi/components/schemas/FlexiblePlan.yaml
@@ -1,9 +1,5 @@
 allOf:
   - type: object
-    description: |-
-      Customize an existing plan for the current order.
-
-      To create a new plan, see [Create a plan](https://www.rebilly.com/catalog/all/Plans/PostPlan).
     required:
       - id
     properties:

--- a/openapi/components/schemas/StorefrontAccount.yaml
+++ b/openapi/components/schemas/StorefrontAccount.yaml
@@ -28,7 +28,6 @@ properties:
       Default payment instrument.
       The default payment instrument is used to automatically pay subscription renewals,
       and for transaction requests where a specific payment instrument is not provided.
-      The default payment instrument takes precedence over the customer's primary payment instrument.
     required:
       - method
     properties:

--- a/openapi/components/schemas/StorefrontAccount.yaml
+++ b/openapi/components/schemas/StorefrontAccount.yaml
@@ -24,7 +24,11 @@ properties:
       This token may only be used once before it expires.
   defaultPaymentInstrument:
     type: object
-    description: Default payment instrument information.
+    description: |-
+      Default payment instrument.
+      The default payment instrument is used to automatically pay subscription renewals,
+      and for transaction requests where a specific payment instrument is not provided.
+      The default payment instrument takes precedence over the customer's primary payment instrument.
     required:
       - method
     properties:

--- a/openapi/components/schemas/SubscriptionOrOneTimeSaleItem.yaml
+++ b/openapi/components/schemas/SubscriptionOrOneTimeSaleItem.yaml
@@ -22,7 +22,6 @@ properties:
     description: Number of filled product units.
     type: integer
   plan:
-    description: Details of the plan.
     anyOf:
       - $ref: ./OriginalPlan.yaml
       - $ref: ./FlexiblePlan.yaml

--- a/openapi/components/schemas/Transaction.yaml
+++ b/openapi/components/schemas/Transaction.yaml
@@ -394,7 +394,6 @@ properties:
     readOnly: true
   paymentInstrument:
     type: object
-    description: Payment instrument information.
     anyOf:
       - $ref: ./VaultedInstrument.yaml
       - $ref: ./AlternativePaymentInstrument.yaml

--- a/openapi/components/schemas/VaultedInstrument.yaml
+++ b/openapi/components/schemas/VaultedInstrument.yaml
@@ -2,9 +2,9 @@ title: Vaulted payment instrument
 description: |-
         Vaulted payment instrument.
 
-        If chosen as the default payment instrument,
-        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
-        The default payment instrument takes precedence over the customer's primary payment instrument.
+        To use this payment instrument for automatic subscription renewals,
+        and for transactions when no specific payment instrument is provided by the user,
+        set this as the default payment instrument.
 required:
   - method
   - paymentInstrumentId

--- a/openapi/components/schemas/VaultedInstrument.yaml
+++ b/openapi/components/schemas/VaultedInstrument.yaml
@@ -1,5 +1,10 @@
-description: Vaulted payment instrument.
-title: Vaulted instrument
+title: Vaulted payment instrument
+description: |-
+        Vaulted payment instrument.
+
+        If chosen as the default payment instrument,
+        it is used for automatic subscription renewals and transactions when no specific payment instrument is provided.
+        The default payment instrument takes precedence over the customer's primary payment instrument.
 required:
   - method
   - paymentInstrumentId


### PR DESCRIPTION
## Summary

This pull request adds detail to the default payment instrument field descriptions.

This pull request also fixes an issue where `anyOf` sibling element descriptions were being overwritten by the description of the parent element.

## Checklist

- [X] Writing style
- [X] API design standards

### [Preview](https://rebilly-website--rem-git-rem-01hnb1ejh7zd3eqe72m-d74fe2.preview.redocly.app/catalog/all/Customers/PostCustomer/#!t=request&path=defaultPaymentInstrument)
