### PR TITLE
Add cancelUrl and redirectUrl to StorefrontTransaction links

### DIFF
--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -329,3 +329,4 @@ properties:
             - approvalUrl
             - approvalContinue
             - approvalBypass
+            - cancelUrl

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -136,8 +136,8 @@ properties:
       URL where the end-user is redirected to when an offsite transaction is completed.
       The default value is the website URL.
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     format: uri
   retryNumber:
     type: integer
@@ -150,8 +150,8 @@ properties:
     description: Specifies if a transaction is a retry.
   billingDescriptor:
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     readOnly: true
     description: |-
       Billing descriptor that appears on the periodic billing statement.
@@ -191,38 +191,38 @@ properties:
           code:
             description: Gateway response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           message:
             description: Gateway response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           type:
             description: Gateway response type.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw, unmapped gateway response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw, unmapped gateway response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           humanMessage:
             description: Human-readable gateway response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           humanDescription:
             description: Human-readable gateway response description with more detailed information.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
       avsResponse:
         description: Gateway Address Verification System (AVS) response.
         type: object
@@ -230,23 +230,23 @@ properties:
           code:
             description: Response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           message:
             description: Response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
       cvvResponse:
         description: Gateway Card Verification Value (CVV) response.
         type: object
@@ -254,23 +254,23 @@ properties:
           code:
             description: Response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           message:
             description: Response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalCode:
             description: Raw response code.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
           originalMessage:
             description: Raw response message.
             type:
-              - "string"
-              - "null"
+              - 'string'
+              - 'null'
   customFields:
     $ref: ./ResourceCustomFields.yaml
   processedTime:
@@ -306,8 +306,8 @@ properties:
   depositRequestId:
     readOnly: true
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     description: ID of the deposit request if applicable. The created transaction is based on the properties of this deposit request.
     maxLength: 50
     example: dep_req_0YVJ65BSGYC3EAT58SEX8KY6J7

--- a/openapi/components/schemas/StorefrontTransaction.yaml
+++ b/openapi/components/schemas/StorefrontTransaction.yaml
@@ -136,8 +136,8 @@ properties:
       URL where the end-user is redirected to when an offsite transaction is completed.
       The default value is the website URL.
     type:
-      - 'string'
-      - 'null'
+      - "string"
+      - "null"
     format: uri
   retryNumber:
     type: integer
@@ -150,8 +150,8 @@ properties:
     description: Specifies if a transaction is a retry.
   billingDescriptor:
     type:
-      - 'string'
-      - 'null'
+      - "string"
+      - "null"
     readOnly: true
     description: |-
       Billing descriptor that appears on the periodic billing statement.
@@ -191,38 +191,38 @@ properties:
           code:
             description: Gateway response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           message:
             description: Gateway response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           type:
             description: Gateway response type.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalCode:
             description: Raw, unmapped gateway response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalMessage:
             description: Raw, unmapped gateway response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           humanMessage:
             description: Human-readable gateway response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           humanDescription:
             description: Human-readable gateway response description with more detailed information.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
       avsResponse:
         description: Gateway Address Verification System (AVS) response.
         type: object
@@ -230,23 +230,23 @@ properties:
           code:
             description: Response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           message:
             description: Response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalCode:
             description: Raw response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalMessage:
             description: Raw response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
       cvvResponse:
         description: Gateway Card Verification Value (CVV) response.
         type: object
@@ -254,23 +254,23 @@ properties:
           code:
             description: Response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           message:
             description: Response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalCode:
             description: Raw response code.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
           originalMessage:
             description: Raw response message.
             type:
-              - 'string'
-              - 'null'
+              - "string"
+              - "null"
   customFields:
     $ref: ./ResourceCustomFields.yaml
   processedTime:
@@ -306,8 +306,8 @@ properties:
   depositRequestId:
     readOnly: true
     type:
-      - 'string'
-      - 'null'
+      - "string"
+      - "null"
     description: ID of the deposit request if applicable. The created transaction is based on the properties of this deposit request.
     maxLength: 50
     example: dep_req_0YVJ65BSGYC3EAT58SEX8KY6J7
@@ -330,3 +330,4 @@ properties:
             - approvalContinue
             - approvalBypass
             - cancelUrl
+            - redirectUrl


### PR DESCRIPTION
Adds missing `cancelUrl` and `redirectUrl` related link items.