### PR TITLE
feat: use x-badges feature

### DIFF
--- a/openapi/components/requestBodies/SubscriptionItemUpdate.yaml
+++ b/openapi/components/requestBodies/SubscriptionItemUpdate.yaml
@@ -3,6 +3,7 @@ required:
   - quantityFilled
 properties:
   quantityFilled:
-    x-badge: Experimental
+    x-badges:
+      - name: Experimental
     description: Filled quantity of the subscription item (experimental property).
     type: integer

--- a/openapi/components/schemas/Subscription.yaml
+++ b/openapi/components/schemas/Subscription.yaml
@@ -455,7 +455,8 @@ properties:
       - 'string'
       - 'null'
     readOnly: true
-    x-badge: experimental
+    x-badges:
+      - name: Experimental
   customFields:
     $ref: ./ResourceCustomFields.yaml
   createdTime:

--- a/openapi/paths/balance-transactions.yaml
+++ b/openapi/paths/balance-transactions.yaml
@@ -1,5 +1,6 @@
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Users
   tags: ["Balance transactions"]

--- a/openapi/paths/balance-transactions@{id}.yaml
+++ b/openapi/paths/balance-transactions@{id}.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Users
   tags: ["Balance transactions"]

--- a/openapi/paths/customers@{customerId}@summary-metrics.yaml
+++ b/openapi/paths/customers@{customerId}@summary-metrics.yaml
@@ -25,7 +25,8 @@ parameters:
     schema:
       type: string
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/deposit-custom-property-sets.yaml
+++ b/openapi/paths/deposit-custom-property-sets.yaml
@@ -1,7 +1,8 @@
 post:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Create a custom deposit property set
@@ -37,7 +38,8 @@ post:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve custom deposit properties sets

--- a/openapi/paths/deposit-custom-property-sets@{id}.yaml
+++ b/openapi/paths/deposit-custom-property-sets@{id}.yaml
@@ -3,7 +3,8 @@ parameters:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve a custom deposit property set
@@ -26,7 +27,8 @@ get:
 put:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Upsert a custom deposit property set
@@ -67,7 +69,8 @@ put:
 delete:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Delete a custom deposit property set

--- a/openapi/paths/deposit-requests.yaml
+++ b/openapi/paths/deposit-requests.yaml
@@ -1,7 +1,8 @@
 post:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Create a deposit request
@@ -38,7 +39,8 @@ post:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve deposit requests

--- a/openapi/paths/deposit-requests@{id}.yaml
+++ b/openapi/paths/deposit-requests@{id}.yaml
@@ -3,7 +3,8 @@ parameters:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve a deposit request

--- a/openapi/paths/deposit-strategies.yaml
+++ b/openapi/paths/deposit-strategies.yaml
@@ -1,7 +1,8 @@
 post:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Create a deposit strategy
@@ -38,7 +39,8 @@ post:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve deposit strategies

--- a/openapi/paths/deposit-strategies@{id}.yaml
+++ b/openapi/paths/deposit-strategies@{id}.yaml
@@ -3,7 +3,8 @@ parameters:
 get:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Retrieve a deposit strategy
@@ -26,7 +27,8 @@ get:
 put:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Upsert a deposit strategy
@@ -67,7 +69,8 @@ put:
 delete:
   x-products:
     - Core
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Deposits
   summary: Delete a deposit strategy

--- a/openapi/paths/fees.yaml
+++ b/openapi/paths/fees.yaml
@@ -1,5 +1,6 @@
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -36,7 +37,8 @@ get:
     '403':
       $ref: ../components/responses/Forbidden.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]

--- a/openapi/paths/fees@{id}.yaml
+++ b/openapi/paths/fees@{id}.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -33,7 +34,8 @@ get:
     '404':
       $ref: ../components/responses/NotFound.yaml
 put:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -94,7 +96,8 @@ put:
     '422':
       $ref: ../components/responses/ValidationError.yaml
 patch:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]
@@ -139,7 +142,8 @@ patch:
     '422':
       $ref: ../components/responses/ValidationError.yaml
 delete:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags: [Fees]

--- a/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
+++ b/openapi/paths/gateway-accounts@{id}@financial-settings.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Users
   tags:
@@ -28,7 +29,8 @@ get:
       $ref: ../components/responses/NotFound.yaml
 
 put:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Users
   tags:

--- a/openapi/paths/histograms@transactions.yaml
+++ b/openapi/paths/histograms@transactions.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/quotes.yaml
+++ b/openapi/paths/quotes.yaml
@@ -1,5 +1,6 @@
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:
@@ -35,7 +36,8 @@ get:
     '403':
       $ref: ../components/responses/Forbidden.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}.yaml
+++ b/openapi/paths/quotes@{id}.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:
@@ -30,7 +31,8 @@ get:
     '404':
       $ref: ../components/responses/NotFound.yaml
 put:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:
@@ -73,7 +75,8 @@ put:
     '422':
       $ref: ../components/responses/ValidationError.yaml
 patch:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@accept.yaml
+++ b/openapi/paths/quotes@{id}@accept.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@cancel.yaml
+++ b/openapi/paths/quotes@{id}@cancel.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@issue.yaml
+++ b/openapi/paths/quotes@{id}@issue.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@recall.yaml
+++ b/openapi/paths/quotes@{id}@recall.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@reject.yaml
+++ b/openapi/paths/quotes@{id}@reject.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@timeline.yaml
+++ b/openapi/paths/quotes@{id}@timeline.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:
@@ -38,7 +39,8 @@ get:
       $ref: ../components/responses/Forbidden.yaml
 
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/quotes@{id}@timeline@{messageId}.yaml
+++ b/openapi/paths/quotes@{id}@timeline@{messageId}.yaml
@@ -7,7 +7,8 @@ parameters:
     schema:
       type: string
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:
@@ -30,7 +31,8 @@ get:
     '404':
       $ref: ../components/responses/NotFound.yaml
 delete:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/reports@api-log-summary.yaml
+++ b/openapi/paths/reports@api-log-summary.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@cumulative-subscriptions.yaml
+++ b/openapi/paths/reports@cumulative-subscriptions.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@dashboard.yaml
+++ b/openapi/paths/reports@dashboard.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@dcc-markup.yaml
+++ b/openapi/paths/reports@dcc-markup.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@declined-transactions.yaml
+++ b/openapi/paths/reports@declined-transactions.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@disputes.yaml
+++ b/openapi/paths/reports@disputes.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@events-triggered.yaml
+++ b/openapi/paths/reports@events-triggered.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
+++ b/openapi/paths/reports@events-triggered@{eventType}@rules.yaml
@@ -25,7 +25,8 @@ parameters:
     schema:
       $ref: ../components/schemas/EventType.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@future-renewals.yaml
+++ b/openapi/paths/reports@future-renewals.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@journal.yaml
+++ b/openapi/paths/reports@journal.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-acceptance-summary.yaml
+++ b/openapi/paths/reports@kyc-acceptance-summary.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-rejection-summary.yaml
+++ b/openapi/paths/reports@kyc-rejection-summary.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@kyc-request-summary.yaml
+++ b/openapi/paths/reports@kyc-request-summary.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@monthly-recurring-revenue.yaml
+++ b/openapi/paths/reports@monthly-recurring-revenue.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@renewal-sales.yaml
+++ b/openapi/paths/reports@renewal-sales.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@retention-percentage.yaml
+++ b/openapi/paths/reports@retention-percentage.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@retention-value.yaml
+++ b/openapi/paths/reports@retention-value.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@revenue-audit.yaml
+++ b/openapi/paths/reports@revenue-audit.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@revenue-waterfall.yaml
+++ b/openapi/paths/reports@revenue-waterfall.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@subscription-cancellation.yaml
+++ b/openapi/paths/reports@subscription-cancellation.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@subscription-renewal.yaml
+++ b/openapi/paths/reports@subscription-renewal.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@tax.yaml
+++ b/openapi/paths/reports@tax.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@time-series-transaction.yaml
+++ b/openapi/paths/reports@time-series-transaction.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@transactions-time-dispute.yaml
+++ b/openapi/paths/reports@transactions-time-dispute.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/reports@transactions.yaml
+++ b/openapi/paths/reports@transactions.yaml
@@ -18,7 +18,8 @@ servers:
           An organization is an entity that represents a company.
           For more information, see [Obtain an organization ID](https://www.rebilly.com/docs/settings/organizations-and-websites/#obtain-your-organization-id-and-website-id).
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:

--- a/openapi/paths/storefront/deposit-requests@{id}.yaml
+++ b/openapi/paths/storefront/deposit-requests@{id}.yaml
@@ -3,7 +3,8 @@ parameters:
 get:
   x-products:
     - Storefront
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Storefront deposits
   summary: Retrieve a deposit request

--- a/openapi/paths/storefront/deposit-strategies@{id}.yaml
+++ b/openapi/paths/storefront/deposit-strategies@{id}.yaml
@@ -3,7 +3,8 @@ parameters:
 get:
   x-products:
     - Storefront
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Storefront deposits
   summary: Retrieve a deposit strategy

--- a/openapi/paths/storefront/deposit.yaml
+++ b/openapi/paths/storefront/deposit.yaml
@@ -1,7 +1,8 @@
 post:
   x-products:
     - Storefront
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   tags:
     - Storefront deposits
   summary: Create a deposit

--- a/openapi/paths/storefront/preview-purchase.yaml
+++ b/openapi/paths/storefront/preview-purchase.yaml
@@ -1,5 +1,6 @@
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/quotes@{id}.yaml
+++ b/openapi/paths/storefront/quotes@{id}.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/quotes@{id}@accept.yaml
+++ b/openapi/paths/storefront/quotes@{id}@accept.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/quotes@{id}@reject.yaml
+++ b/openapi/paths/storefront/quotes@{id}@reject.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/subscription-reactivations.yaml
+++ b/openapi/paths/storefront/subscription-reactivations.yaml
@@ -1,5 +1,6 @@
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/subscriptions.yaml
+++ b/openapi/paths/storefront/subscriptions.yaml
@@ -1,5 +1,6 @@
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/storefront/subscriptions@{id}@change-items.yaml
+++ b/openapi/paths/storefront/subscriptions@{id}@change-items.yaml
@@ -1,7 +1,8 @@
 parameters:
   - $ref: ../../components/parameters/resourceId.yaml
 post:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Storefront
   tags:

--- a/openapi/paths/subscriptions@{id}@items@{itemId}.yaml
+++ b/openapi/paths/subscriptions@{id}@items@{itemId}.yaml
@@ -7,7 +7,8 @@ parameters:
     schema:
       type: string
 patch:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Core
   tags:

--- a/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
+++ b/openapi/paths/subscriptions@{subscriptionId}@summary-metrics.yaml
@@ -25,7 +25,8 @@ parameters:
     schema:
       type: string
 get:
-  x-badge: Experimental
+  x-badges:
+    - name: Experimental
   x-products:
     - Reports
   tags:


### PR DESCRIPTION
## Summary

Use `x-badges` feature. This is a new Redocly-supported feature. We made up our own `x-badge` and this is very similar (except you can have more than one badge and control the position in the description (`position: before` or `position: after` (default behavior)).

## Links

![image](https://github.com/Rebilly/api-definitions/assets/1161871/7e9f99e9-5bb1-49ca-8592-5664a1700470)


This could be done to also add badges for storefront APIs.

## Checklist

- [x] Writing style
- [x] API design standards
