### PR TITLE
Fix filters guide and expand links to actual destinations

### DIFF
--- a/openapi/components/parameters/collectionExpand.yaml
+++ b/openapi/components/parameters/collectionExpand.yaml
@@ -5,6 +5,6 @@ description: |-
   property of the response. This field accepts a comma-separated list of objects.
 
   For more information, see
-  [Expand to include embedded objects](https://www.rebilly.com/docs/dev-docs/api/#section/Expand-to-include-embedded-objects).
+  [Expand to include embedded objects](https://www.rebilly.com/docs/dev-docs/expand-embedded-resources).
 schema:
   type: string

--- a/openapi/components/parameters/collectionFilter.yaml
+++ b/openapi/components/parameters/collectionFilter.yaml
@@ -5,6 +5,6 @@ description: |-
   a special format. Use `,` for multiple allowed values.  Use `;` for multiple fields.
 
   For more information, see
-  [Using filter with collections](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+  [Using filter with collections](https://www.rebilly.com/docs/dev-docs/search-filters).
 schema:
   type: string

--- a/openapi/components/parameters/subscriptionExpand.yaml
+++ b/openapi/components/parameters/subscriptionExpand.yaml
@@ -17,6 +17,6 @@ description: |-
     - `upcomingInvoice`
     - `paymentInstrument`
 
-  For more information, see [Expand to include embedded objects](https://www.rebilly.com/docs/dev-docs/api/#section/Expand-to-include-embedded-objects).
+  For more information, see [Expand to include embedded objects](https://www.rebilly.com/docs/dev-docs/expand-embedded-resources).
 schema:
   type: string

--- a/openapi/components/schemas/Bind.yaml
+++ b/openapi/components/schemas/Bind.yaml
@@ -30,7 +30,7 @@ properties:
       This field requires a special format. Use `,` for multiple allowed values.
       Use `;` for multiple fields.
 
-      For more information, see [Using filter with collections](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+      For more information, see [Using filter with collections](https://www.rebilly.com/docs/dev-docs/search-filters).
     type: string
   actions:
     description: Actions that execute when an event occurs.

--- a/openapi/components/schemas/GatewayAccount.yaml
+++ b/openapi/components/schemas/GatewayAccount.yaml
@@ -323,7 +323,7 @@ properties:
       If a transaction exceeds this value, the gateway account is not used.
 
       For more information see,
-      [Using filters](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+      [Using filters](https://www.rebilly.com/docs/dev-docs/search-filters).
     type:
       - 'string'
       - 'null'

--- a/openapi/components/schemas/GlobalWebhook.yaml
+++ b/openapi/components/schemas/GlobalWebhook.yaml
@@ -87,7 +87,7 @@ properties:
       Use `;` for multiple fields.
 
       For more information,
-      see [Using filters](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+      see [Using filters](https://www.rebilly.com/docs/dev-docs/search-filters).
     type:
       - 'string'
       - 'null'

--- a/openapi/components/schemas/ReadyToPayMethodFilters.yaml
+++ b/openapi/components/schemas/ReadyToPayMethodFilters.yaml
@@ -2,6 +2,6 @@ type: array
 description: |-
   For the method to be applicable, one or more of the following filters must match.
   If no filters are sent, no restrictions are applied.
-  For more information, see [Using filters](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+  For more information, see [Using filters](https://www.rebilly.com/docs/dev-docs/search-filters).
 items:
   type: string

--- a/openapi/components/schemas/ReadyToPayoutMethodFilters.yaml
+++ b/openapi/components/schemas/ReadyToPayoutMethodFilters.yaml
@@ -2,6 +2,6 @@ type: array
 description: |-
   For the method to be applicable, one or more of the following filters must match.
   If no filters are sent, no restrictions are applied.
-  For more information, see [Using filters](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections).
+  For more information, see [Using filters](https://www.rebilly.com/docs/dev-docs/search-filters).
 items:
   type: string

--- a/openapi/paths/reports@revenue-audit.yaml
+++ b/openapi/paths/reports@revenue-audit.yaml
@@ -31,7 +31,7 @@ get:
 
     A revenue audit report is a combination of a granular [revenue waterfall](https://www.rebilly.com/docs/data-tables/revenue-recognition/#revenue-waterfall) and a journal report,
     which describes revenue per account.
-    Use [`filter`](https://www.rebilly.com/docs/dev-docs/api/#section/Using-filter-with-collections) `limit` and `offset` parameters to restrict the output.
+    Use [`filter`](https://www.rebilly.com/docs/dev-docs/search-filters) `limit` and `offset` parameters to restrict the output.
   security:
     - SecretApiKey: []
     - JWT: []


### PR DESCRIPTION
## Summary
Use the actual new document links. This fixes the link changes that were part of  #1868 I was linking to the auto-generated links for filters and expand. This fixes that to point to the proper, manually written guides.

## Links


## Checklist

- [x] Writing style
- [x] API design standards
