### PR TITLE
feat: Add new factors to RiskScoreRules

### DIFF
--- a/openapi/components/schemas/RiskScoreRules.yaml
+++ b/openapi/components/schemas/RiskScoreRules.yaml
@@ -79,10 +79,10 @@ properties:
     $ref: ./RiskScoreBoolean.yaml
   customerLifetimeValue:
     description: Total revenue from the customer, in USD.
-    $ref: ./RiskScoreRange.yaml
+    $ref: ./RiskScoreBracket.yaml
   browserAdBlockEnabled:
     description: Specifies whether an ad blocker was detected.
     $ref: ./RiskScoreBoolean.yaml
   paymentInstrumentApprovedTransactionCount:
     description: Number of approved transactions for this payment instrument.
-    $ref: ./RiskScoreRange.yaml
+    $ref: ./RiskScoreBracket.yaml

--- a/openapi/components/schemas/RiskScoreRules.yaml
+++ b/openapi/components/schemas/RiskScoreRules.yaml
@@ -17,6 +17,11 @@ required:
   - ipVelocity
   - emailVelocity
   - billingAddressVelocity
+  - isRebill
+  - isRetry
+  - customerLifetimeValue
+  - browserAdBlockEnabled
+  - paymentInstrumentApprovedTransactionCount
 properties:
   isProxy:
     description: Specifies whether the customer's IP address is related to a proxy.
@@ -66,3 +71,18 @@ properties:
   billingAddressVelocity:
     description: Number of transactions for this billing address in the last 24 hours.
     $ref: ./RiskScoreBracket.yaml
+  isRebill:
+    description: Specifies whether the transaction is one of a number of recurring payments in a subscription, excluding trials or setup fees.
+    $ref: ./RiskScoreBoolean.yaml
+  isRetry:
+    description: Specifies whether the transaction is a retry.
+    $ref: ./RiskScoreBoolean.yaml
+  customerLifetimeValue:
+    description: Total revenue from the customer, in USD.
+    $ref: ./RiskScoreRange.yaml
+  browserAdBlockEnabled:
+    description: Specifies whether an ad blocker was detected.
+    $ref: ./RiskScoreBoolean.yaml
+  paymentInstrumentApprovedTransactionCount:
+    description: Number of approved transactions for this payment instrument.
+    $ref: ./RiskScoreRange.yaml


### PR DESCRIPTION
## Summary
Updates `RiskScoreRules` schema to include the following:
  - `isRebill`
  - `isRetry`
  - `customerLifetimeValue`
  - `browserAdBlockEnabled`
  - `paymentInstrumentApprovedTransactionCount`

## Checklist

- [X] Writing style
- [X] API design standards
