### PR TITLE
Add `isBot` riskMetadata field

### DIFF
--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -224,9 +224,7 @@ properties:
     readOnly: true
   isBot:
     description: Specifies if the visitor session is identified as a bot.
-    type:
-      - 'boolean'
-      - 'null'
+    type: boolean
     readOnly: true
   deviceVelocity:
     description: Number of transactions for this device, based on fingerprint, in the last 24 hours.

--- a/openapi/components/schemas/RiskMetadata.yaml
+++ b/openapi/components/schemas/RiskMetadata.yaml
@@ -222,6 +222,12 @@ properties:
     description: Number of declined transactions for this payment instrument fingerprint in the last 24 hours.
     type: integer
     readOnly: true
+  isBot:
+    description: Specifies if the visitor session is identified as a bot.
+    type:
+      - 'boolean'
+      - 'null'
+    readOnly: true
   deviceVelocity:
     description: Number of transactions for this device, based on fingerprint, in the last 24 hours.
     type: integer


### PR DESCRIPTION
## Summary
Add new RiskMetadata field that holds information on whether the visitor sessions has been identified as a bot generated session.

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
