### PR TITLE
Rename orderId to subscriptionId in quotes

### DIFF
--- a/openapi/components/schemas/Quote.yaml
+++ b/openapi/components/schemas/Quote.yaml
@@ -4,7 +4,7 @@ discriminator:
     create: ./QuoteCreateOrder.yaml
     change: ./QuoteChangeOrder.yaml
     reactivate: ./QuoteReactivateOrder.yaml
-    trial-conversion: ./QuoteTrialConversionOrder.yaml
+    trial-only-conversion: ./QuoteTrialConversionOrder.yaml
 oneOf:
   - $ref: ./QuoteCreateOrder.yaml
   - $ref: ./QuoteChangeOrder.yaml

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -5,7 +5,7 @@ required:
   - customerId
   - items
   - action
-  - orderId
+  - subscriptionId
 properties:
   id:
     readOnly: true

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -59,8 +59,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription.
     type: string
     maxLength: 50
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -25,7 +25,7 @@ properties:
     description: |-
       Action of the quote.
       When a quote is accepted, a new order is created.
-      The `orderId` value is filled with a new generated value from the order.
+      The `subscriptionId` value is filled with a new generated value from the order.
     type: string
     enum:
       - create
@@ -59,8 +59,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription or one-time sale.
     readOnly: true
     type:
       - 'string'

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -60,7 +60,7 @@ properties:
         isFulfilled:
           type: boolean
   subscriptionId:
-    description: ID of the related subscription or one-time sale.
+    description: ID of the related subscription or one-time purchase.
     readOnly: true
     type:
       - 'string'

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -5,7 +5,7 @@ required:
   - customerId
   - items
   - action
-  - orderId
+  - subscriptionId
 properties:
   id:
     readOnly: true

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -59,8 +59,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription.
     type: string
     maxLength: 50
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ

--- a/openapi/components/schemas/QuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/QuoteTrialConversionOrder.yaml
@@ -1,11 +1,11 @@
 type: object
-title: QuoteChangeOrder
+title: QuoteTrialConversionOrder
 required:
   - websiteId
   - customerId
   - items
   - action
-  - orderId
+  - subscriptionId
 properties:
   id:
     readOnly: true
@@ -24,12 +24,12 @@ properties:
       - one-time-order
   action:
     description: |-
-      Action of the quote for change order items.
-      When a quote is accepted, quote items are applied to the related order.
+      Action of the quote for a trial order with ended trial.
+      When a quote is accepted, the related order is activated.
     type: string
     enum:
-      - change
-    example: change
+      - trial-conversion
+    example: trial-conversion
   acceptanceConditions:
     type: array
     writeOnly: true
@@ -59,7 +59,7 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
+  subscriptionId:
     description: ID of the related order.
     type: string
     maxLength: 50

--- a/openapi/components/schemas/QuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/QuoteTrialConversionOrder.yaml
@@ -24,12 +24,12 @@ properties:
       - one-time-order
   action:
     description: |-
-      Action of the quote for a trial order with ended trial.
+      Action of the quote for an ended trial-only subscription.
       When a quote is accepted, the related order is activated.
     type: string
     enum:
-      - trial-conversion
-    example: trial-conversion
+      - trial-only-conversion
+    example: trial-only-conversion
   acceptanceConditions:
     type: array
     writeOnly: true

--- a/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
@@ -52,8 +52,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription.
     readOnly: true
     type: string
     maxLength: 50

--- a/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
@@ -19,7 +19,7 @@ properties:
     description: |-
       Action of the quote.
       When a quote is accepted, a new order is created.
-      The `orderId` value is filled with a new generated value from the order.
+      The `subscriptionId` value is filled with a new generated value from the order.
     type: string
     enum:
       - create
@@ -53,8 +53,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription or one-time sale.
     readOnly: true
     type:
       - 'string'

--- a/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
@@ -54,7 +54,7 @@ properties:
         isFulfilled:
           type: boolean
   subscriptionId:
-    description: ID of the related subscription or one-time sale.
+    description: ID of the related subscription or one-time purchase.
     readOnly: true
     type:
       - 'string'

--- a/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
@@ -52,8 +52,8 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription.
     readOnly: true
     type: string
     maxLength: 50

--- a/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
@@ -17,13 +17,12 @@ properties:
       - one-time-order
   action:
     description: |-
-      Action of the quote.
-      When a quote is accepted, a new order is created.
-      The `orderId` value is filled with a new generated value from the order.
+      Action of the quote for a trial order with ended trial.
+      When a quote is accepted, the related order is activated.
     type: string
     enum:
-      - create
-    example: create
+      - trial-conversion
+    example: trial-conversion
   acceptanceConditions:
     type: array
     writeOnly: true
@@ -53,12 +52,10 @@ properties:
             - organization
         isFulfilled:
           type: boolean
-  orderId:
-    description: ID of the related order.
+  subscriptionId:
+    description: ID of the related subscription.
     readOnly: true
-    type:
-      - 'string'
-      - 'null'
+    type: string
     maxLength: 50
     example: ord_0YV7DES3WPC5J8JD8QTVNZBZNZ
   invoiceId:

--- a/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
@@ -17,12 +17,12 @@ properties:
       - one-time-order
   action:
     description: |-
-      Action of the quote for a trial order with ended trial.
+      Action of the quote for an ended trial-only subscription.
       When a quote is accepted, the related order is activated.
     type: string
     enum:
-      - trial-conversion
-    example: trial-conversion
+      - trial-only-conversion
+    example: trial-only-conversion
   acceptanceConditions:
     type: array
     writeOnly: true


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->
Old `orderId` can be subscription or one time sale purchase
## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
