### PR TITLE
Allow negative risk score rule values

### DIFF
--- a/openapi/components/schemas/RiskScoreBracket.yaml
+++ b/openapi/components/schemas/RiskScoreBracket.yaml
@@ -26,4 +26,3 @@ properties:
         value:
           type: integer
           description: Value added to the risk score of the transaction.
-          minimum: 1


### PR DESCRIPTION
## Summary
Removes the `minimum` attribute from risk score bracket rules to allow for negative values to be input. Boolean/fixed rules already allow for negative values in the API spec.

## Checklist

- [X] Writing style
- [X] API design standards
