### PR TITLE
Unify ULID prefixes

### DIFF
--- a/openapi/components/requestBodies/PatchCreditMemo.yaml
+++ b/openapi/components/requestBodies/PatchCreditMemo.yaml
@@ -82,7 +82,7 @@ properties:
           description: ID of the credit memo item.
           readOnly: true
           maxLength: 50
-          example: crmm_itm_0YVCNN22TWC3G8H82QNPNVZCHG
+          example: crmm_itm_01HXC7PK2C6F367VYCFXDRYMAQ
         invoiceItemId:
           description: ID of the invoice item to which the credit item is referenced.
           type:

--- a/openapi/components/requestBodies/Webhooks/QuoteWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/QuoteWebhook.yaml
@@ -5,7 +5,7 @@ content:
         quoteId:
           type: string
           description: ID of the quote.
-          example: qt_01GYJPRKHBD6ZYHH897QCJMBS4
+          example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
         eventType:
           type: string
           description: Type of webhook event.

--- a/openapi/components/requestBodies/Webhooks/UsageLimitWebhook.yaml
+++ b/openapi/components/requestBodies/Webhooks/UsageLimitWebhook.yaml
@@ -13,7 +13,7 @@ content:
         planId:
           type: string
           description: ID of the plan.
-          example: plan_01GYJPRKHBD6ZYHH897QCJMBS4
+          example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
         usageQuantity:
           type: integer
           description: Reported usage quantity.

--- a/openapi/components/schemas/Allowlist.yaml
+++ b/openapi/components/schemas/Allowlist.yaml
@@ -9,7 +9,7 @@ properties:
     description: ID of the allowlist record.
     readOnly: true
     maxLength: 50
-    example: rsal_0YVF9605RKC62BP14NE2R7V2XT
+    example: rsal_01HXBY67D5CNWM2YK79PFZR4C2
   type:
     type: string
     description: |-

--- a/openapi/components/schemas/CouponRedemption.yaml
+++ b/openapi/components/schemas/CouponRedemption.yaml
@@ -6,7 +6,7 @@ properties:
     readOnly: true
     description: Unique resource ID.
     maxLength: 50
-    example: cpn_rdm_0YVCNKF81GD778N4YNVGDJK558
+    example: cpn_rdm_01HXC82EEPW6YD3MPWJY7151VR
   couponId:
     type: string
     description: ID of the coupon.

--- a/openapi/components/schemas/CreditMemo.yaml
+++ b/openapi/components/schemas/CreditMemo.yaml
@@ -95,7 +95,7 @@ properties:
           description: ID of the credit memo item.
           readOnly: true
           maxLength: 50
-          example: crmm_itm_0YVCNN22TWC3G8H82QNPNVZCHG
+          example: crmm_itm_01HXC7PK2C6F367VYCFXDRYMAQ
         invoiceItemId:
           description: ID of the invoice item to which the credit item is referenced.
           type:

--- a/openapi/components/schemas/Invoice.yaml
+++ b/openapi/components/schemas/Invoice.yaml
@@ -40,7 +40,7 @@ properties:
       This field is `null` if there are no related quotes.
     readOnly: true
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   currency:
     x-sortable: true
     x-basic: true

--- a/openapi/components/schemas/OrganizationExport.yaml
+++ b/openapi/components/schemas/OrganizationExport.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     description: Unique resource ID.
     maxLength: 50
-    example: org_exp_0YVDMCH30ZC2XA5BYHH6B6SRTJ
+    example: org_exp_01HXC7MKK4GCS6WRRXY4X9CRMK
   userId:
     description: ID of the user who requested the organization data export.
     readOnly: true

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -106,7 +106,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -342,7 +342,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -12,7 +12,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -106,7 +106,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -342,7 +342,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteChangeOrder.yaml
+++ b/openapi/components/schemas/QuoteChangeOrder.yaml
@@ -261,7 +261,7 @@ properties:
           description: |-
             ID of the plan to which usages are transferred.
             If an item with a specified plan does not exist, or does not have a metered billing plan, this transfer is ignored.
-          example: plan_0YV7DENSVGDBW9S71XZNNYYQ0Y
+          example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
   invoicePreview:
     type: object
     description: Preview of the quote invoice.

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -108,7 +108,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -292,7 +292,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -108,7 +108,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -292,7 +292,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteCreateOrder.yaml
+++ b/openapi/components/schemas/QuoteCreateOrder.yaml
@@ -11,7 +11,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -106,7 +106,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -313,7 +313,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -12,7 +12,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/QuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/QuoteReactivateOrder.yaml
@@ -106,7 +106,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -313,7 +313,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/QuoteTrialConversionOrder.yaml
@@ -12,7 +12,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/QuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/QuoteTrialConversionOrder.yaml
@@ -105,7 +105,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -279,7 +279,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/QuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/QuoteTrialConversionOrder.yaml
@@ -105,7 +105,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -279,7 +279,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontKycLivenessSession.yaml
+++ b/openapi/components/schemas/StorefrontKycLivenessSession.yaml
@@ -8,7 +8,7 @@ properties:
     readOnly: true
     description: ID of the KYC liveness session.
     maxLength: 50
-    example: kyc_liv_0YV7JMJ3DBCGRBR7K9D4HVGPP5
+    example: kyc_liv_01HXBZ0MS1GPS6S34MPQXYT5TZ
   customerId:
     $ref: ./CustomerId.yaml
     readOnly: true

--- a/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
@@ -5,7 +5,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
@@ -255,7 +255,7 @@ properties:
           description: |-
             ID of the plan to which usages are transferred.
             If an item with a specified plan does not exist, or does not have a metered billing plan, this transfer is ignored.
-          example: plan_0YV7DENSVGDBW9S71XZNNYYQ0Y
+          example: plan_0YV7DENSVGDBW9S71XZNNYYQ0X
   invoicePreview:
     type: object
     description: Preview of the quote invoice.

--- a/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -336,7 +336,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteChangeOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -336,7 +336,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
@@ -5,7 +5,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
@@ -102,7 +102,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -286,7 +286,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteCreateOrder.yaml
@@ -102,7 +102,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -286,7 +286,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
@@ -5,7 +5,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -307,7 +307,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteReactivateOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -307,7 +307,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -274,7 +274,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_0YV7DES3WPC5J8JD8QTVNZBZNZ
+              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
@@ -5,7 +5,7 @@ properties:
     description: ID of the quote.
     type: string
     maxLength: 50
-    example: qt_0YV7DES3WPC5J8JD8QTVNZBZNZ
+    example: qt_01HXBZMEGPETPHJZH6V4RHBMA8
   type:
     description: |-
       Specifies the type of the quote.

--- a/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
+++ b/openapi/components/schemas/StorefrontQuoteTrialConversionOrder.yaml
@@ -100,7 +100,7 @@ properties:
           description: ID of the quote item.
           readOnly: true
           type: string
-          example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+          example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
         quantity:
           description: Number of product units in the specified plan.
           type: integer
@@ -274,7 +274,7 @@ properties:
             quoteItemId:
               description: ID of the related quote item.
               type: string
-              example: qti_01HXCEQNR3F1G2A6RX6HPS3KFY
+              example: qt_itm_01HXCEQNR3F1G2A6RX6HPS3KFY
             type:
               type: string
               description: Type of the invoice item.

--- a/openapi/components/schemas/Transaction.yaml
+++ b/openapi/components/schemas/Transaction.yaml
@@ -610,7 +610,7 @@ properties:
       - 'null'
     description: ID of the payout request if applicable. The created transaction is based on the properties of this payout request.
     maxLength: 50
-    example: pout_req_0YVJ65BSGYC3EAT58SEX8KY6J7
+    example: pout_req_0YVDMDE2BMC6KBB5MX76RF6T80
   _links:
     type: array
     description: Related links.

--- a/openapi/components/schemas/WebhookTracking.yaml
+++ b/openapi/components/schemas/WebhookTracking.yaml
@@ -6,7 +6,7 @@ properties:
     type: string
     description: ID of the webhook tracking log.
     maxLength: 50
-    example: hook_log_0YVBG8S0K0DG59J6S3RMN9K452
+    example: hook_log_01HXC7HJ1V2FNJD1R396WCG2HB
   status:
     type: integer
     x-sortable: true

--- a/openapi/paths/tags@{tag}@aml-checks.yaml
+++ b/openapi/paths/tags@{tag}@aml-checks.yaml
@@ -29,7 +29,7 @@ post:
               maxItems: 1000
               items:
                 type: string
-                example: aml_chk_0YV7JHY705C6DA487BFTAA33V8
+                example: aml_chk_0YV8XJT2ZWDR398Q8NFEM7DEPM
   responses:
     '204':
       description: AML checks tagging process has been scheduled.
@@ -68,7 +68,7 @@ delete:
               maxItems: 1000
               items:
                 type: string
-                example: aml_chk_0YV7JHY705C6DA487BFTAA33V8
+                example: aml_chk_0YV8XJT2ZWDR398Q8NFEM7DEPM
   responses:
     '204':
       description: AML checks untagging process has been scheduled.


### PR DESCRIPTION
## Summary
<!-- add a brief summary of what and why -->

[Preview](https://rebilly-website--rem-git-rem-01hnb1ejh7zd3eqe72m-2c9498.preview.redocly.app/catalog/all/allowlists/getallowlistcollection#allowlists/getallowlistcollection/t=response&c=200&path=id)

Set the same `ULID` examples per resource.

- [x] Fix quote item prefix examples
- [x] Unify `aml_chk_` prefixes
- [x] Unify `pout_req_` prefix
- [x] Unify `rsal_` prefix
- [x] Unify `kyc_liv_` prefix
- [x] Unify `qt_` prefix
- [x] Unify `hook_log_` prefix
- [x] Unify `org_exp_` prefix
- [x] Unify `crmm_itm_` prefix
- [x] Unify `cpn_rdm_` prefix
- [x] Unify `plan_` prefixes

## Links
<!-- add any related links to other PRs or docs -->

[Follow up](https://github.com/Rebilly/api-definitions/pull/1872)

## Checklist

- [x] Writing style
- [x] API design standards
