### PR TITLE
feat: Add transaction-processed to the list of supported tag/untag rules

### DIFF
--- a/openapi/components/schemas/EventType.yaml
+++ b/openapi/components/schemas/EventType.yaml
@@ -28,7 +28,7 @@ enum:
   - gateway-account-onboarding-completed
   - gateway-account-onboarding-failed
   - gateway-account-requested
-  - hard-usage-limit-reached.yaml
+  - hard-usage-limit-reached
   - invoice-issued
   - invoice-modified
   - invoice-paid
@@ -67,7 +67,7 @@ enum:
   - renewal-invoice-payment-canceled
   - renewal-invoice-payment-declined
   - risk-score-changed
-  - soft-usage-limit-reached.yaml
+  - soft-usage-limit-reached
   - subscription-activated
   - subscription-canceled
   - subscription-churned

--- a/openapi/components/schemas/GlobalEventType.yaml
+++ b/openapi/components/schemas/GlobalEventType.yaml
@@ -34,7 +34,7 @@ enum:
   - gateway-account-onboarding-completed
   - gateway-account-onboarding-failed
   - gateway-account-requested
-  - hard-usage-limit-reached.yaml
+  - hard-usage-limit-reached
   - invoice-abandoned
   - invoice-created
   - invoice-issued
@@ -81,7 +81,7 @@ enum:
   - renewal-invoice-payment-canceled
   - renewal-invoice-payment-declined
   - risk-score-changed
-  - soft-usage-limit-reached.yaml
+  - soft-usage-limit-reached
   - subscription-activated
   - subscription-canceled
   - subscription-churned

--- a/openapi/components/schemas/TagUntagRule.yaml
+++ b/openapi/components/schemas/TagUntagRule.yaml
@@ -51,6 +51,7 @@ properties:
             - payment-instrument-modified
             - renewal-invoice-payment-canceled
             - risk-score-changed
+            - subscription-items-changed
             - subscription-modified
             - subscription-pause-created
             - subscription-pause-modified
@@ -61,7 +62,6 @@ properties:
             - subscription-trial-end-reminder
             - subscription-trial-ended
             - transaction-process-requested
-            - transaction-processed
             - transaction-reconciled
             - transaction-timeout-resolved
             - waiting-gateway-transaction-completed

--- a/openapi/components/schemas/TagUntagRule.yaml
+++ b/openapi/components/schemas/TagUntagRule.yaml
@@ -66,8 +66,8 @@ properties:
             - transaction-timeout-resolved
             - waiting-gateway-transaction-completed
             - data-export-completed
-            - hard-usage-limit-reached.yaml
-            - soft-usage-limit-reached.yaml
+            - hard-usage-limit-reached
+            - soft-usage-limit-reached
   filter:
     description: |-
       Filter that determines whether to tag or untag.


### PR DESCRIPTION
## Summary

- Add transaction-processed to the list of supported tag/untag rules
- Exclude subscription-items-changed
- Fix hard-usage-limit-reached, soft-usage-limit-reached event names

## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
