### PR TITLE
Add abandon-scheduled-payments rule action

### DIFF
--- a/openapi/components/schemas/RuleAction.yaml
+++ b/openapi/components/schemas/RuleAction.yaml
@@ -2,6 +2,7 @@ type: object
 discriminator:
   propertyName: name
   mapping:
+    abandon-scheduled-payments: ./RuleActionAbandonScheduledPayments.yaml
     add-risk-score: ./RuleActionAddRiskScore.yaml
     adjust-ready-to-pay: ./RuleActionAdjustReadyToPay.yaml
     adjust-ready-to-payout: ./RuleActionAdjustReadyToPayout.yaml
@@ -38,6 +39,7 @@ properties:
     type: string
     description: Name of the action.
     enum:
+      - abandon-scheduled-payments
       - add-risk-score
       - adjust-ready-to-pay
       - blocklist

--- a/openapi/components/schemas/RuleActionAbandonScheduledPayments.yaml
+++ b/openapi/components/schemas/RuleActionAbandonScheduledPayments.yaml
@@ -1,0 +1,3 @@
+description: Abandon scheduled payments of reached delinquency order.
+allOf:
+  - $ref: ./RuleAction.yaml

--- a/openapi/components/schemas/RuleActionAbandonScheduledPayments.yaml
+++ b/openapi/components/schemas/RuleActionAbandonScheduledPayments.yaml
@@ -1,3 +1,3 @@
-description: Abandon scheduled payments of reached delinquency order.
+description: Abandon scheduled payments for an order that exceeds the configured delinquency period.
 allOf:
   - $ref: ./RuleAction.yaml


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

Added `abandon-scheduled-payments` rule action which allows to change default behaviour of invoice in case of reaching delinquency. 

If rule is configured, invoice change state from `past-due` to `abandoned`.


## Links
<!-- add any related links to other PRs or docs -->

## Checklist

- [x] Writing style
- [x] API design standards
