### PR TITLE
Add `fingerprintJsRequestId` field to RiskMetadata.extraData

### DIFF
--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -98,6 +98,10 @@ properties:
         minimum: 1
         maximum: 128
         example: dd65ratxc5qv15iph3vyoq7l6davuowadd65ratxc5qv15iph3vyoq7l6davuowa
+      fingerprintJsRequestId:
+        description: Unique identifier of the visitor's identification request.
+        type: string
+        example: 1708102555327.NLOjmg
   isProxy:
     description: Specifies if the customer's IP address is related to a proxy.
     type: boolean


### PR DESCRIPTION
## Summary
Add the optional parameter `fingerprintJsRequestId` to the RiskMetada.extraData to extract more visitor information

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
