### PR TITLE
chore: add the missing lodash.set depenency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "rebilly-openapi-spec",
       "version": "1.0.0",
       "dependencies": {
-        "@redocly/cli": "1.34.4"
+        "@redocly/cli": "1.34.4",
+        "lodash.set": "^4.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1644,6 +1645,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.1",
@@ -3903,6 +3910,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "long": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "rebilly-openapi-spec",
   "version": "1.0.0",
   "dependencies": {
-    "@redocly/cli": "1.34.4"
+    "@redocly/cli": "1.34.4",
+    "lodash.set": "^4.3.2"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Added the missing `lodash.set` dependency (added [here](https://github.com/tatomyr/rebilly-api-definitions/commit/d1be11ba921e2d03faeda26f7c7d705c480494b4#diff-28872f6b29ea0778ae926235cb0095cca1bdd8e59d04df4f06e521232b15458dR1)). 

Linting/bundling fails with the following error otherwise:

```
Error: Cannot find module 'lodash.set'
Require stack:
- /Users/andrewtatomyr/Redocly/redocly-cli/benchmark/api-definitions/plugins/decorators/include-deprecated-fields.js
```