### PR TITLE
Revert sort type change

### DIFF
--- a/openapi/components/parameters/collectionSort.yaml
+++ b/openapi/components/parameters/collectionSort.yaml
@@ -3,7 +3,6 @@ in: query
 description: |-
   Sorts and orders the collection of items. To sort in descending
   order, prefix with `-`. Multiple fields can be sorted by separating each with `,`.
-example: -createdTime,firstName
 style: form
 explode: false
 schema:

--- a/openapi/components/parameters/collectionSort.yaml
+++ b/openapi/components/parameters/collectionSort.yaml
@@ -7,4 +7,6 @@ example: -createdTime,firstName
 style: form
 explode: false
 schema:
-  type: string
+  type: array
+  items:
+    type: string


### PR DESCRIPTION
## Summary
#1868 turned sort into `type: string` with `style: form`, the original definition was correct. I kept the description update though.

## Links
https://swagger.io/specification/#style-values:~:text=200.B%3D150-,form,false,-color%3D

## Checklist

- [x] Writing style
- [x] API design standards
